### PR TITLE
Revert "refactor(describer): structure-driven prose (port from earlie…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,26 +87,18 @@ for step in analysis.decisions:
 
 ### Natural-language description (`describe`)
 
-`bluenamer.describe(smiles)` emits structure-driven, reconstructable
-prose about the molecule: the parent skeleton, heteroatoms, unsaturation,
-stereochemistry, substituents, and connectivity for atom-by-atom
-rebuilding. Useful for explainability views and for generating
-(SMILES, name, description) training tuples:
+`bluenamer.describe(smiles)` walks the same trace and renders a
+deterministic, multi-paragraph explanation of how the name is built.
+Useful for explainability views and for generating (SMILES, name,
+description) training tuples:
 
 ```python
 from bluenamer import describe
 
-d = describe("CCO")
-print(d)
-# The molecule is built around a 2-atom carbon chain. Within that parent
-# framework, all parent-chain bonds are single. Attached to the parent is
-# a hydroxy group at position 1. For reconstruction, number the parent
-# as follows: 1-2 single.
-
-d.facts[0].parent_summary       # 'a 2-atom carbon chain'
-d.facts[0].substituents         # ('a hydroxy group at position 1',)
-d.facts[0].connectivity         # ('1-2 single',)
-d.name                          # 'ethanol'  (handy, from the namer)
+d = describe("CC(=O)Nc1ccccc1")
+print(d)            # multi-paragraph prose
+d.rules_hit         # ('P-44', 'P-45', 'P-41', 'P-61', 'P-67')
+d.components[0]     # DescribedComponent(phase='parse', text='RDKit parsed ...')
 ```
 
 Same input → same output. No LLM in the loop.

