### PR TITLE
PR8: rdkit-version compat suite (golden corpus + matrix CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,46 @@ jobs:
 
       - name: Run fast tests
         run: |
-          pytest -m "not slow and not dataset" \
+          pytest -m "not slow and not dataset and not golden" \
                  --maxfail=20 \
                  --durations=20
+
+  rdkit-compat:
+    # Strict golden-output regression across RDKit versions. Detects
+    # naming output that drifts with the RDKit upgrade cycle (aromaticity,
+    # kekulisation, H-count perception). Each matrix row pins a specific
+    # rdkit and runs only the `golden` test.
+    runs-on: ubuntu-latest
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        rdkit-version:
+          - "2024.03.6"
+          - "2024.09.6"
+          - "2025.03.6"
+          - "2025.09.5"
+          - "2026.3.2"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package + pinned rdkit
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install --force-reinstall --no-deps "rdkit==${{ matrix.rdkit-version }}"
+
+      - name: Show installed versions
+        run: |
+          python -c "import rdkit, sys; print('python', sys.version); print('rdkit', rdkit.__version__)"
+
+      - name: Run golden corpus test
+        run: pytest -m golden -v --no-header -rA
 
   docker:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -130,7 +130,10 @@ pip install -e ".[dev]"
 pytest
 
 # run only fast tests
-pytest -m "not slow and not dataset"
+pytest -m "not slow and not dataset and not golden"
+
+# strict RDKit-version regression suite (also runs in the rdkit-compat CI job)
+pytest -m golden
 
 # lint and format
 ruff check --fix src/bluenamer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ markers = [
     "opsin: requires py2opsin and Java",
     "dataset: requires the [datasets] extra and network access",
     "fuzz: hypothesis-based fuzz tests",
+    "golden: strict golden-output regression test; run via the rdkit-compat job",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/scripts/regenerate_goldens.py
+++ b/scripts/regenerate_goldens.py
@@ -1,0 +1,49 @@
+"""Regenerate the corpus golden file from the current namer + rdkit.
+
+Run when the namer or rdkit version intentionally changes the expected
+output for a corpus entry::
+
+    python scripts/regenerate_goldens.py
+
+Always run after the change is reviewed: the goldens are a *contract*
+that next CI run pins. Inspect the diff before committing.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+import rdkit
+
+from bluenamer import name_smiles
+
+ROOT = Path(__file__).resolve().parent.parent
+CORPUS = ROOT / "tests/fixtures/diverse_corpus.csv"
+GOLDEN = ROOT / "tests/fixtures/diverse_corpus.golden.json"
+
+
+def main() -> int:
+    rows = []
+    with CORPUS.open() as fh:
+        for row in csv.DictReader(fh):
+            smiles = row["smiles"].strip()
+            if not smiles:
+                continue
+            rows.append(
+                {
+                    "smiles": smiles,
+                    "name": name_smiles(smiles),
+                    "category": row.get("category", "").strip(),
+                }
+            )
+    GOLDEN.write_text(json.dumps(rows, indent=2) + "\n")
+    named = sum(1 for r in rows if r["name"])
+    print(f"rdkit {rdkit.__version__}: wrote {len(rows)} entries, named={named}/{len(rows)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/diverse_corpus.golden.json
+++ b/tests/fixtures/diverse_corpus.golden.json
@@ -1,0 +1,532 @@
+[
+  {
+    "smiles": "C",
+    "name": "methane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CC",
+    "name": "ethane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CCC",
+    "name": "propane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CCCC",
+    "name": "butane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CC(C)C",
+    "name": "2-methylpropane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CC(C)(C)C",
+    "name": "2,2-dimethylpropane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CCCCCCCC",
+    "name": "octane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "C1CCCCC1",
+    "name": "cyclohexane",
+    "category": "alicyclic"
+  },
+  {
+    "smiles": "C1CCCC1",
+    "name": "cyclopentane",
+    "category": "alicyclic"
+  },
+  {
+    "smiles": "C1CCC1",
+    "name": "cyclobutane",
+    "category": "alicyclic"
+  },
+  {
+    "smiles": "C1CC1",
+    "name": "cyclopropane",
+    "category": "alicyclic"
+  },
+  {
+    "smiles": "C=C",
+    "name": "eth-1-ene",
+    "category": "alkene"
+  },
+  {
+    "smiles": "CC=C",
+    "name": "prop-1-ene",
+    "category": "alkene"
+  },
+  {
+    "smiles": "C=CC=C",
+    "name": "buta-1,3-diene",
+    "category": "alkene"
+  },
+  {
+    "smiles": "C#C",
+    "name": "eth-1-yne",
+    "category": "alkyne"
+  },
+  {
+    "smiles": "CC#C",
+    "name": "prop-1-yne",
+    "category": "alkyne"
+  },
+  {
+    "smiles": "c1ccccc1",
+    "name": "benzene",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "Cc1ccccc1",
+    "name": "methylbenzene",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "c1ccc(O)cc1",
+    "name": "benzen-1-ol",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "c1ccc(N)cc1",
+    "name": "benzen-1-amine",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "c1ccc(Cl)cc1",
+    "name": "chlorobenzene",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "c1ccc2ccccc2c1",
+    "name": "naphthalene",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "CO",
+    "name": "methanol",
+    "category": "alcohol"
+  },
+  {
+    "smiles": "CCO",
+    "name": "ethanol",
+    "category": "alcohol"
+  },
+  {
+    "smiles": "CCCO",
+    "name": "propan-1-ol",
+    "category": "alcohol"
+  },
+  {
+    "smiles": "CC(C)O",
+    "name": "propan-2-ol",
+    "category": "alcohol"
+  },
+  {
+    "smiles": "OCCO",
+    "name": "ethane-1,2-diol",
+    "category": "alcohol"
+  },
+  {
+    "smiles": "OCC(O)CO",
+    "name": "propane-1,2,3-triol",
+    "category": "alcohol"
+  },
+  {
+    "smiles": "CC(=O)",
+    "name": "ethanal",
+    "category": "carbonyl"
+  },
+  {
+    "smiles": "CCC(=O)",
+    "name": "propanal",
+    "category": "carbonyl"
+  },
+  {
+    "smiles": "CC(=O)C",
+    "name": "propan-2-one",
+    "category": "carbonyl"
+  },
+  {
+    "smiles": "CCC(=O)CC",
+    "name": "pentan-3-one",
+    "category": "carbonyl"
+  },
+  {
+    "smiles": "CC(=O)O",
+    "name": "acetic acid",
+    "category": "carboxylic_acid"
+  },
+  {
+    "smiles": "CCC(=O)O",
+    "name": "propanoic acid",
+    "category": "carboxylic_acid"
+  },
+  {
+    "smiles": "OC(=O)CC(=O)O",
+    "name": "malonic acid",
+    "category": "carboxylic_acid"
+  },
+  {
+    "smiles": "OC(=O)C(O)C(O)C(=O)O",
+    "name": "2,3-dihydroxybutanedioic acid",
+    "category": "carboxylic_acid"
+  },
+  {
+    "smiles": "OC(=O)c1ccccc1",
+    "name": "benzoic acid",
+    "category": "carboxylic_acid"
+  },
+  {
+    "smiles": "CC(=O)OC",
+    "name": "methyl acetate",
+    "category": "ester"
+  },
+  {
+    "smiles": "CCOC(C)=O",
+    "name": "ethyl acetate",
+    "category": "ester"
+  },
+  {
+    "smiles": "CC(=O)OCC",
+    "name": "ethyl acetate",
+    "category": "ester"
+  },
+  {
+    "smiles": "CN",
+    "name": "methanamine",
+    "category": "amine"
+  },
+  {
+    "smiles": "CCN",
+    "name": "ethanamine",
+    "category": "amine"
+  },
+  {
+    "smiles": "CCCN",
+    "name": "propan-1-amine",
+    "category": "amine"
+  },
+  {
+    "smiles": "CC(C)N",
+    "name": "propan-2-amine",
+    "category": "amine"
+  },
+  {
+    "smiles": "CN(C)C",
+    "name": "trimethyl-azane",
+    "category": "amine"
+  },
+  {
+    "smiles": "CC(=O)N",
+    "name": "acetamide",
+    "category": "amide"
+  },
+  {
+    "smiles": "CC(=O)NC",
+    "name": "N-methylacetamide",
+    "category": "amide"
+  },
+  {
+    "smiles": "CC(=O)Nc1ccccc1",
+    "name": "N-phenylacetamide",
+    "category": "amide"
+  },
+  {
+    "smiles": "COC",
+    "name": "methoxymethane",
+    "category": "ether"
+  },
+  {
+    "smiles": "CCOCC",
+    "name": "1-ethoxyethane",
+    "category": "ether"
+  },
+  {
+    "smiles": "C1CCOCC1",
+    "name": "oxane",
+    "category": "ether"
+  },
+  {
+    "smiles": "C1COCC1",
+    "name": "oxolane",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "C1COCO1",
+    "name": "1,3-dioxolane",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "c1ccoc1",
+    "name": "furan",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "c1cc[nH]c1",
+    "name": "1H-pyrrole",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "c1ccncc1",
+    "name": "pyridine",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "c1ccsc1",
+    "name": "thiophene",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "c1cnc[nH]1",
+    "name": "1H-imidazole",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "c1ccc2[nH]ccc2c1",
+    "name": "1H-indole",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "ClCCl",
+    "name": "dichloromethane",
+    "category": "haloalkane"
+  },
+  {
+    "smiles": "ClC(Cl)(Cl)Cl",
+    "name": "tetrachloromethane",
+    "category": "haloalkane"
+  },
+  {
+    "smiles": "FC(F)(F)F",
+    "name": "tetrafluoromethane",
+    "category": "haloalkane"
+  },
+  {
+    "smiles": "BrCC",
+    "name": "1-bromoethane",
+    "category": "haloalkane"
+  },
+  {
+    "smiles": "ClCC(Cl)C",
+    "name": "1,2-dichloropropane",
+    "category": "haloalkane"
+  },
+  {
+    "smiles": "N#CC",
+    "name": "acetonitrile",
+    "category": "nitrile"
+  },
+  {
+    "smiles": "N#Cc1ccccc1",
+    "name": "benzonitrile",
+    "category": "nitrile"
+  },
+  {
+    "smiles": "[N+](=O)(C)[O-]",
+    "name": "nitromethane",
+    "category": "nitro"
+  },
+  {
+    "smiles": "[N+](=O)([O-])c1ccccc1",
+    "name": "nitrobenzene",
+    "category": "nitro"
+  },
+  {
+    "smiles": "CS",
+    "name": "methanethiol",
+    "category": "thiol"
+  },
+  {
+    "smiles": "CSC",
+    "name": "dimethyl-sulfane",
+    "category": "sulfide"
+  },
+  {
+    "smiles": "CS(=O)(=O)O",
+    "name": "methanesulfonic acid",
+    "category": "sulfonic_acid"
+  },
+  {
+    "smiles": "CS(C)(=O)=O",
+    "name": "(methylsulfonyl)methane",
+    "category": "sulfone"
+  },
+  {
+    "smiles": "CS(C)=O",
+    "name": "dimethyl sulfoxide",
+    "category": "sulfoxide"
+  },
+  {
+    "smiles": "N#CC#N",
+    "name": "ethanedinitrile",
+    "category": "multifunctional"
+  },
+  {
+    "smiles": "OCC(N)C(=O)O",
+    "name": "2-amino-3-hydroxypropanoic acid",
+    "category": "amino_acid"
+  },
+  {
+    "smiles": "NC(Cc1ccccc1)C(=O)O",
+    "name": "2-amino-3-phenylpropanoic acid",
+    "category": "amino_acid"
+  },
+  {
+    "smiles": "NC(C(=O)O)C",
+    "name": "2-aminopropanoic acid",
+    "category": "amino_acid"
+  },
+  {
+    "smiles": "CC(N)C(=O)O",
+    "name": "2-aminopropanoic acid",
+    "category": "amino_acid"
+  },
+  {
+    "smiles": "OC1OC(CO)C(O)C(O)C1O",
+    "name": "6-(hydroxymethyl)oxane-2,3,4,5-tetraol",
+    "category": "sugar"
+  },
+  {
+    "smiles": "OCC1OC(O)C(O)C(O)C1O",
+    "name": "6-(hydroxymethyl)oxane-2,3,4,5-tetraol",
+    "category": "sugar"
+  },
+  {
+    "smiles": "CCCCCC=CCC=CCCCCCCCC(=O)O",
+    "name": "octadeca-9,12-dienoic acid",
+    "category": "fatty_acid"
+  },
+  {
+    "smiles": "CCCCCCCCCCCCCC(=O)O",
+    "name": "tetradecanoic acid",
+    "category": "fatty_acid"
+  },
+  {
+    "smiles": "Oc1ccc(O)cc1",
+    "name": "benzene-1,4-diol",
+    "category": "aromatic_alcohol"
+  },
+  {
+    "smiles": "Oc1cccc(O)c1",
+    "name": "benzene-1,3-diol",
+    "category": "aromatic_alcohol"
+  },
+  {
+    "smiles": "COc1ccccc1",
+    "name": "methoxybenzene",
+    "category": "aromatic_ether"
+  },
+  {
+    "smiles": "CC1=CC=CC=C1",
+    "name": "methylbenzene",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "CC(C)C1CCCCC1",
+    "name": "(propan-2-yl)cyclohexane",
+    "category": "alicyclic"
+  },
+  {
+    "smiles": "O=C1CCCCC1",
+    "name": "cyclohexanone",
+    "category": "ketone"
+  },
+  {
+    "smiles": "O=C1OCCO1",
+    "name": "1,3-dioxolan-2-one",
+    "category": "lactone"
+  },
+  {
+    "smiles": "O=C1OCC1",
+    "name": "1-oxacyclobutan-2-one",
+    "category": "lactone"
+  },
+  {
+    "smiles": "O=C1NCCC1",
+    "name": "pyrrolidin-2-one",
+    "category": "lactam"
+  },
+  {
+    "smiles": "O=C1CCCC1",
+    "name": "cyclopentanone",
+    "category": "ketone"
+  },
+  {
+    "smiles": "O=C1CCC=CC1",
+    "name": "cyclohex-3-en-1-one",
+    "category": "enone"
+  },
+  {
+    "smiles": "c1ccc(-c2ccccc2)cc1",
+    "name": "phenylbenzene",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "c1ccc2c(c1)c1ccccc1n2",
+    "name": "8-azatricyclo[7.4.0.0^{2,7}]tridecane",
+    "category": "heterocycle"
+  },
+  {
+    "smiles": "CC(=O)OC1CCCCC1",
+    "name": "cyclohexyl acetate",
+    "category": "ester"
+  },
+  {
+    "smiles": "CCCCCC",
+    "name": "hexane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CC(C)(C)CC",
+    "name": "2,2-dimethylbutane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CCC(C)CC",
+    "name": "3-methylpentane",
+    "category": "alkane"
+  },
+  {
+    "smiles": "CC=CC",
+    "name": "but-2-ene",
+    "category": "alkene"
+  },
+  {
+    "smiles": "CC(C)=C",
+    "name": "2-methylprop-1-ene",
+    "category": "alkene"
+  },
+  {
+    "smiles": "C1=CC=CC=C1Cl",
+    "name": "chlorobenzene",
+    "category": "aromatic"
+  },
+  {
+    "smiles": "NC(=O)N",
+    "name": "1-aminomethanamide",
+    "category": "amide"
+  },
+  {
+    "smiles": "NC(=N)N",
+    "name": "1-iminomethanediamine",
+    "category": "guanidine"
+  },
+  {
+    "smiles": "N=C=O",
+    "name": "1-iminomethanal",
+    "category": "isocyanate"
+  },
+  {
+    "smiles": "S=C=N",
+    "name": "1-thioxomethanimine",
+    "category": "isothiocyanate"
+  }
+]

--- a/tests/integration/test_corpus_golden.py
+++ b/tests/integration/test_corpus_golden.py
@@ -1,0 +1,63 @@
+"""Strict golden-name comparison across RDKit versions.
+
+The naming engine reads aromaticity / H-counts / kekulisation off RDKit,
+so the same SMILES can in principle name to a different string under
+different RDKit versions. This test pins the expected name for every
+entry in ``tests/fixtures/diverse_corpus.csv`` to its golden value in
+``tests/fixtures/diverse_corpus.golden.json``. Any divergence is
+reported as an actionable list.
+
+Run::
+
+    pytest -m golden            # this test only
+    pytest                      # default suite *excludes* it
+
+The companion ``rdkit-compat`` CI job runs this test against a matrix
+of RDKit versions; failures pinpoint which structures depend on RDKit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import rdkit
+
+from bluenamer import name_smiles
+
+GOLDEN = Path(__file__).resolve().parent.parent / "fixtures" / "diverse_corpus.golden.json"
+
+pytestmark = pytest.mark.golden
+
+
+@pytest.fixture(scope="module")
+def goldens() -> list[dict]:
+    return json.loads(GOLDEN.read_text())
+
+
+def test_golden_file_is_non_trivial(goldens):
+    assert len(goldens) >= 50, "Corpus shrank below 50 entries; regenerate goldens?"
+
+
+def test_corpus_names_match_golden(goldens, capsys):
+    """Every (SMILES → expected name) must match the current namer output."""
+
+    mismatches: list[tuple[str, str, str, str]] = []
+    for row in goldens:
+        actual = name_smiles(row["smiles"])
+        if actual != row["name"]:
+            mismatches.append((row["smiles"], row["category"], row["name"], actual))
+
+    if mismatches:
+        with capsys.disabled():
+            print(f"\nrdkit version: {rdkit.__version__}")
+            print(f"divergent SMILES: {len(mismatches)}/{len(goldens)}\n")
+            for smi, cat, want, got in mismatches:
+                print(f"  [{cat:18s}] {smi}")
+                print(f"    expected: {want}")
+                print(f"    got:      {got}")
+        pytest.fail(
+            f"{len(mismatches)} corpus entries name differently on rdkit "
+            f"{rdkit.__version__} than the committed goldens"
+        )


### PR DESCRIPTION
## Summary
Builds out broad detection for naming output that drifts with the RDKit upgrade cycle. The existing `test_charged_ammonio_substituent_keeps_all_n_ligands_explicit` xfail was a one-off symptom — this PR adds the infrastructure to find all of them.

### Golden corpus
- `tests/fixtures/diverse_corpus.golden.json` — frozen `(SMILES → expected name)` pairs for every entry in `diverse_corpus.csv`. Generated against rdkit 2025.03.6 locally; treat as the contract.
- `tests/integration/test_corpus_golden.py` — strict equality test. Divergences are listed as a single failure showing every `(smiles, category, expected, got)` row, so reviewers see the full delta at once.
- `scripts/regenerate_goldens.py` — helper for intentional resets when the namer or rdkit pin changes.

The test is gated by a new `golden` pytest marker and is **excluded** from the default `pytest` suite so an rdkit bump in `[dev]` doesn't make the standard CI matrix red overnight.

### `rdkit-compat` CI job
New matrix job in `.github/workflows/ci.yml` that pins rdkit to each of
- `2024.03.6`
- `2024.09.6`
- `2025.03.6`
- `2025.09.5`
- `2026.3.2`

on py3.12 and runs only `pytest -m golden`. `fail-fast: false` so we get the full divergence picture, not the first version that breaks.

Expect this job to be **red on at least some matrix rows initially** — that's the point. Each red row is an action item: a SMILES whose name depends on rdkit's perception logic. As the namer is hardened, divergent goldens disappear and the matrix turns green across all versions.

## Test plan
- [x] `pytest -m golden` → 2 passed on rdkit 2025.03.6 (local).
- [x] `pytest -m "not slow and not dataset and not golden"` → 168 passed (same as PR7).
- [x] `ruff check` + `ruff format --check` clean over `src/`, `tests/`, `scripts/`.
- [ ] CI `rdkit-compat`: will reveal which entries (if any) drift across rdkit 2024–2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a golden-name regression suite and RDKit version-matrix CI job to detect and manage naming drift across RDKit releases.

New Features:
- Introduce a golden corpus integration test that compares SMILES-to-name output against a frozen JSON fixture.
- Add a helper script to regenerate the golden corpus from the current naming engine and RDKit version.

Enhancements:
- Tag the golden regression test with a dedicated pytest marker and exclude it from the default fast test selection in both config and README usage docs.

CI:
- Add an rdkit-compat CI job that runs the golden regression suite against a matrix of pinned RDKit versions to surface version-dependent naming differences.