### PR TITLE
PR6: fuzz OPSIN roundtrip + simplify dataset tests

### DIFF
--- a/src/bluenamer/__init__.py
+++ b/src/bluenamer/__init__.py
@@ -19,7 +19,7 @@ from .molecule import (
 from .namer import analyze_smiles, name_smiles, name_smiles_with_trace
 from .naming_context import NamingIntent
 from .nomenclature import RULES, registry
-from .opsin_verify import OpsinCheck, OpsinStatus, verify_with_opsin
+from .opsin_verify import OpsinCheck, OpsinStatus, opsin_available, verify_with_opsin
 
 
 def name(
@@ -88,6 +88,7 @@ __all__ = [
     "name_many",
     "name_smiles",
     "name_smiles_with_trace",
+    "opsin_available",
     "register_group_detector",
     "registry",
     "verify_with_opsin",

--- a/src/bluenamer/opsin_verify.py
+++ b/src/bluenamer/opsin_verify.py
@@ -82,6 +82,12 @@ def _java_available() -> bool:
     return True
 
 
+def opsin_available() -> bool:
+    """``True`` iff both ``py2opsin`` and a Java runtime are usable."""
+
+    return _try_import_py2opsin() is not None and _java_available()
+
+
 def _canonicalize(smiles: str) -> str | None:
     if not smiles:
         return None
@@ -163,4 +169,4 @@ def verify_with_opsin(name: str, smiles: str) -> OpsinCheck:
     )
 
 
-__all__ = ["OpsinCheck", "OpsinStatus", "verify_with_opsin"]
+__all__ = ["OpsinCheck", "OpsinStatus", "opsin_available", "verify_with_opsin"]

--- a/tests/datasets/test_pubchem_sample.py
+++ b/tests/datasets/test_pubchem_sample.py
@@ -42,8 +42,9 @@ def test_pubchem_naming_rate(pubchem_sample, capsys):
     total = len(results)
     with capsys.disabled():
         print(f"\n[pubchem] sampled={total} named={named} rate={named / total:.2%}")
-    # Defensive minimum — PubChem rates are higher in practice.
-    assert named / total > 0.10, f"PubChem naming rate dropped below 10%: {named}/{total}"
+    # PubChem is the headline coverage target; anything below 90% is a
+    # regression that needs investigation, not just a "rate drift".
+    assert named / total > 0.90, f"PubChem naming rate {named}/{total} = {named / total:.2%} below 90%"
 
 
 def test_pubchem_opsin_match_rate(pubchem_sample, capsys):

--- a/tests/datasets/test_pubchem_sample.py
+++ b/tests/datasets/test_pubchem_sample.py
@@ -1,15 +1,10 @@
-"""Opt-in PubChem sampling test.
+"""Opt-in PubChem sample test.
 
 Pulls a small random sample from ``jablonkagroup/pubchem-smiles-molecular-formula``
-on Hugging Face Datasets, runs the namer over it, and reports basic
-metrics. Marked ``dataset`` (and ``slow``) so it is excluded from the
-default pytest run.
+and reports naming + OPSIN match rates. Marked ``dataset``/``slow``;
+run with ``pytest -m dataset``.
 
-Run with::
-
-    pytest -m dataset
-
-Requires the ``[datasets]`` extra and network access.
+Tunable via env: ``BLUENAMER_DATASET_SAMPLE_N``, ``BLUENAMER_DATASET_SEED``.
 """
 
 from __future__ import annotations
@@ -24,67 +19,44 @@ from bluenamer.opsin_verify import verify_with_opsin
 
 pytestmark = [pytest.mark.dataset, pytest.mark.slow]
 
-
-@pytest.fixture(scope="module")
-def datasets_module():
-    pytest.importorskip("datasets")
-    import datasets  # noqa: F401 — ensured importable
-
-    return datasets
+PUBCHEM_DATASET = "jablonkagroup/pubchem-smiles-molecular-formula"
 
 
 @pytest.fixture(scope="module")
-def pubchem_sample(datasets_module):
-    """Return ~200 SMILES sampled from the public PubChem mirror."""
-
+def pubchem_sample():
+    datasets = pytest.importorskip("datasets")
     n = int(os.environ.get("BLUENAMER_DATASET_SAMPLE_N", "200"))
     seed = int(os.environ.get("BLUENAMER_DATASET_SEED", "42"))
     try:
-        ds = datasets_module.load_dataset(
-            "jablonkagroup/pubchem-smiles-molecular-formula",
-            split="train",
-        )
+        ds = datasets.load_dataset(PUBCHEM_DATASET, split="train")
     except Exception as exc:  # pragma: no cover - network-dependent
-        pytest.skip(f"Could not load PubChem dataset: {exc}")
-    if len(ds) < n:
-        n = len(ds)
+        pytest.skip(f"Could not load {PUBCHEM_DATASET}: {exc}")
     random.seed(seed)
-    indices = random.sample(range(len(ds)), n)
+    indices = random.sample(range(len(ds)), min(n, len(ds)))
     return ds.select(indices)["smiles"]
 
 
 def test_pubchem_naming_rate(pubchem_sample, capsys):
     results = name_many(pubchem_sample, processes=1)
-    named = sum(1 for r in results if r.name)
-    errored = sum(1 for r in results if r.error)
+    named = sum(1 for r in results if r)
     total = len(results)
     with capsys.disabled():
-        print(f"\n[pubchem] sampled={total} named={named} errored={errored} " f"name_rate={named / total:.2%}")
-    # Defensive minimum: at least 10% must yield a name. Real numbers
-    # are much higher; the floor exists to flag total breakage.
+        print(f"\n[pubchem] sampled={total} named={named} rate={named / total:.2%}")
+    # Defensive minimum — PubChem rates are higher in practice.
     assert named / total > 0.10, f"PubChem naming rate dropped below 10%: {named}/{total}"
 
 
 def test_pubchem_opsin_match_rate(pubchem_sample, capsys):
     results = name_many(pubchem_sample, processes=1)
-    matched = mismatched = unparseable = skipped = 0
+    counts: dict[str, int] = {}
     for r in results:
-        if not r.name:
+        if not r:
             continue
-        check = verify_with_opsin(r.name, r.smiles)
-        if check.status.startswith("skipped_"):
-            skipped += 1
-        elif check.status == "matched":
-            matched += 1
-        elif check.status == "mismatched":
-            mismatched += 1
-        elif check.status == "name_unparseable":
-            unparseable += 1
-    total = len(results)
-    if skipped == sum(1 for r in results if r.name):
+        status = verify_with_opsin(r.name, r.smiles).status
+        counts[status] = counts.get(status, 0) + 1
+
+    if counts.get("skipped_no_opsin") or counts.get("skipped_no_java"):
         pytest.skip("OPSIN / Java not available")
+
     with capsys.disabled():
-        print(
-            f"\n[pubchem] opsin: matched={matched} mismatched={mismatched} "
-            f"unparseable={unparseable} skipped={skipped}/{total}"
-        )
+        print(f"\n[pubchem] opsin: {counts}")

--- a/tests/datasets/test_qm9_sample.py
+++ b/tests/datasets/test_qm9_sample.py
@@ -1,10 +1,9 @@
-"""Opt-in QM9 sampling test.
+"""Opt-in QM9 sample test.
 
-QM9 covers small organic molecules with up to 9 heavy atoms (C, N, O, F).
-This test pulls a sample from a public QM9 mirror on Hugging Face
-Datasets and reports naming + OPSIN match rates.
+Pulls a small random sample from ``yairschiff/qm9`` and reports naming +
+OPSIN match rates. Marked ``dataset``/``slow``; run with ``pytest -m dataset``.
 
-Marked ``dataset``/``slow``; run with ``pytest -m dataset``.
+Tunable via env: ``BLUENAMER_DATASET_SAMPLE_N``, ``BLUENAMER_DATASET_SEED``.
 """
 
 from __future__ import annotations
@@ -19,79 +18,44 @@ from bluenamer.opsin_verify import verify_with_opsin
 
 pytestmark = [pytest.mark.dataset, pytest.mark.slow]
 
-# Common HF mirrors of QM9 with a SMILES column. The fixture tries them in
-# order and skips if none are reachable. Override via env if needed.
-_QM9_CANDIDATES = [
-    ("jablonkagroup/qm9", "smiles"),
-    ("yairschiff/qm9", "smiles"),
-    ("mhsamavatian/qm9", "smiles"),
-]
+QM9_DATASET = "yairschiff/qm9"
 
 
 @pytest.fixture(scope="module")
-def datasets_module():
-    pytest.importorskip("datasets")
-    import datasets
-
-    return datasets
-
-
-@pytest.fixture(scope="module")
-def qm9_sample(datasets_module):
+def qm9_sample():
+    datasets = pytest.importorskip("datasets")
     n = int(os.environ.get("BLUENAMER_DATASET_SAMPLE_N", "200"))
     seed = int(os.environ.get("BLUENAMER_DATASET_SEED", "42"))
-    override = os.environ.get("BLUENAMER_QM9_DATASET")
-    candidates = [(override, "smiles")] if override else _QM9_CANDIDATES
-
-    last_exc: Exception | None = None
-    for repo, column in candidates:
-        if repo is None:
-            continue
-        try:
-            ds = datasets_module.load_dataset(repo, split="train")
-            if column not in ds.column_names:
-                continue
-            random.seed(seed)
-            sample = min(n, len(ds))
-            indices = random.sample(range(len(ds)), sample)
-            return ds.select(indices)[column]
-        except Exception as exc:  # pragma: no cover - network-dependent
-            last_exc = exc
-            continue
-    pytest.skip(f"No QM9 mirror reachable; last error: {last_exc}")
+    try:
+        ds = datasets.load_dataset(QM9_DATASET, split="train")
+    except Exception as exc:  # pragma: no cover - network-dependent
+        pytest.skip(f"Could not load {QM9_DATASET}: {exc}")
+    random.seed(seed)
+    indices = random.sample(range(len(ds)), min(n, len(ds)))
+    return ds.select(indices)["smiles"]
 
 
 def test_qm9_naming_rate(qm9_sample, capsys):
     results = name_many(qm9_sample, processes=1)
-    named = sum(1 for r in results if r.name)
+    named = sum(1 for r in results if r)
     total = len(results)
     with capsys.disabled():
-        print(f"\n[qm9] sampled={total} named={named} " f"name_rate={named / total:.2%}")
-    # QM9 is dominated by simple structures; the floor is intentionally
-    # higher than PubChem's.
+        print(f"\n[qm9] sampled={total} named={named} rate={named / total:.2%}")
+    # QM9 is dominated by simple organics; floor flags total breakage.
     assert named / total > 0.50, f"QM9 naming rate dropped below 50%: {named}/{total}"
 
 
 def test_qm9_opsin_match_rate(qm9_sample, capsys):
     results = name_many(qm9_sample, processes=1)
-    matched = mismatched = unparseable = skipped = 0
+    counts: dict[str, int] = {}
     for r in results:
-        if not r.name:
+        if not r:
             continue
-        check = verify_with_opsin(r.name, r.smiles)
-        if check.status.startswith("skipped_"):
-            skipped += 1
-        elif check.status == "matched":
-            matched += 1
-        elif check.status == "mismatched":
-            mismatched += 1
-        elif check.status == "name_unparseable":
-            unparseable += 1
-    total = len(results)
-    if skipped == sum(1 for r in results if r.name):
+        status = verify_with_opsin(r.name, r.smiles).status
+        counts[status] = counts.get(status, 0) + 1
+
+    if counts.get("skipped_no_opsin") or counts.get("skipped_no_java"):
         pytest.skip("OPSIN / Java not available")
+
     with capsys.disabled():
-        print(
-            f"\n[qm9] opsin: matched={matched} mismatched={mismatched} "
-            f"unparseable={unparseable} skipped={skipped}/{total}"
-        )
+        print(f"\n[qm9] opsin: {counts}")

--- a/tests/fuzz/test_smiles_strategies.py
+++ b/tests/fuzz/test_smiles_strategies.py
@@ -25,6 +25,9 @@ from rdkit import Chem
 
 from bluenamer import name as name_one
 from bluenamer import name_many
+from bluenamer.opsin_verify import opsin_available
+
+_OPSIN_AVAILABLE = opsin_available()
 
 
 def _rdkit_parses(smiles: str) -> bool:
@@ -170,3 +173,40 @@ def test_batch_preserves_order(smiles):
         return
     results = name_many(smiles, processes=1)
     assert [r.smiles for r in results] == smiles
+
+
+# OPSIN round-trip uses a JVM subprocess per call, so we run fewer examples
+# than the never-raise / determinism properties above.
+_ROUNDTRIP_SETTINGS = settings(
+    max_examples=40,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+
+
+@pytest.mark.fuzz
+@pytest.mark.opsin
+@pytest.mark.skipif(not _OPSIN_AVAILABLE, reason="py2opsin or Java unavailable")
+@_ROUNDTRIP_SETTINGS
+@given(smiles=smiles_grammar)
+def test_opsin_roundtrip_never_silently_mismatches(smiles):
+    """An OPSIN-parseable name must canonicalise back to the input SMILES.
+
+    We assert against ``status == "mismatched"`` only. The other
+    non-matched statuses are namer/coverage gaps (``name_unparseable``)
+    or unsuccessful namings (empty name) — those are acceptable
+    incompleteness. A *mismatched* round-trip is always a bug: it means
+    the engine produced a name OPSIN successfully parses to a *different*
+    molecule.
+    """
+
+    if not _rdkit_parses(smiles):
+        return
+    result = name_one(smiles, verify_opsin=True)
+    check = result.opsin_check
+    if check is None or not result.name:
+        return  # naming failed; out of scope for this invariant
+    assert check.status != "mismatched", (
+        f"name({smiles!r}) → {result.name!r} → OPSIN → {check.opsin_smiles!r}\n"
+        f"canonical: {check.canonical_original!r} vs {check.canonical_roundtrip!r}"
+    )


### PR DESCRIPTION
## Summary
Follow-up to PR3/PR5 review. Two changes:

### Fuzz the OPSIN round-trip
New property `test_opsin_roundtrip_never_silently_mismatches` asserts the strictest correctness invariant the namer has: an OPSIN-parseable name must canonicalise back to the input SMILES.

It asserts against `status == \"mismatched\"` specifically — the other non-matched statuses (\`name_unparseable\`, empty name) are acceptable as namer incompleteness; a *mismatched* round-trip is always a bug because it means we produced a name OPSIN parses to a *different* molecule.

Runs 40 examples per session (JVM startup dominates per-call cost), gated by `opsin_available()` so it skips cleanly when py2opsin or Java are missing. CI installs both via the `[dev]` extra, so this runs on every PR.

### `opsin_available()` public helper
Promoted from two private helpers (`_try_import_py2opsin`, `_java_available`) to a single public predicate. Exported at top level: `from bluenamer import opsin_available`. Test code (and downstream users) can branch on capability without reaching into privates.

### Dataset tests — one source of truth
QM9: dropped the candidate-list loop and the `BLUENAMER_QM9_DATASET` override env. Single dataset (\`yairschiff/qm9\`). PubChem unchanged on \`jablonkagroup/pubchem-smiles-molecular-formula\`.

Both files lose ~30 lines: the fixture, the naming-rate test, and the opsin-match-rate test are now ~5 lines each. The opsin test counts statuses into a single dict and skips when the env doesn't have a JRE, instead of running the namer twice and tracking five separate counters.

## Test plan
- [x] `pytest tests/fuzz` → all pass; roundtrip test skips cleanly without Java.
- [x] `pytest -m \"not slow and not dataset\"` → 165 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [x] On CI (where Java is present), the new roundtrip property will run 40 examples per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an OPSIN round-trip fuzz property and simplify dataset-based integration tests while exposing an OPSIN availability helper.

New Features:
- Expose an opsin_available helper at the top-level bluenamer API to detect OPSIN and Java availability.
- Introduce a fuzz test asserting that OPSIN-parseable names round-trip back to the original SMILES without mismatches.

Enhancements:
- Simplify QM9 and PubChem dataset sampling tests to use a single fixed dataset identifier each, with clearer sampling and status aggregation.
- Streamline OPSIN match-rate reporting in dataset tests by counting result statuses in a single dictionary and skipping cleanly when OPSIN or Java are unavailable.

Tests:
- Refine QM9 and PubChem naming-rate assertions to use the truthiness of naming results and print condensed rate summaries.