--- a/examples/eval_via_opsin.py
+++ b/examples/eval_via_opsin.py
@@ -61,4 +61,3 @@ matches = np.array([s == o and s is not None for s, o in zip(smiles_strings, ori
 accuracy = np.mean(matches)
 
 print(f"Accuracy: {accuracy:.2%}")
-

--- a/examples/find_small_failures.py
+++ b/examples/find_small_failures.py
@@ -5,10 +5,10 @@ from concurrent.futures import ProcessPoolExecutor
 import py2opsin
 from datasets import load_dataset
 from tqdm import tqdm
-from bluenamer.utils import standardize_mol
 
 from bluenamer.namer import name_smiles
 from bluenamer.resonance_compare import equivalent_smiles
+from bluenamer.utils import standardize_mol
 
 
 def canon(smi):

--- a/examples/opsin_eval_ZINC22.py
+++ b/examples/opsin_eval_ZINC22.py
@@ -94,8 +94,7 @@ def load_parquet_shard(parquet_path):
 
     if SMILES_COLUMN not in ds.column_names:
         raise RuntimeError(
-            f"Column {SMILES_COLUMN!r} not found in {parquet_path}. "
-            f"Available columns: {ds.column_names}"
+            f"Column {SMILES_COLUMN!r} not found in {parquet_path}. Available columns: {ds.column_names}"
         )
 
     return ds
@@ -133,15 +132,10 @@ def sample_zinc22_from_random_parquet_batches(parquet_files, seed):
     )
 
     for batch_start in range(0, len(shuffled_parquets), PARQUET_BATCH_SIZE):
-        batch = shuffled_parquets[
-            batch_start : batch_start + PARQUET_BATCH_SIZE
-        ]
+        batch = shuffled_parquets[batch_start : batch_start + PARQUET_BATCH_SIZE]
         parquet_batches_read += 1
 
-        print(
-            f"Seed {seed}: reading parquet batch {parquet_batches_read} "
-            f"with {len(batch)} shard(s)"
-        )
+        print(f"Seed {seed}: reading parquet batch {parquet_batches_read} with {len(batch)} shard(s)")
 
         for parquet_path in batch:
             if len(pool) >= target_pool_size:
@@ -276,10 +270,7 @@ def opsin_batch_with_fallback(names):
                 converted = [converted]
 
             if len(converted) != len(name_chunk):
-                raise ValueError(
-                    f"OPSIN returned {len(converted)} results for "
-                    f"{len(name_chunk)} names"
-                )
+                raise ValueError(f"OPSIN returned {len(converted)} results for {len(name_chunk)} names")
 
         except Exception:
             converted = [opsin_one(name) for name in name_chunk]
@@ -510,6 +501,7 @@ def main():
     print(f"Overall accuracy: {overall_accuracy:.2%}")
     print(f"Total failures: {len(all_failures):,}")
     print(f"Wrote results to: {OUT_DIR.resolve()}")
+
 
 if __name__ == "__main__":
     mp.freeze_support()

--- a/examples/opsin_eval_ZINC22.py
+++ b/examples/opsin_eval_ZINC22.py
@@ -5,15 +5,15 @@ import random
 from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from huggingface_hub import HfApi, hf_hub_url
 
 import numpy as np
 import py2opsin
 from datasets import load_dataset
+from huggingface_hub import HfApi, hf_hub_url
 from tqdm import tqdm
-from bluenamer.utils import standardize_mol
 
 from bluenamer.namer import name_smiles
+from bluenamer.utils import standardize_mol
 
 # --- Configuration ---
 ZINC22_REPO_ID = "chandar-lab/ZINC_22"

--- a/examples/opsin_eval_pubchem.py
+++ b/examples/opsin_eval_pubchem.py
@@ -106,10 +106,7 @@ def opsin_batch_with_fallback(names):
                 converted = [converted]
 
             if len(converted) != len(name_chunk):
-                raise ValueError(
-                    f"OPSIN returned {len(converted)} results for "
-                    f"{len(name_chunk)} names"
-                )
+                raise ValueError(f"OPSIN returned {len(converted)} results for {len(name_chunk)} names")
 
         except Exception:
             converted = [opsin_one(name) for name in name_chunk]

--- a/examples/test_opsin_mac.py
+++ b/examples/test_opsin_mac.py
@@ -7,9 +7,9 @@ import numpy as np
 import py2opsin
 from datasets import load_dataset
 from tqdm import tqdm
-from bluenamer.utils import standardize_mol
 
 from bluenamer.namer import name_smiles
+from bluenamer.utils import standardize_mol
 
 # --- Configuration ---
 N_TEST = 1000_000

--- a/examples/test_opsin_mac_ZINC22.py
+++ b/examples/test_opsin_mac_ZINC22.py
@@ -11,9 +11,9 @@ import pandas as pd
 import py2opsin
 from datasets import load_dataset
 from tqdm import tqdm
-from bluenamer.utils import standardize_mol
 
 from bluenamer.namer import name_smiles
+from bluenamer.utils import standardize_mol
 
 # --- Configuration ---
 N_TEST = 100_000

--- a/examples/test_opsin_mac_ZINC22_light.py
+++ b/examples/test_opsin_mac_ZINC22_light.py
@@ -12,9 +12,9 @@ import py2opsin
 from datasets import load_dataset
 from huggingface_hub import list_repo_files
 from tqdm import tqdm
-from bluenamer.utils import standardize_mol
 
 from bluenamer.namer import name_smiles
+from bluenamer.utils import standardize_mol
 
 # --- Configuration ---
 N_TEST = 100_000

--- a/examples/test_qm9_opsin_batch.py
+++ b/examples/test_qm9_opsin_batch.py
@@ -147,11 +147,21 @@ def main():
 
     ds = load_dataset(
         "yairschiff/qm9",
-        split="train",
+        split=None,
     )
+    if isinstance(ds, dict):
+        ds = ds.values()
+        ds = ds[0] if isinstance(ds, list) else list(ds)[0]
 
-    # all_smiles = ds["smiles"]
-    dataset = list(ds["smiles"])
+    if "SMILES" in ds.column_names:
+        smiles_col = "SMILES"
+    elif "smiles" in ds.column_names:
+        smiles_col = "smiles"
+    else:
+        smiles_col = ds.column_names[0]
+
+
+    dataset = list([smiles_col])
 
     print("Converting SMILES to IUPAC names...")
 

--- a/examples/test_qm9_opsin_batch.py
+++ b/examples/test_qm9_opsin_batch.py
@@ -160,7 +160,6 @@ def main():
     else:
         smiles_col = ds.column_names[0]
 
-
     dataset = list([smiles_col])
 
     print("Converting SMILES to IUPAC names...")

--- a/src/bluenamer/__init__.py
+++ b/src/bluenamer/__init__.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 
-from .describer import Description, DescriptionFacts, describe
+from .describer import DescribedComponent, Description, describe
 from .engine import DEFAULT_NAMING_ENGINE, NamingEngine, NamingRequest, NamingResult
 from .functional_groups import register_group_detector
 from .molecule import (
@@ -69,8 +69,8 @@ __all__ = [
     "AtomBinding",
     "BondBinding",
     "DecisionTrace",
+    "DescribedComponent",
     "Description",
-    "DescriptionFacts",
     "FunctionalGroupMetadata",
     "NameAnalysis",
     "NamingEngine",

--- a/src/bluenamer/cli.py
+++ b/src/bluenamer/cli.py
@@ -92,7 +92,7 @@ def _cmd_describe(args: argparse.Namespace) -> int:
         sys.stdout.write("\n")
     else:
         sys.stdout.write(str(description) + "\n")
-    return 0 if description.text else 1
+    return 0 if description.name else 1
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/bluenamer/describer.py
+++ b/src/bluenamer/describer.py
@@ -1,509 +1,215 @@
-"""Human-readable molecular structure descriptions from SMILES.
+"""Natural-language description of how a structure was named.
 
-The describer reuses the naming pipeline's graph model, parent selection,
-and numbering, then emits prose intended to be reconstructable by a
-human. It is intentionally descriptive (graph facts in chemistry
-vocabulary) rather than a second IUPAC name generator: a reader of the
-description could draw the molecule.
+`describe(smiles)` returns a `Description` that bundles a deterministic
+multi-line prose explanation plus the structured components it was
+rendered from. The prose is built directly from the `DecisionTrace` and
+`trace_segments` that the engine already emits, so the output is
+faithful to what the namer actually did — not a separate model.
 
-Deterministic by construction. No LLM in the loop.
+Same input → same output. Safe to use in dataset pipelines.
 """
 
 from __future__ import annotations
 
-import dataclasses
-from collections import defaultdict, deque
 from dataclasses import dataclass
 
-from .chains import find_all_carbon_paths, find_ring_systems
-from .engine import DEFAULT_NAMING_ENGINE, NamingRequest
-from .graph_io import get_connected_components, read_smiles
-from .locants import parse_locant
-from .molecule import Molecule
-from .namer import name_subgraph
-from .numbering import number_parent
-from .parent_selection import select_principal_parent
-
-BOND_WORDS = {1: "single", 2: "double", 3: "triple"}
-ELEMENT_WORDS = {
-    "B": "boron",
-    "C": "carbon",
-    "N": "nitrogen",
-    "O": "oxygen",
-    "F": "fluorine",
-    "Si": "silicon",
-    "P": "phosphorus",
-    "S": "sulfur",
-    "Cl": "chlorine",
-    "Se": "selenium",
-    "Br": "bromine",
-    "I": "iodine",
-}
-HALO_PREFIXES = {"F": "fluoro", "Cl": "chloro", "Br": "bromo", "I": "iodo"}
+from .engine import DEFAULT_NAMING_ENGINE, NamingRequest, _extract_rules_hit
+from .molecule import TracePhase, TraceStep
 
 
 @dataclass(frozen=True)
-class DescriptionFacts:
-    """Structured facts extracted from a molecular component.
+class DescribedComponent:
+    """One phase-tagged human-readable line."""
 
-    Each field is a tuple of human-readable phrases the assembler
-    composes into prose.
-    """
-
-    parent_summary: str
-    parent_detail: str = ""
-    heteroatoms: tuple[str, ...] = ()
-    unsaturation: tuple[str, ...] = ()
-    stereochemistry: tuple[str, ...] = ()
-    substituents: tuple[str, ...] = ()
-    connectivity: tuple[str, ...] = ()
+    phase: str
+    text: str
 
 
 @dataclass(frozen=True)
 class Description:
-    """Result of :func:`describe`.
-
-    ``str(d)`` returns the prose. ``d.facts`` holds the structured
-    per-component facts the prose was assembled from.
-    """
+    """Result of `describe`. ``str(d)`` returns the rendered prose."""
 
     smiles: str
     name: str
-    text: str
-    facts: tuple[DescriptionFacts, ...] = ()
+    paragraphs: tuple[str, ...]
+    components: tuple[DescribedComponent, ...] = ()
+    rules_hit: tuple[str, ...] = ()
+    rule_hints: tuple[str, ...] = ()
 
     def __str__(self) -> str:
-        return self.text
+        return "\n\n".join(self.paragraphs)
+
+    @property
+    def summary(self) -> str:
+        return self.paragraphs[0] if self.paragraphs else ""
 
     def to_dict(self) -> dict:
         return {
             "smiles": self.smiles,
             "name": self.name,
-            "text": self.text,
-            "facts": [dataclasses.asdict(f) for f in self.facts],
+            "summary": self.summary,
+            "paragraphs": list(self.paragraphs),
+            "components": [{"phase": c.phase, "text": c.text} for c in self.components],
+            "rules_hit": list(self.rules_hit),
+            "rule_hints": list(self.rule_hints),
         }
 
 
-# --- public entry point --------------------------------------------------
+def _plural(n: int, word: str) -> str:
+    return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+
+def _render_parse(step: TraceStep) -> str | None:
+    atoms = step.data.get("atom_count")
+    if atoms is None:
+        return None
+    bonds = step.data.get("bond_count", 0)
+    return f"RDKit parsed the SMILES into a molecular graph with {_plural(atoms, 'atom')} and {_plural(bonds, 'bond')}."
+
+
+def _render_component(step: TraceStep) -> str | None:
+    components = step.data.get("components") or []
+    if not components:
+        return None
+    if len(components) == 1:
+        return "The structure is a single connected component, named in one piece."
+    return f"The structure splits into {len(components)} connected components, named independently and joined."
+
+
+def _render_perception(step: TraceStep) -> str | None:
+    groups = step.data.get("groups") or []
+    if not groups:
+        return "Perception found no nameable principal groups."
+    names = sorted({g.get("key", "?") for g in groups})
+    principals = sorted({g.get("key", "?") for g in groups if g.get("principal_candidate")})
+    if not principals:
+        return f"Perception identified non-principal groups: {', '.join(names)}."
+    return (
+        f"Perception identified {_plural(len(groups), 'functional group')} "
+        f"({', '.join(names)}); principal candidate{'s' if len(principals) > 1 else ''}: {', '.join(principals)}."
+    )
+
+
+def _render_priority(step: TraceStep) -> str | None:
+    key = step.data.get("principal_key")
+    if not key:
+        return None
+    role = (
+        "treated as a substituent"
+        if step.data.get("is_substituent")
+        else "selected as the principal characteristic group"
+    )
+    return f"The {key} group is {role}, per the registry seniority order."
+
+
+def _render_parent_selection(step: TraceStep) -> str | None:
+    parent = step.data.get("parent_atoms") or []
+    if not parent:
+        return None
+    if step.data.get("is_bicycle"):
+        kind = "bicyclic ring system"
+    elif step.data.get("is_ring"):
+        kind = "ring"
+    else:
+        kind = "acyclic chain"
+    return f"The parent skeleton is a {len(parent)}-atom {kind} (atoms {sorted(parent)})."
+
+
+def _render_numbering(step: TraceStep) -> str | None:
+    locants = step.data.get("locants") or {}
+    if not locants:
+        return None
+    sample = sorted(locants.items(), key=lambda kv: kv[1])[:4]
+    sample_str = ", ".join(f"atom {a}→{loc}" for a, loc in sample)
+    return f"Numbering minimizes locants for the principal group and substituents (e.g. {sample_str})."
+
+
+def _render_assembly(step: TraceStep) -> str | None:
+    name = step.data.get("name")
+    if name is None:
+        return None
+    components = step.data.get("components")
+    if components is not None:
+        if len(components) == 1:
+            return f"The final assembled name is **{name}**."
+        return f"The final assembled name is **{name}** ({len(components)} pieces joined)."
+    sub_count = step.data.get("substituent_count")
+    if sub_count is None:
+        return None
+    return f"Component assembled as **{name}** with {_plural(sub_count, 'substituent')}."
+
+
+_RENDERERS: dict[TracePhase, callable] = {
+    TracePhase.PARSE: _render_parse,
+    TracePhase.COMPONENT: _render_component,
+    TracePhase.PERCEPTION: _render_perception,
+    TracePhase.PRIORITY: _render_priority,
+    TracePhase.PARENT_SELECTION: _render_parent_selection,
+    TracePhase.NUMBERING: _render_numbering,
+    TracePhase.ASSEMBLY: _render_assembly,
+}
+
+
+def _trace_segment_lines(trace_segments: list[dict]) -> list[str]:
+    lines = []
+    for seg in trace_segments:
+        if not isinstance(seg, dict):
+            continue
+        label = seg.get("label") or seg.get("key")
+        terms = seg.get("name_terms") or []
+        if not label or not terms:
+            continue
+        atoms = seg.get("atoms") or []
+        suffix = f" (atoms {atoms})" if atoms else ""
+        lines.append(f"- {label}: contributes “{terms[0]}”{suffix}.")
+    return lines
 
 
 def describe(smiles: str) -> Description:
-    """Render a structure-driven natural-language description of ``smiles``."""
+    """Render a natural-language explanation of how ``smiles`` is named."""
 
-    mol = read_smiles(smiles)
-    if not mol.atoms:
-        return Description(smiles=smiles, name="", text="")
+    result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, include_trace=True))
 
-    components = get_connected_components(mol)
-    name_result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles))
+    if not result.name:
+        summary = f"The structure {smiles} could not be named by the current ruleset."
+    else:
+        summary = f"The molecule {smiles} is named **{result.name}**."
 
-    facts_list: list[DescriptionFacts] = []
-    sentences: list[str] = []
-    for component in components:
-        facts = _describe_component_facts(mol, component)
-        if facts is None:
-            sentences.append(_describe_unselected_component(mol, component))
+    components: list[DescribedComponent] = []
+    seen: set[tuple[str, str]] = set()
+    for step in result.decisions:
+        renderer = _RENDERERS.get(step.phase)
+        if renderer is None:
             continue
-        facts_list.append(facts)
-        sentences.append(_assemble_description(facts))
+        text = renderer(step)
+        if not text:
+            continue
+        key = (step.phase.value, text)
+        if key in seen:
+            continue
+        seen.add(key)
+        components.append(DescribedComponent(phase=step.phase.value, text=text))
+
+    paragraphs: list[str] = [summary]
+    if components:
+        paragraphs.append("\n".join(c.text for c in components))
+
+    seg_lines = _trace_segment_lines(result.trace_segments)
+    if seg_lines:
+        paragraphs.append("Name pieces contributed by the trace:\n" + "\n".join(seg_lines))
+
+    rules, hints = _extract_rules_hit(result.trace_segments)
+    if rules:
+        paragraphs.append("IUPAC Blue Book rules applied: " + ", ".join(rules) + ".")
 
     return Description(
         smiles=smiles,
-        name=name_result.name,
-        text=" ".join(part for part in sentences if part),
-        facts=tuple(facts_list),
+        name=result.name,
+        paragraphs=tuple(paragraphs),
+        components=tuple(components),
+        rules_hit=rules,
+        rule_hints=hints,
     )
 
 
-# --- per-component fact extraction ---------------------------------------
-
-
-def _describe_component_facts(mol: Molecule, component_atoms: set[int]) -> DescriptionFacts | None:
-    """Build the structured facts for one connected component."""
-
-    if len(component_atoms) == 1:
-        atom = mol.atoms[next(iter(component_atoms))]
-        charge_text = " cation" if atom.charge > 0 else " anion" if atom.charge < 0 else ""
-        return DescriptionFacts(parent_summary=f"a single {atom.element.name}{charge_text}")
-
-    exclude_atoms = set(mol.atoms.keys()) - component_atoms
-    parent = _select_description_parent(mol, exclude_atoms)
-    if parent is None:
-        return None
-
-    seed_path = parent.primary_path
-    branch_index = _branch_attachment_index(mol, seed_path, exclude_atoms)
-    numbered_path = number_parent(
-        mol,
-        parent.paths,
-        set(),
-        branch_index,
-        parent.is_ring,
-        parent.is_bicycle,
-        parent.is_spiro,
-        is_polycycle=parent.is_polycycle,
-        fixed_start=parent.is_bicycle or parent.is_spiro or parent.is_polycycle,
-    )
-    locants = {atom_idx: str(i + 1) for i, atom_idx in enumerate(numbered_path)}
-    parent_set = set(numbered_path)
-
-    return DescriptionFacts(
-        parent_summary=_parent_skeleton_phrase(
-            mol, numbered_path, parent.is_ring, parent.is_bicycle, parent.is_spiro, parent.is_polycycle
-        ),
-        parent_detail=_parent_saturation_phrase(mol, numbered_path, parent.is_ring),
-        heteroatoms=tuple(_parent_heteroatom_phrases(mol, numbered_path, locants)),
-        unsaturation=tuple(_parent_unsaturation_phrases(mol, numbered_path, locants)),
-        stereochemistry=tuple(_stereochemistry_phrases(mol, numbered_path, locants)),
-        substituents=tuple(_parent_substituent_phrases(mol, numbered_path, parent_set, exclude_atoms, locants)),
-        connectivity=tuple(_parent_connection_phrases(mol, numbered_path, locants, parent.is_ring)),
-    )
-
-
-def _describe_unselected_component(mol: Molecule, component: set[int]) -> str:
-    """Fall-back prose when no parent could be selected."""
-
-    n = len(component)
-    elements = sorted({mol.atoms[i].symbol for i in component})
-    return f"A {n}-atom fragment with elements {{{', '.join(elements)}}} (no parent skeleton selected)."
-
-
-def _select_description_parent(mol: Molecule, exclude_atoms: set[int]):
-    chains = find_all_carbon_paths(mol, exclude_atoms)
-    ring_systems = find_ring_systems(mol, exclude_atoms)
-    if not chains and not ring_systems:
-        return None
-    return select_principal_parent(mol, chains, ring_systems, [])
-
-
-def _branch_attachment_index(mol: Molecule, parent_path: list[int], exclude_atoms: set[int]) -> dict[int, list[str]]:
-    """Approximate branch labels so numbering ranks them consistently."""
-
-    parent_set = set(parent_path)
-    mapping: dict[int, list[str]] = defaultdict(list)
-    for atom_idx in parent_path:
-        for neighbor in mol.get_neighbors(atom_idx):
-            if neighbor in parent_set or neighbor in exclude_atoms:
-                continue
-            mapping[atom_idx].append(_short_substituent_label(mol, atom_idx, neighbor, parent_set))
-    return dict(mapping)
-
-
-# --- skeletal-fact phrases -----------------------------------------------
-
-
-def _parent_skeleton_phrase(
-    mol: Molecule,
-    numbered_path: list[int],
-    is_ring: bool,
-    is_bicycle: bool,
-    is_spiro: bool,
-    is_polycycle: bool,
-) -> str:
-    size = len(numbered_path)
-    hetero = any(not mol.atoms[idx].is_carbon for idx in numbered_path)
-    if is_bicycle:
-        kind = "bicyclic heteroskeleton" if hetero else "bicyclic carbon skeleton"
-    elif is_spiro:
-        kind = "spiro heteroskeleton" if hetero else "spiro carbon skeleton"
-    elif is_polycycle:
-        kind = "polycyclic heteroskeleton" if hetero else "polycyclic carbon skeleton"
-    elif is_ring:
-        kind = "heterocycle" if hetero else "carbocycle"
-    else:
-        kind = "heteroatom-containing chain" if hetero else "carbon chain"
-    measure = "membered" if (is_ring or is_bicycle or is_spiro or is_polycycle) else "atom"
-    return f"a {size}-{measure} {kind}"
-
-
-def _parent_heteroatom_phrases(mol: Molecule, numbered_path: list[int], locants: dict[int, str]) -> list[str]:
-    by_element: dict[str, list[str]] = defaultdict(list)
-    for atom_idx in numbered_path:
-        atom = mol.atoms[atom_idx]
-        if not atom.is_carbon:
-            by_element[ELEMENT_WORDS.get(atom.symbol, atom.symbol)].append(locants[atom_idx])
-    return [f"{element} at {_positions_text(locs)}" for element, locs in sorted(by_element.items())]
-
-
-def _parent_unsaturation_phrases(mol: Molecule, numbered_path: list[int], locants: dict[int, str]) -> list[str]:
-    phrases: list[str] = []
-    seen: set[int] = set()
-    parent_set = set(numbered_path)
-    for atom_idx in numbered_path:
-        for neighbor in mol.get_neighbors(atom_idx):
-            if neighbor not in parent_set:
-                continue
-            bond = mol.get_bond(atom_idx, neighbor)
-            if not bond or bond.idx in seen or bond.order <= 1:
-                continue
-            seen.add(bond.idx)
-            loc_pair = sorted([locants[atom_idx], locants[neighbor]], key=parse_locant)
-            stereo = f" with {bond.stereo} geometry" if bond.stereo else ""
-            phrases.append(
-                f"a {BOND_WORDS.get(bond.order, bond.order)} bond between positions "
-                f"{loc_pair[0]} and {loc_pair[1]}{stereo}"
-            )
-    return phrases
-
-
-def _parent_saturation_phrase(mol: Molecule, numbered_path: list[int], is_ring: bool) -> str:
-    locants = {idx: str(i + 1) for i, idx in enumerate(numbered_path)}
-    if _parent_unsaturation_phrases(mol, numbered_path, locants):
-        return ""
-    return "all parent ring bonds are single" if is_ring else "all parent-chain bonds are single"
-
-
-def _stereochemistry_phrases(mol: Molecule, numbered_path: list[int], locants: dict[int, str]) -> list[str]:
-    return [f"position {locants[idx]} is {mol.atoms[idx].stereo}" for idx in numbered_path if mol.atoms[idx].stereo]
-
-
-def _parent_substituent_phrases(
-    mol: Molecule,
-    numbered_path: list[int],
-    parent_set: set[int],
-    exclude_atoms: set[int],
-    locants: dict[int, str],
-) -> list[str]:
-    grouped: dict[str, list[str]] = defaultdict(list)
-    side_chains: list[tuple[str, str]] = []
-    handled: set[int] = set()
-
-    for atom_idx in numbered_path:
-        for neighbor in mol.get_neighbors(atom_idx):
-            if neighbor in parent_set or neighbor in exclude_atoms or neighbor in handled:
-                continue
-            label = _simple_substituent_description(mol, atom_idx, neighbor, parent_set)
-            branch_atoms = _branch_component(mol, neighbor, parent_set | exclude_atoms)
-            handled.update(branch_atoms)
-            if label:
-                grouped[label].append(locants[atom_idx])
-            else:
-                side_chains.append((locants[atom_idx], _describe_side_chain(mol, neighbor, parent_set | exclude_atoms)))
-
-    parts: list[str] = []
-    for label, positions in sorted(grouped.items(), key=lambda item: parse_locant(item[1][0])):
-        parts.append(f"{_pluralize_substituent(label, len(positions))} at {_positions_text(positions)}")
-    for locant, body in sorted(side_chains, key=lambda item: parse_locant(item[0])):
-        parts.append(f"a side chain at position {locant}; this side chain has {body}")
-    return parts
-
-
-def _parent_connection_phrases(
-    mol: Molecule, numbered_path: list[int], locants: dict[int, str], is_ring: bool
-) -> list[str]:
-    if not numbered_path:
-        return []
-    connections: list[str] = []
-    for i in range(len(numbered_path) - 1):
-        u, v = numbered_path[i], numbered_path[i + 1]
-        bond = mol.get_bond(u, v)
-        if bond:
-            connections.append(f"{locants[u]}-{locants[v]} {BOND_WORDS.get(bond.order, bond.order)}")
-    if is_ring and len(numbered_path) > 2:
-        u, v = numbered_path[-1], numbered_path[0]
-        bond = mol.get_bond(u, v)
-        if bond:
-            connections.append(f"{locants[u]}-{locants[v]} {BOND_WORDS.get(bond.order, bond.order)}")
-    return connections
-
-
-# --- prose assembler -----------------------------------------------------
-
-
-def _assemble_description(facts: DescriptionFacts) -> str:
-    sentences: list[str] = []
-    opening = f"The molecule is built around {facts.parent_summary}"
-    if facts.heteroatoms:
-        opening += f", with {_join_human(list(facts.heteroatoms))}"
-    sentences.append(opening + ".")
-
-    if facts.unsaturation:
-        sentences.append(f"Within that parent framework, there is {_join_human(list(facts.unsaturation))}.")
-    elif facts.parent_detail:
-        sentences.append(f"Within that parent framework, {facts.parent_detail}.")
-
-    if facts.substituents:
-        verb = "is" if len(facts.substituents) == 1 else "are"
-        sentences.append(f"Attached to the parent {verb} {_join_human(list(facts.substituents))}.")
-    else:
-        sentences.append("There are no substituents outside the parent framework.")
-
-    if facts.stereochemistry:
-        sentences.append(f"The specified stereochemistry is: {'; '.join(facts.stereochemistry)}.")
-
-    if facts.connectivity:
-        sentences.append(f"For reconstruction, number the parent as follows: {', '.join(facts.connectivity)}.")
-
-    return " ".join(sentences)
-
-
-# --- substituent / branch helpers ----------------------------------------
-
-
-def _short_substituent_label(mol: Molecule, parent_idx: int, neighbor_idx: int, parent_set: set[int]) -> str:
-    label = _simple_substituent_description(mol, parent_idx, neighbor_idx, parent_set)
-    if label:
-        return label
-    try:
-        return name_subgraph(mol, neighbor_idx, parent_set, upstream_atom=parent_idx)
-    except Exception:
-        return mol.atoms[neighbor_idx].symbol
-
-
-def _simple_substituent_description(mol: Molecule, parent_idx: int, neighbor_idx: int, parent_set: set[int]) -> str:
-    atom = mol.atoms[neighbor_idx]
-    bond = mol.get_bond(parent_idx, neighbor_idx)
-    if atom.symbol == "O":
-        externals = [n for n in mol.get_neighbors(neighbor_idx) if n != parent_idx and n not in parent_set]
-        if bond and bond.order == 2:
-            return "oxo group"
-        if not externals and atom.charge == -1:
-            return "oxido group"
-        if not externals:
-            return "hydroxy group"
-    if atom.symbol == "N":
-        externals = [n for n in mol.get_neighbors(neighbor_idx) if n != parent_idx and n not in parent_set]
-        if bond and bond.order == 2:
-            return "imino group"
-        if bond and bond.order == 3:
-            return "nitrilo group"
-        if not externals:
-            return "amino group"
-    if atom.symbol == "S":
-        externals = [n for n in mol.get_neighbors(neighbor_idx) if n != parent_idx and n not in parent_set]
-        if bond and bond.order == 2:
-            return "thioxo group"
-        if not externals:
-            return "sulfanyl group"
-    if atom.symbol in HALO_PREFIXES and mol.degree(neighbor_idx) == 1:
-        return f"{HALO_PREFIXES[atom.symbol]} group"
-    return ""
-
-
-def _branch_component(mol: Molecule, start_idx: int, blocked_atoms: set[int]) -> set[int]:
-    component: set[int] = set()
-    queue: deque[int] = deque([start_idx])
-    while queue:
-        current = queue.popleft()
-        if current in component or current in blocked_atoms:
-            continue
-        component.add(current)
-        for neighbor in mol.get_neighbors(current):
-            if neighbor not in component and neighbor not in blocked_atoms:
-                queue.append(neighbor)
-    return component
-
-
-def _describe_side_chain(mol: Molecule, start_idx: int, blocked_atoms: set[int]) -> str:
-    component = _branch_component(mol, start_idx, blocked_atoms)
-    if not component:
-        return "empty branch"
-
-    simple = _simple_side_chain_summary(mol, start_idx, component, blocked_atoms)
-    if simple:
-        return simple
-
-    local_order = _local_branch_order(mol, start_idx, component)
-    local_locants = {atom_idx: str(i + 1) for i, atom_idx in enumerate(local_order)}
-    carbon_count = sum(1 for idx in component if mol.atoms[idx].is_carbon)
-    hetero_count = len(component) - carbon_count
-
-    atoms = [
-        f"branch atom {local_locants[idx]} is {ELEMENT_WORDS.get(mol.atoms[idx].symbol, mol.atoms[idx].symbol)}"
-        for idx in local_order
-    ]
-    bonds: list[str] = []
-    seen: set[int] = set()
-    for atom_idx in local_order:
-        for neighbor in mol.get_neighbors(atom_idx):
-            if neighbor not in component:
-                continue
-            bond = mol.get_bond(atom_idx, neighbor)
-            if bond and bond.idx not in seen:
-                seen.add(bond.idx)
-                bonds.append(
-                    f"{local_locants[atom_idx]}-{local_locants[neighbor]} {BOND_WORDS.get(bond.order, bond.order)}"
-                )
-
-    count_text = f"{carbon_count} carbon atom{'s' if carbon_count != 1 else ''}"
-    if hetero_count:
-        count_text += f" and {hetero_count} heteroatom{'s' if hetero_count != 1 else ''}"
-    return f"{count_text}; " + "; ".join(atoms) + "; branch connectivity: " + ", ".join(bonds)
-
-
-def _local_branch_order(mol: Molecule, start_idx: int, component: set[int]) -> list[int]:
-    order: list[int] = []
-    queue: deque[int] = deque([start_idx])
-    while queue:
-        current = queue.popleft()
-        if current in order or current not in component:
-            continue
-        order.append(current)
-        for neighbor in sorted(mol.get_neighbors(current)):
-            if neighbor in component and neighbor not in order:
-                queue.append(neighbor)
-    return order
-
-
-def _simple_side_chain_summary(mol: Molecule, start_idx: int, component: set[int], blocked_atoms: set[int]) -> str:
-    """Compact prose for common one-carbon side chains."""
-
-    carbon_atoms = [idx for idx in component if mol.atoms[idx].is_carbon]
-    if len(carbon_atoms) != 1 or carbon_atoms[0] != start_idx:
-        return ""
-    attached = [n for n in mol.get_neighbors(start_idx) if n in component and n != start_idx]
-    if not attached:
-        return "1 carbon atom"
-    hydroxy = [
-        n
-        for n in attached
-        if mol.atoms[n].symbol == "O"
-        and (bond := mol.get_bond(start_idx, n))
-        and bond.order == 1
-        and all(x == start_idx or x in blocked_atoms for x in mol.get_neighbors(n))
-    ]
-    if hydroxy and len(hydroxy) == len(attached):
-        return "1 carbon atom connected to a hydroxy group"
-    return ""
-
-
-# --- formatting ----------------------------------------------------------
-
-
-def _positions_text(locants: list[str]) -> str:
-    ordered = sorted([str(loc) for loc in locants], key=parse_locant)
-    if len(ordered) == 1:
-        return f"position {ordered[0]}"
-    return "positions " + _join_human(ordered)
-
-
-def _join_human(items: list[str]) -> str:
-    if not items:
-        return ""
-    if len(items) == 1:
-        return items[0]
-    if len(items) == 2:
-        return " and ".join(items)
-    return ", ".join(items[:-1]) + f", and {items[-1]}"
-
-
-def _pluralize_substituent(label: str, count: int) -> str:
-    if count == 1:
-        return _indefinite(label)
-    if label.endswith(" group"):
-        return label[:-6] + " groups"
-    return label + "s"
-
-
-def _indefinite(text: str) -> str:
-    if text.startswith(("a ", "an ", "the ")):
-        return text
-    article = "an" if text[0].lower() in "aeiou" else "a"
-    return f"{article} {text}"
-
-
-__all__ = [
-    "Description",
-    "DescriptionFacts",
-    "describe",
-]
+__all__ = ["DescribedComponent", "Description", "describe"]

--- a/src/bluenamer/opsin_verify.py
+++ b/src/bluenamer/opsin_verify.py
@@ -115,7 +115,6 @@ def verify_with_opsin(name: str, smiles: str, standardize_smiles: bool = True) -
         return OpsinCheck(status="skipped_no_java", name=name)
 
     if standardize_smiles:
-
         canonical_original = standardize_mol(smiles)
     else:
         canonical_original = _canonicalize(smiles)
@@ -147,7 +146,9 @@ def verify_with_opsin(name: str, smiles: str, standardize_smiles: bool = True) -
             canonical_original=canonical_original,
             opsin_smiles=opsin_smiles,
             canonical_roundtrip=canonical_roundtrip,
-            error_message= "Failed to standardize SMILES for comparison." if standardize_smiles else "Failed to canonicalize SMILES for comparison.",
+            error_message="Failed to standardize SMILES for comparison."
+            if standardize_smiles
+            else "Failed to canonicalize SMILES for comparison.",
         )
 
     if equivalent_smiles(smiles, opsin_smiles):

--- a/test_opsin_qm9_batch.py
+++ b/test_opsin_qm9_batch.py
@@ -1,15 +1,14 @@
+import multiprocessing as mp
 import os
 import random
-import multiprocessing as mp
 from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
 import py2opsin
 from datasets import load_dataset
-from structure_to_iupac.namer import name_smiles
 from rdkit.Chem import CanonSmiles
+from structure_to_iupac.namer import name_smiles
 from tqdm import tqdm
-
 
 # --- Configuration ---
 N_TEST = 5_000
@@ -51,7 +50,7 @@ def main():
 
     indices = random.sample(range(len(all_smiles)), min(N_TEST, len(all_smiles)))
     dataset = [all_smiles[i] for i in indices]
-    #dataset = all_smiles
+    # dataset = all_smiles
 
     # 2. Parallelize SMILES -> IUPAC
     print("Converting SMILES to IUPAC names...")
@@ -85,10 +84,7 @@ def main():
 
     # 5. Calculate Accuracy
     matches = np.array(
-        [
-            predicted == original and predicted is not None
-            for predicted, original in zip(smiles_strings, original_canon)
-        ]
+        [predicted == original and predicted is not None for predicted, original in zip(smiles_strings, original_canon)]
     )
 
     accuracy = np.mean(matches)

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -1,4 +1,4 @@
-"""Tests for the structure-driven natural-language describer."""
+"""Tests for the natural-language describer added in PR4."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import json
 import subprocess
 import sys
 
-from bluenamer import Description, DescriptionFacts, describe
+from bluenamer import DescribedComponent, Description, describe
 
 
 def test_describe_returns_structured_description():
@@ -14,69 +14,56 @@ def test_describe_returns_structured_description():
     assert isinstance(d, Description)
     assert d.smiles == "CCO"
     assert d.name == "ethanol"
-    assert d.text
-    assert isinstance(d.facts, tuple)
-    assert all(isinstance(f, DescriptionFacts) for f in d.facts)
+    # The summary line names the result.
+    assert "ethanol" in d.summary
+    # Multiple paragraphs render as text.
+    assert "\n\n" in str(d)
+    # rules_hit are extracted.
+    assert d.rules_hit, "expected at least one P-XX rule id"
+    # Components are typed and phase-tagged.
+    assert all(isinstance(c, DescribedComponent) for c in d.components)
+    assert any(c.phase == "parent_selection" for c in d.components)
 
 
-def test_describe_emits_structural_prose():
-    d = describe("CCO")
-    # Structure-driven prose: speaks about the parent and substituents.
-    assert "parent" in d.text
-    assert "hydroxy group" in d.text
-    assert "carbon chain" in d.text
+def test_describe_explains_functional_group_selection():
+    d = describe("CC(=O)Nc1ccccc1")
+    text = str(d)
+    assert "N-phenylacetamide" in text
+    assert "amide" in text
+    # Parent selection is mentioned.
+    assert "parent skeleton" in text
+    # Trace name pieces appear in the prose.
+    assert "Name pieces" in text
 
 
-def test_describe_benzene_speaks_about_carbocycle_and_double_bonds():
+def test_describe_handles_benzene_without_functional_group():
     d = describe("c1ccccc1")
     assert d.name == "benzene"
-    assert "6-membered carbocycle" in d.text
-    assert "double bond between positions" in d.text
-
-
-def test_describe_heterocycle_includes_heteroatom_positions():
-    d = describe("OCC1OC(O)C(O)C(O)C1O")  # tetrahydropyran sugar
-    assert d.name  # the namer should give some non-empty result
-    facts = d.facts[0]
-    assert any("oxygen" in h for h in facts.heteroatoms)
-    assert any("hydroxy" in s for s in facts.substituents)
-
-
-def test_describe_includes_reconstruction_connectivity():
-    d = describe("C1CCCCC1")
-    facts = d.facts[0]
-    # cyclohexane → 6 bonds in the ring, all single
-    assert len(facts.connectivity) == 6
-    assert all("single" in c for c in facts.connectivity)
-
-
-def test_describe_is_deterministic():
-    a = describe("CC(=O)Nc1ccccc1")
-    b = describe("CC(=O)Nc1ccccc1")
-    assert a.text == b.text
-    assert a.facts == b.facts
-
-
-def test_describe_handles_empty_smiles():
-    d = describe("")
-    assert isinstance(d, Description)
-    assert d.text == ""
-    assert d.facts == ()
+    text = str(d)
+    assert "benzene" in text
+    # No principal group → that fact is stated.
+    assert "no nameable principal groups" in text
 
 
 def test_str_of_description_returns_text():
     s = str(describe("CCO"))
     assert isinstance(s, str)
-    assert "carbon chain" in s
+    assert "ethanol" in s
 
 
-def test_to_dict_is_json_serialisable():
-    payload = describe("CCO").to_dict()
-    json.dumps(payload)
-    assert payload["name"] == "ethanol"
-    assert payload["text"]
-    assert isinstance(payload["facts"], list)
-    assert payload["facts"][0]["parent_summary"]
+def test_describe_is_deterministic():
+    a = describe("CC(=O)Nc1ccccc1")
+    b = describe("CC(=O)Nc1ccccc1")
+    assert str(a) == str(b)
+    assert a.rules_hit == b.rules_hit
+
+
+def test_describe_failure_case_still_returns_description():
+    """Even when naming yields no name, describe must not raise."""
+
+    d = describe("")
+    assert isinstance(d, Description)
+    assert "could not be named" in d.summary or d.name == ""
 
 
 def test_cli_describe_subcommand():
@@ -87,8 +74,8 @@ def test_cli_describe_subcommand():
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    assert "carbon chain" in result.stdout
-    assert "hydroxy group" in result.stdout
+    assert "ethanol" in result.stdout
+    assert "RDKit parsed" in result.stdout
 
 
 def test_cli_describe_json():
@@ -102,5 +89,7 @@ def test_cli_describe_json():
     payload = json.loads(result.stdout)
     assert payload["name"] == "ethanol"
     assert payload["smiles"] == "CCO"
-    assert payload["text"]
-    assert isinstance(payload["facts"], list)
+    assert isinstance(payload["paragraphs"], list)
+    assert payload["paragraphs"]
+    assert isinstance(payload["components"], list)
+    assert any(c["phase"] == "parent_selection" for c in payload["components"])

--- a/tests/integration/test_web_app.py
+++ b/tests/integration/test_web_app.py
@@ -62,9 +62,8 @@ def test_describe_endpoint(client):
     assert r.status_code == 200
     body = r.json()
     assert body["name"] == "ethanol"
-    assert "carbon chain" in body["text"]
-    assert isinstance(body["facts"], list)
-    assert body["facts"][0]["parent_summary"]
+    assert isinstance(body["paragraphs"], list)
+    assert body["paragraphs"]
 
 
 def test_name_endpoint_validates_payload(client):


### PR DESCRIPTION
…r branch)"

removing the describer functionality from the main branch, as it is not yet ready for production use. This reverts commit fc7ada93d8c66f9c96e22442a6c7b5998afba7f9.

## Summary by Sourcery

Redesign the `describe` API to produce deterministic, trace-driven explanations of name construction instead of structure-reconstruction prose, updating the public interfaces, CLI, web API, and documentation accordingly.

New Features:
- Expose per-step `DescribedComponent` entries and applied rule IDs (`rules_hit`, `rule_hints`) from the naming trace as part of the description output.

Enhancements:
- Change `Description` to hold multi-paragraph prose with a summary, structured components, and rule metadata instead of fine-grained structural facts.
- Update CLI `describe` behavior to print the new multi-paragraph explanation and treat the absence of a generated name as a failure.
- Adjust the JSON/serialization shape for descriptions (paragraphs, components, rules) and adapt the web API response to the new schema.

Documentation:
- Revise README examples and narrative to describe the new trace-driven description output and data structures.

Tests:
- Rewrite describer integration tests and web-app tests to validate the new description structure, rule metadata, determinism guarantees, and CLI behavior.