### PR TITLE
PR4: describe() + super-easy output types

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ for step in analysis.decisions:
     print(step.phase, step.decision, step.reason)
 ```
 
+### Natural-language description (`describe`)
+
+`bluenamer.describe(smiles)` walks the same trace and renders a
+deterministic, multi-paragraph explanation of how the name is built.
+Useful for explainability views and for generating (SMILES, name,
+description) training tuples:
+
+```python
+from bluenamer import describe
+
+d = describe("CC(=O)Nc1ccccc1")
+print(d)            # multi-paragraph prose
+d.rules_hit         # ('P-44', 'P-45', 'P-41', 'P-61', 'P-67')
+d.components[0]     # DescribedComponent(phase='parse', text='RDKit parsed ...')
+```
+
+Same input → same output. No LLM in the loop.
+
 ### CLI
 
 ```bash

--- a/src/bluenamer/__init__.py
+++ b/src/bluenamer/__init__.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterable
 
+from .describer import DescribedComponent, Description, describe
 from .engine import DEFAULT_NAMING_ENGINE, NamingEngine, NamingRequest, NamingResult
 from .functional_groups import register_group_detector
 from .molecule import (
@@ -65,6 +66,8 @@ __all__ = [
     "AtomBinding",
     "BondBinding",
     "DecisionTrace",
+    "DescribedComponent",
+    "Description",
     "FunctionalGroupMetadata",
     "NameAnalysis",
     "NamingEngine",
@@ -80,6 +83,7 @@ __all__ = [
     "TraceStep",
     "__version__",
     "analyze_smiles",
+    "describe",
     "name",
     "name_many",
     "name_smiles",

--- a/src/bluenamer/cli.py
+++ b/src/bluenamer/cli.py
@@ -16,7 +16,6 @@ recommended entrypoint.
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import json
 import os
 import sys
@@ -24,23 +23,8 @@ from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 from . import __version__, name_many
+from . import describe as describe_one
 from . import name as name_one
-
-
-def _result_to_jsonable(result, *, with_trace: bool) -> dict:
-    payload: dict = {
-        "smiles": result.smiles,
-        "name": result.name,
-        "ok": result.ok,
-        "error": result.error,
-        "rules_hit": list(result.rules_hit),
-        "rule_hints": list(result.rule_hints),
-    }
-    if with_trace:
-        payload["trace_segments"] = result.trace_segments
-    if result.opsin_check is not None:
-        payload["opsin_check"] = dataclasses.asdict(result.opsin_check)
-    return payload
 
 
 def _iter_smiles(path: str) -> Iterator[str]:
@@ -61,7 +45,7 @@ def _cmd_name(args: argparse.Namespace) -> int:
         verify_opsin=args.verify,
     )
     if args.json:
-        json.dump(_result_to_jsonable(result, with_trace=True), sys.stdout, indent=2, default=str)
+        json.dump(result.to_dict(include_trace=True), sys.stdout, indent=2, default=str)
         sys.stdout.write("\n")
     else:
         if result.error:
@@ -89,7 +73,7 @@ def _cmd_batch(args: argparse.Namespace) -> int:
     out = sys.stdout if args.output == "-" else open(args.output, "w", encoding="utf-8")  # noqa: SIM115
     try:
         for r in results:
-            json.dump(_result_to_jsonable(r, with_trace=args.trace), out, default=str)
+            json.dump(r.to_dict(include_trace=args.trace), out, default=str)
             out.write("\n")
     finally:
         if out is not sys.stdout:
@@ -99,6 +83,16 @@ def _cmd_batch(args: argparse.Namespace) -> int:
         print(f"{failed}/{len(results)} failed", file=sys.stderr)
         return 0 if args.allow_failures else 2
     return 0
+
+
+def _cmd_describe(args: argparse.Namespace) -> int:
+    description = describe_one(args.smiles)
+    if args.json:
+        json.dump(description.to_dict(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(str(description) + "\n")
+    return 0 if description.name else 1
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -132,6 +126,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="exit 0 even if some rows produced an error",
     )
     p_batch.set_defaults(func=_cmd_batch)
+
+    p_describe = sub.add_parser(
+        "describe",
+        help="Natural-language description of how the name is built",
+    )
+    p_describe.add_argument("smiles")
+    p_describe.add_argument("--json", action="store_true", help="emit structured Description as JSON")
+    p_describe.set_defaults(func=_cmd_describe)
 
     return parser
 

--- a/src/bluenamer/describer.py
+++ b/src/bluenamer/describer.py
@@ -1,0 +1,215 @@
+"""Natural-language description of how a structure was named.
+
+`describe(smiles)` returns a `Description` that bundles a deterministic
+multi-line prose explanation plus the structured components it was
+rendered from. The prose is built directly from the `DecisionTrace` and
+`trace_segments` that the engine already emits, so the output is
+faithful to what the namer actually did — not a separate model.
+
+Same input → same output. Safe to use in dataset pipelines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .engine import DEFAULT_NAMING_ENGINE, NamingRequest, _extract_rules_hit
+from .molecule import TracePhase, TraceStep
+
+
+@dataclass(frozen=True)
+class DescribedComponent:
+    """One phase-tagged human-readable line."""
+
+    phase: str
+    text: str
+
+
+@dataclass(frozen=True)
+class Description:
+    """Result of `describe`. ``str(d)`` returns the rendered prose."""
+
+    smiles: str
+    name: str
+    paragraphs: tuple[str, ...]
+    components: tuple[DescribedComponent, ...] = ()
+    rules_hit: tuple[str, ...] = ()
+    rule_hints: tuple[str, ...] = ()
+
+    def __str__(self) -> str:
+        return "\n\n".join(self.paragraphs)
+
+    @property
+    def summary(self) -> str:
+        return self.paragraphs[0] if self.paragraphs else ""
+
+    def to_dict(self) -> dict:
+        return {
+            "smiles": self.smiles,
+            "name": self.name,
+            "summary": self.summary,
+            "paragraphs": list(self.paragraphs),
+            "components": [{"phase": c.phase, "text": c.text} for c in self.components],
+            "rules_hit": list(self.rules_hit),
+            "rule_hints": list(self.rule_hints),
+        }
+
+
+def _plural(n: int, word: str) -> str:
+    return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+
+def _render_parse(step: TraceStep) -> str | None:
+    atoms = step.data.get("atom_count")
+    if atoms is None:
+        return None
+    bonds = step.data.get("bond_count", 0)
+    return f"RDKit parsed the SMILES into a molecular graph with {_plural(atoms, 'atom')} and {_plural(bonds, 'bond')}."
+
+
+def _render_component(step: TraceStep) -> str | None:
+    components = step.data.get("components") or []
+    if not components:
+        return None
+    if len(components) == 1:
+        return "The structure is a single connected component, named in one piece."
+    return f"The structure splits into {len(components)} connected components, named independently and joined."
+
+
+def _render_perception(step: TraceStep) -> str | None:
+    groups = step.data.get("groups") or []
+    if not groups:
+        return "Perception found no nameable principal groups."
+    names = sorted({g.get("key", "?") for g in groups})
+    principals = sorted({g.get("key", "?") for g in groups if g.get("principal_candidate")})
+    if not principals:
+        return f"Perception identified non-principal groups: {', '.join(names)}."
+    return (
+        f"Perception identified {_plural(len(groups), 'functional group')} "
+        f"({', '.join(names)}); principal candidate{'s' if len(principals) > 1 else ''}: {', '.join(principals)}."
+    )
+
+
+def _render_priority(step: TraceStep) -> str | None:
+    key = step.data.get("principal_key")
+    if not key:
+        return None
+    role = (
+        "treated as a substituent"
+        if step.data.get("is_substituent")
+        else "selected as the principal characteristic group"
+    )
+    return f"The {key} group is {role}, per the registry seniority order."
+
+
+def _render_parent_selection(step: TraceStep) -> str | None:
+    parent = step.data.get("parent_atoms") or []
+    if not parent:
+        return None
+    if step.data.get("is_bicycle"):
+        kind = "bicyclic ring system"
+    elif step.data.get("is_ring"):
+        kind = "ring"
+    else:
+        kind = "acyclic chain"
+    return f"The parent skeleton is a {len(parent)}-atom {kind} (atoms {sorted(parent)})."
+
+
+def _render_numbering(step: TraceStep) -> str | None:
+    locants = step.data.get("locants") or {}
+    if not locants:
+        return None
+    sample = sorted(locants.items(), key=lambda kv: kv[1])[:4]
+    sample_str = ", ".join(f"atom {a}→{loc}" for a, loc in sample)
+    return f"Numbering minimizes locants for the principal group and substituents (e.g. {sample_str})."
+
+
+def _render_assembly(step: TraceStep) -> str | None:
+    name = step.data.get("name")
+    if name is None:
+        return None
+    components = step.data.get("components")
+    if components is not None:
+        if len(components) == 1:
+            return f"The final assembled name is **{name}**."
+        return f"The final assembled name is **{name}** ({len(components)} pieces joined)."
+    sub_count = step.data.get("substituent_count")
+    if sub_count is None:
+        return None
+    return f"Component assembled as **{name}** with {_plural(sub_count, 'substituent')}."
+
+
+_RENDERERS: dict[TracePhase, callable] = {
+    TracePhase.PARSE: _render_parse,
+    TracePhase.COMPONENT: _render_component,
+    TracePhase.PERCEPTION: _render_perception,
+    TracePhase.PRIORITY: _render_priority,
+    TracePhase.PARENT_SELECTION: _render_parent_selection,
+    TracePhase.NUMBERING: _render_numbering,
+    TracePhase.ASSEMBLY: _render_assembly,
+}
+
+
+def _trace_segment_lines(trace_segments: list[dict]) -> list[str]:
+    lines = []
+    for seg in trace_segments:
+        if not isinstance(seg, dict):
+            continue
+        label = seg.get("label") or seg.get("key")
+        terms = seg.get("name_terms") or []
+        if not label or not terms:
+            continue
+        atoms = seg.get("atoms") or []
+        suffix = f" (atoms {atoms})" if atoms else ""
+        lines.append(f"- {label}: contributes “{terms[0]}”{suffix}.")
+    return lines
+
+
+def describe(smiles: str) -> Description:
+    """Render a natural-language explanation of how ``smiles`` is named."""
+
+    result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, include_trace=True))
+
+    if not result.name:
+        summary = f"The structure {smiles} could not be named by the current ruleset."
+    else:
+        summary = f"The molecule {smiles} is named **{result.name}**."
+
+    components: list[DescribedComponent] = []
+    seen: set[tuple[str, str]] = set()
+    for step in result.decisions:
+        renderer = _RENDERERS.get(step.phase)
+        if renderer is None:
+            continue
+        text = renderer(step)
+        if not text:
+            continue
+        key = (step.phase.value, text)
+        if key in seen:
+            continue
+        seen.add(key)
+        components.append(DescribedComponent(phase=step.phase.value, text=text))
+
+    paragraphs: list[str] = [summary]
+    if components:
+        paragraphs.append("\n".join(c.text for c in components))
+
+    seg_lines = _trace_segment_lines(result.trace_segments)
+    if seg_lines:
+        paragraphs.append("Name pieces contributed by the trace:\n" + "\n".join(seg_lines))
+
+    rules, hints = _extract_rules_hit(result.trace_segments)
+    if rules:
+        paragraphs.append("IUPAC Blue Book rules applied: " + ", ".join(rules) + ".")
+
+    return Description(
+        smiles=smiles,
+        name=result.name,
+        paragraphs=tuple(paragraphs),
+        components=tuple(components),
+        rules_hit=rules,
+        rule_hints=hints,
+    )
+
+
+__all__ = ["DescribedComponent", "Description", "describe"]

--- a/src/bluenamer/engine.py
+++ b/src/bluenamer/engine.py
@@ -72,12 +72,11 @@ class NamingRequest:
 class NamingResult:
     """Named molecule plus optional explainability and verification data.
 
-    Backwards compatible with the previous shape: ``name``,
-    ``trace_segments``, ``decisions`` and ``analysis`` are preserved.
-    Adds ``smiles`` (the input that produced this result), ``error``
-    (populated when naming itself raised), ``rules_hit`` /
-    ``rule_hints`` (extracted from the trace) and ``opsin_check`` (only
-    when verification was requested).
+    Ergonomics:
+
+    - ``str(result)`` → the generated name (empty string on failure).
+    - ``bool(result)`` → ``result.ok``.
+    - ``result.to_dict()`` → JSON-friendly dict, ready for dataset rows.
     """
 
     name: str
@@ -101,6 +100,32 @@ class NamingResult:
         """``True`` when an OPSIN round-trip was requested and matched."""
 
         return self.opsin_check is not None and self.opsin_check.ok
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    def __repr__(self) -> str:
+        return f"NamingResult(name={self.name!r}, smiles={self.smiles!r}, ok={self.ok})"
+
+    def to_dict(self, *, include_trace: bool = False) -> dict:
+        """JSON-friendly dict view. Pass ``include_trace=True`` to keep the raw trace."""
+
+        payload: dict = {
+            "smiles": self.smiles,
+            "name": self.name,
+            "ok": self.ok,
+            "error": self.error,
+            "rules_hit": list(self.rules_hit),
+            "rule_hints": list(self.rule_hints),
+        }
+        if include_trace:
+            payload["trace_segments"] = self.trace_segments
+        if self.opsin_check is not None:
+            payload["opsin_check"] = self.opsin_check.to_dict()
+        return payload
 
 
 class NamingEngine:

--- a/src/bluenamer/opsin_verify.py
+++ b/src/bluenamer/opsin_verify.py
@@ -42,6 +42,22 @@ class OpsinCheck:
 
         return self.status == "matched"
 
+    def __bool__(self) -> bool:
+        return self.ok
+
+    def __str__(self) -> str:
+        return self.status
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status,
+            "name": self.name,
+            "canonical_original": self.canonical_original,
+            "opsin_smiles": self.opsin_smiles,
+            "canonical_roundtrip": self.canonical_roundtrip,
+            "error_message": self.error_message,
+        }
+
 
 def _try_import_py2opsin():
     try:

--- a/src/bluenamer/tests/test_public_api.py
+++ b/src/bluenamer/tests/test_public_api.py
@@ -36,6 +36,27 @@ def test_name_returns_naming_result_with_smiles_field():
     assert result.rules_hit == ()
 
 
+def test_naming_result_is_easy_to_use():
+    """Ergonomics: str, bool, repr, to_dict all do the obvious thing."""
+
+    good = name("CCO")
+    assert str(good) == "ethanol"
+    assert bool(good) is True
+    assert "ethanol" in repr(good)
+    payload = good.to_dict()
+    assert payload["name"] == "ethanol"
+    assert payload["smiles"] == "CCO"
+    assert payload["ok"] is True
+    # Round-trips through json without extra args.
+    import json
+
+    json.dumps(payload)
+
+    bad = name("")
+    assert str(bad) == ""
+    assert bool(bad) is False
+
+
 def test_name_with_trace_populates_rules_hit_and_hints():
     result = name("CC(=O)Nc1ccccc1", include_trace=True)
     assert result.name == "N-phenylacetamide"

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -1,0 +1,95 @@
+"""Tests for the natural-language describer added in PR4."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from bluenamer import DescribedComponent, Description, describe
+
+
+def test_describe_returns_structured_description():
+    d = describe("CCO")
+    assert isinstance(d, Description)
+    assert d.smiles == "CCO"
+    assert d.name == "ethanol"
+    # The summary line names the result.
+    assert "ethanol" in d.summary
+    # Multiple paragraphs render as text.
+    assert "\n\n" in str(d)
+    # rules_hit are extracted.
+    assert d.rules_hit, "expected at least one P-XX rule id"
+    # Components are typed and phase-tagged.
+    assert all(isinstance(c, DescribedComponent) for c in d.components)
+    assert any(c.phase == "parent_selection" for c in d.components)
+
+
+def test_describe_explains_functional_group_selection():
+    d = describe("CC(=O)Nc1ccccc1")
+    text = str(d)
+    assert "N-phenylacetamide" in text
+    assert "amide" in text
+    # Parent selection is mentioned.
+    assert "parent skeleton" in text
+    # Trace name pieces appear in the prose.
+    assert "Name pieces" in text
+
+
+def test_describe_handles_benzene_without_functional_group():
+    d = describe("c1ccccc1")
+    assert d.name == "benzene"
+    text = str(d)
+    assert "benzene" in text
+    # No principal group → that fact is stated.
+    assert "no nameable principal groups" in text
+
+
+def test_str_of_description_returns_text():
+    s = str(describe("CCO"))
+    assert isinstance(s, str)
+    assert "ethanol" in s
+
+
+def test_describe_is_deterministic():
+    a = describe("CC(=O)Nc1ccccc1")
+    b = describe("CC(=O)Nc1ccccc1")
+    assert str(a) == str(b)
+    assert a.rules_hit == b.rules_hit
+
+
+def test_describe_failure_case_still_returns_description():
+    """Even when naming yields no name, describe must not raise."""
+
+    d = describe("")
+    assert isinstance(d, Description)
+    assert "could not be named" in d.summary or d.name == ""
+
+
+def test_cli_describe_subcommand():
+    result = subprocess.run(
+        [sys.executable, "-m", "bluenamer.cli", "describe", "CCO"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ethanol" in result.stdout
+    assert "RDKit parsed" in result.stdout
+
+
+def test_cli_describe_json():
+    result = subprocess.run(
+        [sys.executable, "-m", "bluenamer.cli", "describe", "CCO", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["name"] == "ethanol"
+    assert payload["smiles"] == "CCO"
+    assert isinstance(payload["paragraphs"], list)
+    assert payload["paragraphs"]
+    assert isinstance(payload["components"], list)
+    assert any(c["phase"] == "parent_selection" for c in payload["components"])


### PR DESCRIPTION
## Summary
Stacks on PR3. Adds the `describe()` natural-language renderer and
polishes the typed result objects so they are obvious to use.

### `describe(smiles) → Description`
Walks the existing `DecisionTrace` / `trace_segments` and renders a
deterministic multi-paragraph prose explanation: parse stats →
perception → principal-group priority → parent selection → numbering
→ assembly → per-segment contributions → Blue Book rules invoked.

```python
from bluenamer import describe
d = describe("CC(=O)Nc1ccccc1")
print(d)            # prose
d.rules_hit         # ('P-44', 'P-45', 'P-41', 'P-61', 'P-67')
d.components[0]     # DescribedComponent(phase='parse', text='RDKit parsed ...')
```

No LLM in the loop — same input → same output, safe in dataset
pipelines. Plus CLI:

```bash
bluenamer describe "CC(=O)Nc1ccccc1"
bluenamer describe "CC(=O)Nc1ccccc1" --json
```

### Output types — super easy to use
The user feedback was that the typed objects need to be obvious. They now all support the natural Python protocols:

```python
result = name("CCO")
str(result)           # 'ethanol'
bool(result)          # True
repr(result)          # NamingResult(name='ethanol', smiles='CCO', ok=True)
result.to_dict()      # JSON-friendly, ready for a CSV/JSONL row

check = result.opsin_check     # OpsinCheck | None
if check: ...                  # bool == matched
str(check)                     # 'matched' / 'mismatched' / ...
check.to_dict()                # serialisable

d = describe("CCO")
str(d)                # full prose
d.summary             # first paragraph
d.to_dict()           # serialisable
```

The CLI's previous ad-hoc serializer is collapsed onto these.

### Cleanups for staff-level quality
- Drop the `describe_smiles` wrapper (callers use `str(describe(s))`).
- Drop a dead regex (`_NAME_TERM_HINT`) in describer.
- Replace the `summary` field on `Description` with a property.
- Simplify `_render_assembly` and tighten `_trace_segment_lines`.
- CLI uses the dataclass `to_dict` methods instead of a duplicate helper.

## Test plan
- [x] `pytest tests/integration/test_describer.py src/bluenamer/tests/test_public_api.py` → 23 passed.
- [x] `pytest -m "not slow and not dataset"` → 158 passed.
- [x] `ruff check src/bluenamer tests` + `ruff format --check` clean.
- [x] Manual CLI: `bluenamer name CCO`, `bluenamer describe CCO`, `bluenamer describe CC(=O)Nc1ccccc1 --json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a deterministic natural-language description API for naming explanations and make result objects easier to consume programmatically and via the CLI.

New Features:
- Introduce a describe(smiles) API that returns a structured Description with prose, components, and rule metadata.
- Expose Description and DescribedComponent types, along with describe(), from the public bluenamer package.
- Add a bluenamer CLI describe subcommand with optional JSON output for description results.

Enhancements:
- Make NamingResult and OpsinCheck ergonomically usable via str/bool/repr and JSON-friendly to_dict() helpers.
- Refine natural-language rendering of naming decisions into paragraphs and per-phase components, including trace segment summaries.
- Update the CLI to use the dataclass to_dict methods instead of a custom serializer.

Documentation:
- Document the new describe API and its usage in the README.

Tests:
- Add integration tests for the describer API and CLI describe subcommand.
- Extend public API tests to cover the new NamingResult ergonomics and JSON round-tripping.