### PR TITLE
metadata for sub-chains

### DIFF
--- a/examples/opsin_eval_ZINC22.py
+++ b/examples/opsin_eval_ZINC22.py
@@ -30,7 +30,7 @@ SAMPLE_POOL_MULTIPLIER = 2
 HF_TOKEN = os.environ.get("HF_TOKEN")
 N_PER_SEED = 100_000
 SEEDS = [42, 17, 87, 5, 63]
-OUT_DIR = Path("eval_failures")
+OUT_DIR = Path("eval_failures/zinc22")
 
 NAME_CHUNKSIZE = 10
 OPSIN_BATCH_SIZE = 1000

--- a/examples/opsin_eval_pubchem.py
+++ b/examples/opsin_eval_pubchem.py
@@ -10,14 +10,14 @@ import numpy as np
 import py2opsin
 from datasets import load_dataset
 from tqdm import tqdm
-from utils import standardize_mol
+from bluenamer.utils import standardize_mol
 
 from bluenamer.namer import name_smiles
 
 # --- Configuration ---
 N_PER_SEED = 100_000
 SEEDS = [42, 17, 87, 5, 63]
-OUT_DIR = Path("eval_failures")
+OUT_DIR = Path("eval_failures/pubchem")
 
 NAME_CHUNKSIZE = 10
 OPSIN_BATCH_SIZE = 1000

--- a/examples/test_qm9_opsin_batch.py
+++ b/examples/test_qm9_opsin_batch.py
@@ -160,7 +160,7 @@ def main():
     else:
         smiles_col = ds.column_names[0]
 
-    dataset = list([smiles_col])
+    dataset = ds[smiles_col]
 
     print("Converting SMILES to IUPAC names...")
 

--- a/src/bluenamer/assembly_parts.py
+++ b/src/bluenamer/assembly_parts.py
@@ -32,6 +32,8 @@ class SubstituentItem:
     charge_atom_ids: set[int] = field(default_factory=set)
     emitted_tokens: tuple[NameTokenBinding, ...] = ()
     trace_segments: list[dict] = field(default_factory=list)
+    nested_decisions: list[dict] = field(default_factory=list)
+    substituent_tree: dict | None = None
     spiro: SpiroAssembly | None = None
 
 

--- a/src/bluenamer/component_modifiers.py
+++ b/src/bluenamer/component_modifiers.py
@@ -6,11 +6,11 @@ from .assembly_parts import AssemblyParts, SubstituentItem
 from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
-from .molecule import Molecule
+from .molecule import DecisionTrace, Molecule
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .subgraph_tools import subgraph_component
-from .trace_helpers import add_substituent_trace, bond_ids_within
+from .trace_helpers import add_substituent_trace, bond_ids_within, decision_trace_data
 
 BranchNamer = Callable[..., str]
 
@@ -97,9 +97,13 @@ def add_component_n_substituents(
                 principal_key, len(principal_groups), len(nitrogens), n_idx_local, n_idx_global
             )
             for n_sub in n_substituents:
-                branch_name, branch_trace = _nitrogen_substituent_name(mol, single_n, n_sub, sub_exclude, branch_namer)
+                branch_decisions = DecisionTrace()
+                branch_name, branch_trace, branch_tree = _nitrogen_substituent_name(
+                    mol, single_n, n_sub, sub_exclude, branch_namer, branch_decisions
+                )
                 if branch_name:
                     branch_atoms = subgraph_component(mol, n_sub, sub_exclude | {single_n})
+                    nested_decisions = decision_trace_data(branch_decisions)
                     if _use_hydrazone_suffix_modifier(parts, principal_key):
                         parts.principal_suffix_modifiers.append(
                             SubstituentItem(
@@ -109,6 +113,8 @@ def add_component_n_substituents(
                                 bond_ids=bond_ids_within(mol, branch_atoms | {single_n}),
                                 charge_atom_ids=_charged_atoms(mol, branch_atoms),
                                 trace_segments=branch_trace,
+                                nested_decisions=nested_decisions,
+                                substituent_tree=branch_tree,
                             )
                         )
                         continue
@@ -120,6 +126,8 @@ def add_component_n_substituents(
                         bond_ids_within(mol, branch_atoms | {single_n}),
                         _charged_atoms(mol, branch_atoms),
                         branch_trace,
+                        nested_decisions,
+                        substituent_tree=branch_tree,
                     )
             n_idx_global += 1
 
@@ -136,7 +144,8 @@ def _nitrogen_substituent_name(
     substituent: int,
     sub_exclude: set[int],
     branch_namer: BranchNamer,
-) -> tuple[str, list]:
+    decision_trace: DecisionTrace | None = None,
+) -> tuple[str, list, dict | None]:
     """Render graph-bound N-substituents on principal nitrogen groups."""
 
     bond = mol.get_bond(nitrogen, substituent)
@@ -146,8 +155,16 @@ def _nitrogen_substituent_name(
         and mol.atoms[substituent].symbol == "N"
         and not [n for n in mol.get_neighbors(substituent) if n != nitrogen and mol.atoms[n].symbol != "H"]
     ):
-        return "imino", []
-    return branch_namer(mol, substituent, sub_exclude | {nitrogen}, upstream_atom=nitrogen, return_trace=True)
+        return "imino", [], None
+    return branch_namer(
+        mol,
+        substituent,
+        sub_exclude | {nitrogen},
+        upstream_atom=nitrogen,
+        return_trace=True,
+        return_tree=True,
+        decision_trace=decision_trace,
+    )
 
 
 def _use_hydrazone_suffix_modifier(parts: AssemblyParts, principal_key: str | None) -> bool:

--- a/src/bluenamer/component_modifiers.py
+++ b/src/bluenamer/component_modifiers.py
@@ -1,6 +1,6 @@
 """Data-driven component modifiers attached after parent numbering."""
 
-from collections.abc import Callable
+from typing import Literal, Protocol, overload
 
 from .assembly_parts import AssemblyParts, SubstituentItem
 from .formatting import strip_outer_parentheses
@@ -12,7 +12,61 @@ from .perception import PerceivedGroup
 from .subgraph_tools import subgraph_component
 from .trace_helpers import add_substituent_trace, bond_ids_within, decision_trace_data
 
-BranchNamer = Callable[..., str]
+
+class BranchNamer(Protocol):
+    """Recursive branch namer with simple and traced/tree return modes."""
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> str: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[True],
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict]]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[True],
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict], dict | None]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, dict | None]: ...
 
 
 def add_component_front_modifiers(

--- a/src/bluenamer/component_namer.py
+++ b/src/bluenamer/component_namer.py
@@ -593,17 +593,21 @@ def name_component(
             "name_rewrite_history": parts.name_rewrite_history,
         },
     )
-    tree = assembly_substituent_tree(
-        parts,
-        name=name,
-        atom_ids=state.component_atoms,
-        bond_ids=bond_ids_within(mol, state.component_atoms),
-    )
-    tree["kind"] = "component"
+    trace_segments = assembly_trace_segments(parts) if return_trace or return_tree else []
+    tree = None
+    if return_tree:
+        tree = assembly_substituent_tree(
+            parts,
+            name=name,
+            atom_ids=state.component_atoms,
+            bond_ids=bond_ids_within(mol, state.component_atoms),
+            trace_segments=trace_segments,
+        )
+        tree["kind"] = "component"
     if return_trace and return_tree:
-        return name, assembly_trace_segments(parts), tree
+        return name, trace_segments, tree
     if return_trace:
-        return name, assembly_trace_segments(parts)
+        return name, trace_segments
     if return_tree:
         return name, tree
     return name

--- a/src/bluenamer/component_namer.py
+++ b/src/bluenamer/component_namer.py
@@ -44,8 +44,10 @@ from .subgraph_tools import (
 from .substituent_tokens import graph_bound_substituent_tokens
 from .trace_helpers import (
     add_substituent_trace,
+    assembly_substituent_tree,
     assembly_trace_segments,
     bond_ids_within,
+    decision_trace_data,
     functional_group_trace_data,
     trace_decision,
 )
@@ -108,8 +110,15 @@ def collect_component_branch_substituents(
 
         for n_idx in n_subs:
             if n_idx not in main_set and n_idx not in principal_involved_atom_ids and n_idx not in handled_prefix_atoms:
-                branch_name, branch_trace = name_subgraph(
-                    mol, n_idx, sub_exclude | main_set, upstream_atom=c_idx, return_trace=True
+                branch_decisions = DecisionTrace()
+                branch_name, branch_trace, branch_tree = name_subgraph(
+                    mol,
+                    n_idx,
+                    sub_exclude | main_set,
+                    upstream_atom=c_idx,
+                    return_trace=True,
+                    return_tree=True,
+                    decision_trace=branch_decisions,
                 )
                 if branch_name:
                     branch_exclude = sub_exclude | main_set
@@ -131,6 +140,8 @@ def collect_component_branch_substituents(
                                 name_subgraph,
                             ),
                             trace_segments=branch_trace,
+                            nested_decisions=decision_trace_data(branch_decisions),
+                            substituent_tree=branch_tree,
                         )
                     )
 
@@ -152,7 +163,9 @@ def add_component_substituents(
                     item.bond_ids,
                     item.charge_atom_ids,
                     item.trace_segments,
+                    item.nested_decisions,
                     item.emitted_tokens,
+                    substituent_tree=item.substituent_tree,
                     spiro=item.spiro,
                 )
 
@@ -202,6 +215,7 @@ def name_component(
     *,
     is_substituent: bool = False,
     return_trace: bool = False,
+    return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
     name_subgraph: SubgraphNamer,
     name_spiro_subgraph: SpiroSubgraphNamer,
@@ -231,8 +245,12 @@ def name_component(
                 "name_rewrite_history": rewrite_history,
             },
         )
+        if return_trace and return_tree:
+            return name, [], _shortcut_tree(name, component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
+        if return_tree:
+            return name, _shortcut_tree(name, component_atoms, bindings, token_spans)
         return name
 
     def name_component_again(next_mol: Molecule, next_atoms: set[int], is_substituent: bool = False):
@@ -268,8 +286,12 @@ def name_component(
                 "name_rewrite_history": rewrite_history,
             },
         )
+        if return_trace and return_tree:
+            return name, [], _shortcut_tree(name, component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
+        if return_tree:
+            return name, _shortcut_tree(name, component_atoms, bindings, token_spans)
         return name
 
     state = ComponentNamingState(component_atoms=set(component_atoms), is_substituent=is_substituent)
@@ -317,8 +339,12 @@ def name_component(
                 "name_rewrite_history": rewrite_history,
             },
         )
+        if return_trace and return_tree:
+            return name, [], _shortcut_tree(name, state.component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
+        if return_tree:
+            return name, _shortcut_tree(name, state.component_atoms, bindings, token_spans)
         return name
 
     state.exclude_atoms = set(mol.atoms.keys()) - state.component_atoms
@@ -510,6 +536,37 @@ def name_component(
             "name_rewrite_history": parts.name_rewrite_history,
         },
     )
+    tree = assembly_substituent_tree(
+        parts,
+        name=name,
+        atom_ids=state.component_atoms,
+        bond_ids=bond_ids_within(mol, state.component_atoms),
+    )
+    tree["kind"] = "component"
+    if return_trace and return_tree:
+        return name, assembly_trace_segments(parts), tree
     if return_trace:
         return name, assembly_trace_segments(parts)
+    if return_tree:
+        return name, tree
     return name
+
+
+def _shortcut_tree(name: str, component_atoms: set[int], bindings: list[dict], token_spans: list[dict]) -> dict:
+    """Return a minimal component tree for shortcut component names."""
+
+    return {
+        "kind": "component",
+        "name": name,
+        "atoms": sorted(component_atoms),
+        "bonds": [],
+        "parent": None,
+        "principal_group": None,
+        "substituents": [],
+        "replacement_prefixes": [],
+        "unsaturations": [],
+        "trace_segments": [],
+        "nested_decisions": [],
+        "name_atom_bindings": bindings,
+        "name_token_spans": token_spans,
+    }

--- a/src/bluenamer/component_namer.py
+++ b/src/bluenamer/component_namer.py
@@ -1,6 +1,7 @@
 """Connected-component naming pipeline."""
 
 from collections.abc import Callable
+from typing import Literal, Protocol, overload
 
 from .assembly_parts import AssemblyParts, NameAtomBinding, SubstituentItem
 from .chains import find_all_carbon_paths, find_ring_systems, get_cyclic_atoms
@@ -52,7 +53,63 @@ from .trace_helpers import (
     trace_decision,
 )
 
-SubgraphNamer = Callable[..., str]
+
+class SubgraphNamer(Protocol):
+    """Recursive subgraph namer with simple and traced/tree return modes."""
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> str: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[True],
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict]]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[True],
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict], dict | None]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        *,
+        upstream_atom: int | None = None,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, dict | None]: ...
+
+
 SpiroSubgraphNamer = Callable[[Molecule, int, set[int]], SpiroAssembly]
 ParentAssembler = Callable[..., str]
 

--- a/src/bluenamer/engine.py
+++ b/src/bluenamer/engine.py
@@ -83,6 +83,7 @@ class NamingResult:
     smiles: str = ""
     error: str | None = None
     trace_segments: list[dict] = field(default_factory=list)
+    substituent_tree: list[dict] = field(default_factory=list)
     decisions: list = field(default_factory=list)
     analysis: NameAnalysis | None = None
     rules_hit: tuple[str, ...] = ()
@@ -123,6 +124,7 @@ class NamingResult:
         }
         if include_trace:
             payload["trace_segments"] = self.trace_segments
+            payload["substituent_tree"] = self.substituent_tree
         if self.opsin_check is not None:
             payload["opsin_check"] = self.opsin_check.to_dict()
         return payload
@@ -163,7 +165,7 @@ class NamingEngine:
 
         result = self.run(NamingRequest(smiles=smiles, include_trace=True))
         if result.analysis is None:
-            return NameAnalysis(result.name, result.trace_segments, result.decisions)
+            return NameAnalysis(result.name, result.trace_segments, result.decisions, result.substituent_tree)
         return result.analysis
 
     def analyze_smiles(self, smiles: str) -> NameAnalysis:
@@ -187,6 +189,7 @@ class NamingEngine:
                     name=analysis.name,
                     smiles=request.smiles,
                     trace_segments=analysis.trace_segments,
+                    substituent_tree=analysis.substituent_tree,
                     decisions=analysis.decisions,
                     analysis=analysis,
                     rules_hit=rules,
@@ -279,32 +282,37 @@ class NamingEngine:
 
         named_components = []
         for component in components:
-            component_name, trace = self._name_component(
+            component_name, trace, tree = self._name_component(
                 mol,
                 component,
                 return_trace=True,
+                return_tree=True,
                 decision_trace=decisions,
             )
             if component_name:
-                named_components.append((component_name, trace))
+                named_components.append((component_name, trace, tree))
 
         named_components.sort(key=lambda item: self._component_sort_key(item[0]))
-        final_name = " ".join(name for name, _ in named_components)
+        final_name = " ".join(name for name, _, _ in named_components)
         trace_segments = []
-        for _, trace in named_components:
+        substituent_tree = []
+        for _, trace, tree in named_components:
             trace_segments.extend(trace)
+            if tree:
+                substituent_tree.append(tree)
         trace_decision(
             decisions,
             TracePhase.ASSEMBLY,
             "assembled final molecule name",
             "Named components are sorted with supported salt metals first, then joined.",
             atoms=set(mol.atoms.keys()),
-            data={"name": final_name, "components": [name for name, _ in named_components]},
+            data={"name": final_name, "components": [name for name, _, _ in named_components]},
         )
         return NameAnalysis(
             name=final_name,
             trace_segments=trace_segments,
             decisions=decisions.steps,
+            substituent_tree=substituent_tree,
             operations=infer_operations(decisions.steps, trace_segments),
         )
 

--- a/src/bluenamer/molecule.py
+++ b/src/bluenamer/molecule.py
@@ -160,6 +160,7 @@ class NameAnalysis:
     name: str
     trace_segments: list[dict]
     decisions: list[TraceStep]
+    substituent_tree: list[dict] = field(default_factory=list)
     operations: list[NomenclatureOperation] = field(default_factory=list)
 
 

--- a/src/bluenamer/namer.py
+++ b/src/bluenamer/namer.py
@@ -44,13 +44,13 @@ from .substituent_tokens import graph_bound_substituent_tokens
 from .trace_helpers import (
     add_substituent_trace as _add_substituent_trace,
 )
+from .trace_helpers import assembly_substituent_tree as _assembly_substituent_tree
 from .trace_helpers import (
     assembly_trace_segments as _assembly_trace_segments,
 )
 from .trace_helpers import (
     bond_ids_within as _bond_ids_within,
 )
-from .trace_helpers import assembly_substituent_tree as _assembly_substituent_tree
 from .trace_helpers import decision_trace_data, trace_decision
 
 

--- a/src/bluenamer/namer.py
+++ b/src/bluenamer/namer.py
@@ -1236,6 +1236,7 @@ def name_subgraph(
     )
 
     name = _assemble_parent_name(mol, parts, numbered_path, get_loc, finalize_subgraph=True)
+    trace_segments = _assembly_trace_segments(parts) if return_trace or return_tree else []
     trace_decision(
         decision_trace,
         TracePhase.ASSEMBLY,
@@ -1245,11 +1246,10 @@ def name_subgraph(
         bonds=_bond_ids_within(mol, component),
         data={
             "name": name,
-            "trace_segment_count": len(_assembly_trace_segments(parts)) if return_trace else 0,
+            "trace_segment_count": len(trace_segments),
         },
     )
     if return_trace:
-        trace_segments = _assembly_trace_segments(parts)
         if return_tree:
             return (
                 name,
@@ -1260,6 +1260,7 @@ def name_subgraph(
                     atom_ids=component,
                     bond_ids=_bond_ids_within(mol, component),
                     decisions=decision_trace_data(decision_trace),
+                    trace_segments=trace_segments,
                 ),
             )
         return name, trace_segments
@@ -1272,6 +1273,7 @@ def name_subgraph(
                 atom_ids=component,
                 bond_ids=_bond_ids_within(mol, component),
                 decisions=decision_trace_data(decision_trace),
+                trace_segments=trace_segments,
             ),
         )
     return name

--- a/src/bluenamer/namer.py
+++ b/src/bluenamer/namer.py
@@ -1,6 +1,7 @@
 # bluenamer/api.py
 
 import re
+from dataclasses import dataclass, field
 
 from .assembler import assemble_name_raw, post_process_name
 from .assembly_parts import AssemblyParts, SubstituentItem
@@ -12,7 +13,7 @@ from .formatting import format_counted_prefixes, format_multiplier, strip_outer_
 from .group_atom_roles import amide_nitrogen
 from .heteroatom_subgraphs import name_heteroatom_subgraph
 from .ionic_naming import apply_anionic_parent_names, apply_cationic_imino_names, apply_cationic_imino_parent_prefixes
-from .molecule import DecisionTrace, Molecule, NameAnalysis
+from .molecule import DecisionTrace, Molecule, NameAnalysis, TracePhase
 from .name_assembly import NameAssemblyResult, token_span_trace_data
 from .naming_context import NamingIntent
 from .nomenclature import RULES
@@ -49,9 +50,44 @@ from .trace_helpers import (
 from .trace_helpers import (
     bond_ids_within as _bond_ids_within,
 )
+from .trace_helpers import assembly_substituent_tree as _assembly_substituent_tree
+from .trace_helpers import decision_trace_data, trace_decision
 
 
-def _direct_subgraph_prefix(mol: Molecule, start_idx: int, component: set[int]) -> str:
+@dataclass
+class DirectSubgraphPrefix:
+    """Structured result for a direct functional-prefix subgraph."""
+
+    name: str
+    group_key: str = ""
+    attachment_atom: int | None = None
+    group_atoms: set[int] = field(default_factory=set)
+    core_atoms: set[int] = field(default_factory=set)
+    group_bonds: set[int] = field(default_factory=set)
+    ligand_trees: list[dict] = field(default_factory=list)
+    ligand_trace_segments: list[dict] = field(default_factory=list)
+    ligand_decisions: list[dict] = field(default_factory=list)
+    source: str = "direct_subgraph_prefix"
+
+    def __bool__(self) -> bool:
+        return bool(self.name)
+
+    def trace_data(self) -> dict:
+        """Return JSON-safe metadata for decision traces and tree nodes."""
+
+        return {
+            "name": self.name,
+            "group_key": self.group_key,
+            "attachment_atom": self.attachment_atom,
+            "group_atoms": sorted(self.group_atoms),
+            "core_atoms": sorted(self.core_atoms),
+            "group_bonds": sorted(self.group_bonds),
+            "ligand_count": len(self.ligand_trees),
+            "source": self.source,
+        }
+
+
+def _direct_subgraph_prefix(mol: Molecule, start_idx: int, component: set[int]) -> DirectSubgraphPrefix | None:
     """Return a direct functional-group prefix when the subgraph is one group.
 
     Blue Book references: P-63 through P-67 for direct detachable prefixes such
@@ -69,7 +105,7 @@ def _direct_subgraph_prefix(mol: Molecule, start_idx: int, component: set[int]) 
             and all(other == start_idx for other in mol.get_neighbors(neighbor))
         ]
         if len(terminal_sulfurs) == 1 and component == {start_idx, terminal_sulfurs[0]}:
-            return "thioformyl"
+            return DirectSubgraphPrefix(name="thioformyl", core_atoms=set(component), source="structural_direct_prefix")
 
         triple_phosphorus = [
             neighbor
@@ -92,9 +128,17 @@ def _direct_subgraph_prefix(mol: Molecule, start_idx: int, component: set[int]) 
                 and all(other == phosphorus for other in mol.get_neighbors(neighbor))
             ]
             if component == {start_idx, phosphorus}:
-                return "phosphanylidynemethyl"
+                return DirectSubgraphPrefix(
+                    name="phosphanylidynemethyl",
+                    core_atoms=set(component),
+                    source="structural_direct_prefix",
+                )
             if len(terminal_oxo) == 1 and component == {start_idx, phosphorus, terminal_oxo[0]}:
-                return "oxophosphanylidynemethyl"
+                return DirectSubgraphPrefix(
+                    name="oxophosphanylidynemethyl",
+                    core_atoms=set(component),
+                    source="structural_direct_prefix",
+                )
 
     for group in perceive_groups(mol):
         if start_idx in group.atoms_involved and group.atoms_involved.issubset(component):
@@ -104,16 +148,25 @@ def _direct_subgraph_prefix(mol: Molecule, start_idx: int, component: set[int]) 
                     return substituted
             prefix = RULES.functional_groups.direct_subgraph_prefix_for(group.key)
             if prefix:
-                return prefix
-    return ""
+                return DirectSubgraphPrefix(
+                    name=prefix,
+                    group_key=group.key,
+                    attachment_atom=group.attachment_carbon,
+                    group_atoms=set(group.atom_ids),
+                    core_atoms=set(group.atoms_involved),
+                    group_bonds=set(group.bond_ids),
+                )
+    return None
 
 
-def _direct_amide_subgraph_prefix(mol: Molecule, group: PerceivedGroup, component: set[int]) -> str:
+def _direct_amide_subgraph_prefix(
+    mol: Molecule, group: PerceivedGroup, component: set[int]
+) -> DirectSubgraphPrefix | None:
     """Return substituted carbamoyl/carbamothioyl for direct amide subgraphs."""
 
     amide_n = amide_nitrogen(mol, group)
     if amide_n is None:
-        return ""
+        return None
     n_substituents = [
         n
         for n in mol.get_neighbors(amide_n)
@@ -121,24 +174,51 @@ def _direct_amide_subgraph_prefix(mol: Molecule, group: PerceivedGroup, componen
     ]
     base = RULES.functional_groups.prefix_for(group.key) or ""
     if not base:
-        return ""
+        return None
     if not n_substituents:
-        return base
+        return DirectSubgraphPrefix(
+            name=base,
+            group_key=group.key,
+            attachment_atom=group.attachment_carbon,
+            group_atoms=set(group.atom_ids),
+            core_atoms=set(group.atoms_involved),
+            group_bonds=set(group.bond_ids),
+        )
     outside_component = set(mol.atoms.keys()) - component
     branch_names = []
+    ligand_trees = []
+    ligand_trace_segments = []
+    ligand_decisions = []
     for n_sub in n_substituents:
-        branch = name_subgraph(
+        branch_decisions = DecisionTrace()
+        branch, branch_trace, branch_tree = name_subgraph(
             mol,
             n_sub,
             outside_component | set(group.atoms_involved) | {amide_n},
             upstream_atom=amide_n,
+            return_trace=True,
+            return_tree=True,
+            decision_trace=branch_decisions,
         )
         branch = strip_outer_parentheses(branch)
         if branch:
             branch_names.append(branch)
-    if not branch_names:
-        return base
-    return f"({format_counted_prefixes(branch_names)}{base})"
+            ligand_trace_segments.extend(branch_trace)
+            ligand_decisions.extend(decision_trace_data(branch_decisions))
+            if branch_tree:
+                ligand_trees.append(branch_tree)
+    name = base if not branch_names else f"({format_counted_prefixes(branch_names)}{base})"
+    return DirectSubgraphPrefix(
+        name=name,
+        group_key=group.key,
+        attachment_atom=group.attachment_carbon,
+        group_atoms=set(group.atom_ids),
+        core_atoms=set(group.atoms_involved),
+        group_bonds=set(group.bond_ids),
+        ligand_trees=ligand_trees,
+        ligand_trace_segments=ligand_trace_segments,
+        ligand_decisions=ligand_decisions,
+    )
 
 
 def _find_acyclic_subgraph_paths(
@@ -789,8 +869,15 @@ def _collect_subgraph_substituents(
 
         for n_idx in n_subs:
             if n_idx not in main_set and n_idx not in sub_handled_atoms and n_idx not in sub_exclude:
-                branch_name, branch_trace = name_subgraph(
-                    mol, n_idx, sub_exclude | main_set, upstream_atom=c_idx, return_trace=True
+                branch_decisions = DecisionTrace()
+                branch_name, branch_trace, branch_tree = name_subgraph(
+                    mol,
+                    n_idx,
+                    sub_exclude | main_set,
+                    upstream_atom=c_idx,
+                    return_trace=True,
+                    return_tree=True,
+                    decision_trace=branch_decisions,
                 )
                 if branch_name:
                     branch_exclude = sub_exclude | main_set
@@ -813,6 +900,8 @@ def _collect_subgraph_substituents(
                                 name_subgraph,
                             ),
                             trace_segments=branch_trace,
+                            nested_decisions=decision_trace_data(branch_decisions),
+                            substituent_tree=branch_tree,
                         )
                     )
 
@@ -837,7 +926,9 @@ def _add_subgraph_substituents(parts: AssemblyParts, subst_mapping: dict[int, li
                 item.bond_ids,
                 item.charge_atom_ids,
                 item.trace_segments,
+                item.nested_decisions,
                 item.emitted_tokens,
+                substituent_tree=item.substituent_tree,
                 spiro=item.spiro,
             )
 
@@ -990,6 +1081,8 @@ def name_subgraph(
     exclude_atoms: set[int],
     upstream_atom: int = None,
     return_trace: bool = False,
+    return_tree: bool = False,
+    decision_trace: DecisionTrace | None = None,
 ):
     """Name a recursive substituent subgraph attached to the current parent.
 
@@ -1000,21 +1093,97 @@ def name_subgraph(
 
     start_atom = mol.atoms[start_idx]
     cyclic_atoms_global = get_cyclic_atoms(mol, exclude_atoms)
+    component = _subgraph_component(mol, start_idx, exclude_atoms)
+    trace_decision(
+        decision_trace,
+        TracePhase.COMPONENT,
+        "selected substituent subgraph",
+        "Recursive branch naming starts from the atom attached to the parent and stops at the parent boundary.",
+        atoms=component,
+        bonds=_bond_ids_within(mol, component),
+        data={
+            "start_atom": start_idx,
+            "upstream_atom": upstream_atom,
+            "excluded_atom_count": len(exclude_atoms),
+        },
+    )
 
     if not start_atom.is_carbon and start_idx not in cyclic_atoms_global:
         name = name_heteroatom_subgraph(mol, start_idx, exclude_atoms, upstream_atom, name_subgraph)
         if name is not None:
-            return (name, []) if return_trace else name
+            trace_decision(
+                decision_trace,
+                TracePhase.ASSEMBLY,
+                "assembled heteroatom substituent shortcut",
+                "A terminal non-carbon branch was rendered by the heteroatom-subgraph renderer.",
+                atoms=component,
+                bonds=_bond_ids_within(mol, component),
+                data={"name": name},
+            )
+            tree = _shortcut_substituent_tree(name, component, mol, decision_trace)
+            if return_trace and return_tree:
+                return name, [], tree
+            if return_trace:
+                return name, []
+            if return_tree:
+                return name, tree
+            return name
 
-    component = _subgraph_component(mol, start_idx, exclude_atoms)
     direct_prefix = _direct_subgraph_prefix(mol, start_idx, component)
     if direct_prefix:
-        return (direct_prefix, []) if return_trace else direct_prefix
+        direct_prefix_name = direct_prefix.name
+        trace_decision(
+            decision_trace,
+            TracePhase.ASSEMBLY,
+            "assembled direct substituent prefix",
+            "The complete recursive component matches a direct functional-prefix role.",
+            atoms=component,
+            bonds=_bond_ids_within(mol, component),
+            data=direct_prefix.trace_data(),
+        )
+        tree = _shortcut_substituent_tree(direct_prefix_name, component, mol, decision_trace, direct_prefix)
+        if return_trace and return_tree:
+            return direct_prefix_name, [], tree
+        if return_trace:
+            return direct_prefix_name, []
+        if return_tree:
+            return direct_prefix_name, tree
+        return direct_prefix_name
 
     sub_exclude = set(mol.atoms.keys()) - component
     parent_selection = _select_subgraph_parent(mol, start_idx, component, sub_exclude)
     if parent_selection is None:
-        return ("", []) if return_trace else ""
+        trace_decision(
+            decision_trace,
+            TracePhase.PARENT_SELECTION,
+            "failed substituent parent selection",
+            "No chain or ring parent could be selected inside the recursive component.",
+            atoms=component,
+            bonds=_bond_ids_within(mol, component),
+        )
+        if return_trace and return_tree:
+            return "", [], None
+        if return_trace:
+            return "", []
+        if return_tree:
+            return "", None
+        return ""
+    trace_decision(
+        decision_trace,
+        TracePhase.PARENT_SELECTION,
+        "selected substituent parent skeleton",
+        "The recursive branch uses the same parent-candidate ranking as ordinary components, scoped to the branch graph.",
+        atoms=set(parent_selection.primary_path),
+        bonds=_bond_ids_within(mol, set(parent_selection.primary_path)),
+        data={
+            "primary_path": list(parent_selection.primary_path),
+            "is_ring": parent_selection.is_ring,
+            "is_bicycle": parent_selection.is_bicycle,
+            "is_spiro": parent_selection.is_spiro,
+            "is_polycycle": parent_selection.is_polycycle,
+            "fixed_start_required": parent_selection.fixed_start_required,
+        },
+    )
 
     retained_name_val, locant_maps = resolve_retained_parent(
         mol,
@@ -1040,6 +1209,19 @@ def name_subgraph(
     numbered_path = parent_plan.numbered_path
     get_loc = parent_plan.get_loc
     parts = parent_plan.parts
+    trace_decision(
+        decision_trace,
+        TracePhase.NUMBERING,
+        "selected substituent numbering",
+        "The branch parent numbering was selected before replacement, unsaturation, suffix, and substituent locants were emitted.",
+        atoms=set(numbered_path),
+        bonds=_bond_ids_within(mol, set(numbered_path)),
+        data={
+            "numbered_path": list(numbered_path),
+            "atom_to_locant": {atom_idx: get_loc(atom_idx) for atom_idx in numbered_path},
+            "retained_name": retained_name_val,
+        },
+    )
     _emit_bond_stereo(mol, parts, numbered_path, get_loc, sub_exclude, upstream_atom)
     _add_indicated_hydrogens(mol, parts, numbered_path, get_loc)
     _add_subgraph_substituents(parts, subst_mapping, get_loc)
@@ -1054,9 +1236,88 @@ def name_subgraph(
     )
 
     name = _assemble_parent_name(mol, parts, numbered_path, get_loc, finalize_subgraph=True)
+    trace_decision(
+        decision_trace,
+        TracePhase.ASSEMBLY,
+        "assembled substituent name",
+        "The scoped branch assembly was rendered as a substituent name.",
+        atoms=component,
+        bonds=_bond_ids_within(mol, component),
+        data={
+            "name": name,
+            "trace_segment_count": len(_assembly_trace_segments(parts)) if return_trace else 0,
+        },
+    )
     if return_trace:
-        return name, _assembly_trace_segments(parts)
+        trace_segments = _assembly_trace_segments(parts)
+        if return_tree:
+            return (
+                name,
+                trace_segments,
+                _assembly_substituent_tree(
+                    parts,
+                    name=name,
+                    atom_ids=component,
+                    bond_ids=_bond_ids_within(mol, component),
+                    decisions=decision_trace_data(decision_trace),
+                ),
+            )
+        return name, trace_segments
+    if return_tree:
+        return (
+            name,
+            _assembly_substituent_tree(
+                parts,
+                name=name,
+                atom_ids=component,
+                bond_ids=_bond_ids_within(mol, component),
+                decisions=decision_trace_data(decision_trace),
+            ),
+        )
     return name
+
+
+def _shortcut_substituent_tree(
+    name: str,
+    component: set[int],
+    mol: Molecule,
+    decision_trace: DecisionTrace | None,
+    direct_prefix: DirectSubgraphPrefix | None = None,
+) -> dict:
+    """Return a minimal recursive tree node for shortcut substituent names."""
+
+    node = {
+        "kind": "substituent",
+        "name": name,
+        "atoms": sorted(component),
+        "bonds": sorted(_bond_ids_within(mol, component)),
+        "parent": None,
+        "principal_group": None,
+        "substituents": [],
+        "replacement_prefixes": [],
+        "unsaturations": [],
+        "trace_segments": [],
+        "nested_decisions": decision_trace_data(decision_trace),
+    }
+    if direct_prefix is not None:
+        node["functional_prefix"] = {
+            "kind": "functional_prefix",
+            "name": direct_prefix.name,
+            "group_key": direct_prefix.group_key,
+            "attachment_atom": direct_prefix.attachment_atom,
+            "group_atoms": sorted(direct_prefix.group_atoms),
+            "core_atoms": sorted(direct_prefix.core_atoms),
+            "group_bonds": sorted(direct_prefix.group_bonds),
+            "source": direct_prefix.source,
+            "ligands": list(direct_prefix.ligand_trees),
+            "ligand_trace_segments": list(direct_prefix.ligand_trace_segments),
+            "ligand_decisions": list(direct_prefix.ligand_decisions),
+        }
+        if direct_prefix.ligand_trees:
+            node["substituents"] = list(direct_prefix.ligand_trees)
+        if direct_prefix.ligand_trace_segments:
+            node["trace_segments"] = list(direct_prefix.ligand_trace_segments)
+    return node
 
 
 def name_component(
@@ -1064,6 +1325,7 @@ def name_component(
     component_atoms: set[int],
     is_substituent: bool = False,
     return_trace: bool = False,
+    return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
 ):
     """Name one connected component or recursive component of a molecule."""
@@ -1073,6 +1335,7 @@ def name_component(
         component_atoms,
         is_substituent=is_substituent,
         return_trace=return_trace,
+        return_tree=return_tree,
         decision_trace=decision_trace,
         name_subgraph=name_subgraph,
         name_spiro_subgraph=_spiro_subgraph_assembly,

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -156,7 +156,7 @@ from bluenamer.spiro_assembly import SpiroAssembly
 from bluenamer.stereo_audit import audit_stereochemistry
 from bluenamer.substituent_tokens import graph_bound_substituent_tokens
 from bluenamer.suffix_stack import SuffixStack
-from bluenamer.trace_helpers import add_substituent_trace
+from bluenamer.trace_helpers import add_substituent_trace, assembly_trace_segments
 from bluenamer.von_baeyer import _classify_secondary_bridges, find_von_baeyer_candidates
 
 
@@ -262,6 +262,32 @@ def test_add_substituent_trace_preserves_emitted_tokens_into_bindings():
     assert substituent_binding.emitted_tokens[0].text == "1"
     assert substituent_binding.emitted_tokens[0].token_kind == "locant"
     assert substituent_binding.emitted_tokens[1:] == emitted_tokens
+
+
+def test_add_substituent_trace_preserves_nested_decisions_into_segments():
+    parts = AssemblyParts(parent_length=1, parent_atom_ids={0})
+    nested_decisions = [
+        {
+            "phase": "parent_selection",
+            "decision": "selected substituent parent skeleton",
+            "reason": "test",
+            "atoms": [1, 2],
+            "bonds": [1],
+            "data": {"primary_path": [1, 2]},
+        }
+    ]
+
+    add_substituent_trace(
+        parts,
+        "ethyl",
+        "1",
+        atom_ids={1, 2},
+        bond_ids={1},
+        nested_decisions=nested_decisions,
+    )
+
+    assert parts.substituents[0].nested_decisions == nested_decisions
+    assert assembly_trace_segments(parts)[0]["nested_decisions"] == nested_decisions
 
 
 def test_principal_suffix_tokens_are_emitted_from_functional_group_renderer():
@@ -3159,6 +3185,23 @@ def test_analyze_smiles_exposes_decision_trace():
     assert TracePhase.PARENT_SELECTION in phases
     assert TracePhase.NUMBERING in phases
     assert TracePhase.ASSEMBLY in phases
+
+
+def test_recursive_substituent_trace_segments_include_nested_decisions():
+    analysis = analyze_smiles("CCCCC(c1ccccc1)C(=O)O")
+
+    nested_segments = [segment for segment in analysis.trace_segments if segment.get("nested_decisions")]
+    nested_decisions = [
+        decision
+        for segment in nested_segments
+        for decision in segment["nested_decisions"]
+    ]
+
+    assert nested_segments
+    assert any(decision["decision"] == "selected substituent subgraph" for decision in nested_decisions)
+    assert any(decision["decision"] == "selected substituent parent skeleton" for decision in nested_decisions)
+    assert any(decision["decision"] == "selected substituent numbering" for decision in nested_decisions)
+    assert any(decision["decision"] == "assembled substituent name" for decision in nested_decisions)
 
 
 def test_parent_selection_has_named_shape():

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -3191,11 +3191,7 @@ def test_recursive_substituent_trace_segments_include_nested_decisions():
     analysis = analyze_smiles("CCCCC(c1ccccc1)C(=O)O")
 
     nested_segments = [segment for segment in analysis.trace_segments if segment.get("nested_decisions")]
-    nested_decisions = [
-        decision
-        for segment in nested_segments
-        for decision in segment["nested_decisions"]
-    ]
+    nested_decisions = [decision for segment in nested_segments for decision in segment["nested_decisions"]]
 
     assert nested_segments
     assert any(decision["decision"] == "selected substituent subgraph" for decision in nested_decisions)

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -290,6 +290,29 @@ def test_add_substituent_trace_preserves_nested_decisions_into_segments():
     assert assembly_trace_segments(parts)[0]["nested_decisions"] == nested_decisions
 
 
+def test_add_substituent_trace_preserves_grouped_tree_instances():
+    parts = AssemblyParts(parent_length=1, parent_atom_ids={0})
+
+    add_substituent_trace(
+        parts,
+        "ethyl",
+        "1",
+        atom_ids={1, 2},
+        substituent_tree={"kind": "substituent", "name": "ethyl", "atoms": [1, 2]},
+    )
+    add_substituent_trace(
+        parts,
+        "ethyl",
+        "2",
+        atom_ids={3, 4},
+        substituent_tree={"kind": "substituent", "name": "ethyl", "atoms": [3, 4]},
+    )
+
+    tree = parts.substituents[0].substituent_tree
+    assert tree["kind"] == "grouped_substituent_instances"
+    assert [instance["atoms"] for instance in tree["instances"]] == [[1, 2], [3, 4]]
+
+
 def test_principal_suffix_tokens_are_emitted_from_functional_group_renderer():
     parts = AssemblyParts(
         parent_length=3,

--- a/src/bluenamer/tests/test_public_api.py
+++ b/src/bluenamer/tests/test_public_api.py
@@ -61,11 +61,49 @@ def test_name_with_trace_populates_rules_hit_and_hints():
     result = name("CC(=O)Nc1ccccc1", include_trace=True)
     assert result.name == "N-phenylacetamide"
     assert result.trace_segments, "trace_segments must be populated when include_trace=True"
+    assert result.substituent_tree, "substituent_tree must be populated when include_trace=True"
     assert result.decisions, "decisions must be populated when include_trace=True"
     # Rule hints should reference Blue Book P-XX identifiers in this case.
     assert result.rules_hit, "expected at least one P-XX rule id"
     assert all(rid.startswith("P-") for rid in result.rules_hit)
     assert len(result.rule_hints) >= 1
+
+
+def test_substituent_tree_preserves_nested_branch_hierarchy_and_flat_trace():
+    result = name(
+        "O=C(O)C[C@H](O)C[C@H](O)CCn2c(c(c(c2c1ccc(F)cc1)c3ccccc3)C(=O)Nc4ccccc4)C(C)C",
+        include_trace=True,
+    )
+
+    root = result.substituent_tree[0]
+    pyrrolyl = next(child for child in root["substituents"] if "pyrrol" in child["name"])
+    fluorophenyl = next(child for child in pyrrolyl["substituents"] if "fluorophenyl" in child["name"])
+    phenylcarbamoyl = next(child for child in pyrrolyl["substituents"] if "phenylcarbamoyl" in child["name"])
+
+    assert root["kind"] == "component"
+    assert root["parent"]["parent_length"] == 7
+    assert pyrrolyl["locants"] == ["7"]
+    assert pyrrolyl["parent"]["retained_name"] == "pyrrole"
+    assert {child["name"].strip("()") for child in pyrrolyl["substituents"]} >= {
+        "propan-2-yl",
+        "phenylcarbamoyl",
+        "phenyl",
+        "4-fluorophenyl",
+    }
+    assert fluorophenyl["parent"]["retained_name"] == "benzene"
+    assert fluorophenyl["substituents"][0]["name"] == "fluoro"
+    assert fluorophenyl["substituents"][0]["locants"] == ["4"]
+    assert phenylcarbamoyl["functional_prefix"]["group_key"] == "ring_amide"
+    assert phenylcarbamoyl["functional_prefix"]["attachment_atom"] == 13
+    assert phenylcarbamoyl["functional_prefix"]["core_atoms"] == [29, 30, 31]
+    assert phenylcarbamoyl["functional_prefix"]["group_atoms"] == [13, 29, 30, 31]
+    assert phenylcarbamoyl["functional_prefix"]["ligands"][0]["parent"]["retained_name"] == "benzene"
+    assert phenylcarbamoyl["substituents"][0]["name"] == "phenyl"
+
+    assert result.trace_segments
+    assert any(segment.get("nested_decisions") for segment in result.trace_segments)
+    assembly = [step for step in result.decisions if step.decision == "assembled component name"][-1]
+    assert assembly.data["name_token_spans"]
 
 
 def test_naming_errors_become_result_error_not_exception():
@@ -154,6 +192,7 @@ def test_cli_name_json_emits_structured_payload():
     assert payload["smiles"] == "CC(=O)O"
     assert payload["ok"] is True
     assert "trace_segments" in payload
+    assert "substituent_tree" in payload
 
 
 @pytest.mark.parametrize("processes", [1, 2])

--- a/src/bluenamer/trace_helpers.py
+++ b/src/bluenamer/trace_helpers.py
@@ -11,6 +11,28 @@ from .principal_suffixes import principal_suffix_terms
 from .rules import bonds, multipliers, stems
 
 
+def decision_trace_data(trace: DecisionTrace | list | tuple | None) -> list[dict]:
+    """Return JSON-safe decision trace data for nested name fragments."""
+
+    if trace is None:
+        return []
+    steps = trace.steps if isinstance(trace, DecisionTrace) else trace
+    data = []
+    for step in steps:
+        phase = step.phase.value if hasattr(step.phase, "value") else str(step.phase)
+        data.append(
+            {
+                "phase": phase,
+                "decision": step.decision,
+                "reason": step.reason,
+                "atoms": list(step.atoms),
+                "bonds": list(step.bonds),
+                "data": step.data,
+            }
+        )
+    return data
+
+
 def trace_decision(
     trace: DecisionTrace | None,
     phase: TracePhase,
@@ -68,7 +90,9 @@ def add_substituent_trace(
     bond_ids=None,
     charge_atom_ids=None,
     trace_segments=None,
+    nested_decisions=None,
     emitted_tokens: tuple[NameTokenBinding, ...] = (),
+    substituent_tree=None,
     spiro=None,
 ) -> None:
     """Append or merge a substituent while preserving trace atom/bond IDs."""
@@ -77,6 +101,7 @@ def add_substituent_trace(
     bond_ids = set(bond_ids or ())
     charge_atom_ids = set(charge_atom_ids or ())
     trace_segments = list(trace_segments or ())
+    nested_decisions = list(nested_decisions or ())
     if spiro is not None:
         spiro = replace(spiro, parent_locant=str(locant))
     existing = next((s for s in parts.substituents if s.name == name and s.spiro == spiro), None)
@@ -86,6 +111,9 @@ def add_substituent_trace(
         existing.bond_ids.update(bond_ids)
         existing.charge_atom_ids.update(charge_atom_ids)
         existing.trace_segments.extend(trace_segments)
+        existing.nested_decisions.extend(nested_decisions)
+        if substituent_tree:
+            existing.substituent_tree = substituent_tree
         existing.emitted_tokens = existing.emitted_tokens + tuple(emitted_tokens)
     else:
         parts.substituents.append(
@@ -97,6 +125,8 @@ def add_substituent_trace(
                 charge_atom_ids=charge_atom_ids,
                 emitted_tokens=tuple(emitted_tokens),
                 trace_segments=trace_segments,
+                nested_decisions=nested_decisions,
+                substituent_tree=substituent_tree,
                 spiro=spiro,
             )
         )
@@ -154,20 +184,29 @@ def assembly_trace_segments(parts: AssemblyParts) -> list[dict]:
             target.bond_ids.update(item.bond_ids)
             target.charge_atom_ids.update(item.charge_atom_ids)
             target.trace_segments.extend(item.trace_segments)
+            target.nested_decisions.extend(item.nested_decisions)
+            if item.substituent_tree:
+                target.substituent_tree = item.substituent_tree
         for item in grouped.values():
             if item.trace_segments and strip_outer_parentheses(item.name) != "methyl":
-                segments.extend(item.trace_segments)
+                for segment in item.trace_segments:
+                    segment = dict(segment)
+                    if item.nested_decisions:
+                        segment.setdefault("substituent_name", item.name)
+                        segment.setdefault("nested_decisions", item.nested_decisions)
+                    segments.append(segment)
                 continue
-            segments.append(
-                {
-                    "key": f"substituent:{item.name}",
-                    "label": f"{strip_outer_parentheses(item.name)} substituent",
-                    "atoms": sorted(item.atom_ids),
-                    "bonds": sorted(item.bond_ids),
-                    "name_terms": multiplied_name_terms(item.name, max(1, len(item.locants))),
-                    "rule_hint": "Detachable prefixes: Blue Book P-14.2, P-16.5, and P-61.",
-                }
-            )
+            segment = {
+                "key": f"substituent:{item.name}",
+                "label": f"{strip_outer_parentheses(item.name)} substituent",
+                "atoms": sorted(item.atom_ids),
+                "bonds": sorted(item.bond_ids),
+                "name_terms": multiplied_name_terms(item.name, max(1, len(item.locants))),
+                "rule_hint": "Detachable prefixes: Blue Book P-14.2, P-16.5, and P-61.",
+            }
+            if item.nested_decisions:
+                segment["nested_decisions"] = item.nested_decisions
+            segments.append(segment)
 
     if parts.a_prefixes:
         grouped_a: dict[str, SubstituentItem] = {}
@@ -257,3 +296,147 @@ def assembly_trace_segments(parts: AssemblyParts) -> list[dict]:
             }
         )
     return segments
+
+
+def assembly_substituent_tree(
+    parts: AssemblyParts,
+    *,
+    name: str,
+    atom_ids=None,
+    bond_ids=None,
+    decisions=None,
+) -> dict:
+    """Return a nested substituent tree from the graph-bound assembly parts."""
+
+    component_atoms = set(atom_ids or parts.parent_atom_ids)
+    component_bonds = set(bond_ids or parts.parent_bond_ids)
+    parent_node = {
+        "kind": "fragment",
+        "name": name,
+        "atoms": sorted(component_atoms),
+        "bonds": sorted(component_bonds),
+        "parent": _parent_tree_node(parts),
+        "principal_group": _principal_group_tree_node(parts),
+        "substituents": _substituent_tree_nodes(parts.substituents),
+        "replacement_prefixes": _simple_item_tree_nodes(parts.a_prefixes, "replacement_prefix"),
+        "unsaturations": [
+            {
+                "kind": "unsaturation",
+                "bond_key": item.bond_key,
+                "locants": list(item.locants),
+                "atoms": sorted(item.atom_ids),
+                "bonds": sorted(item.bond_ids),
+            }
+            for item in parts.unsaturations
+        ],
+        "stereo_features": [
+            {"descriptor": descriptor, "locant": locant}
+            for descriptor, locant in parts.stereo_features
+        ],
+        "indicated_hydrogens": list(parts.indicated_hydrogens),
+        "hydro_operations": [
+            {
+                "key": operation.key,
+                "reason": operation.reason,
+                "locants": list(operation.locants),
+                "atom_ids": sorted(operation.atom_ids),
+                "operation_kind": operation.operation_kind,
+            }
+            for operation in parts.hydro_operations
+        ],
+        "parent_charges": [
+            {
+                "locant": item.locant,
+                "symbol": item.symbol,
+                "charge": item.charge,
+                "atom_id": item.atom_id,
+            }
+            for item in parts.parent_charges
+        ],
+        "trace_segments": assembly_trace_segments(parts),
+        "nested_decisions": list(decisions or ()),
+    }
+    return parent_node
+
+
+def _parent_tree_node(parts: AssemblyParts) -> dict:
+    return {
+        "kind": "parent",
+        "retained_name": parts.retained_name,
+        "parent_length": parts.parent_length,
+        "is_ring": parts.is_ring,
+        "is_bicycle": parts.is_bicycle,
+        "is_spiro": parts.is_spiro,
+        "is_polycycle": parts.is_polycycle,
+        "bicycle_descriptor": list(parts.bicycle_xyz) if parts.is_bicycle else [],
+        "spiro_descriptor": list(parts.spiro_xy) if parts.is_spiro else [],
+        "polycycle_descriptor": parts.polycycle_descriptor,
+        "atoms": sorted(parts.parent_atom_ids),
+        "bonds": sorted(parts.parent_bond_ids),
+        "atom_ids_by_locant": dict(parts.parent_atom_ids_by_locant),
+        "atom_symbols_by_locant": dict(parts.parent_atom_symbols_by_locant),
+        "atom_charges_by_locant": dict(parts.parent_atom_charges_by_locant),
+    }
+
+
+def _principal_group_tree_node(parts: AssemblyParts) -> dict | None:
+    if parts.principal_group is None:
+        return None
+    return {
+        "kind": "principal_group",
+        "key": parts.principal_group.key,
+        "locants": list(parts.principal_group.locants),
+        "atoms": sorted(parts.principal_group.atom_ids),
+        "bonds": sorted(parts.principal_group.bond_ids),
+        "charge_atoms": sorted(parts.principal_group.charge_atom_ids),
+    }
+
+
+def _simple_item_tree_nodes(items: list[SubstituentItem], kind: str) -> list[dict]:
+    return [
+        {
+            "kind": kind,
+            "name": item.name,
+            "locants": list(item.locants),
+            "atoms": sorted(item.atom_ids),
+            "bonds": sorted(item.bond_ids),
+            "charge_atoms": sorted(item.charge_atom_ids),
+            "trace_segments": list(item.trace_segments),
+            "nested_decisions": list(item.nested_decisions),
+        }
+        for item in items
+    ]
+
+
+def _substituent_tree_nodes(items: list[SubstituentItem]) -> list[dict]:
+    nodes = []
+    for item in items:
+        child = dict(item.substituent_tree or {})
+        if child:
+            child.setdefault("kind", "substituent")
+            child.setdefault("name", item.name)
+            child.setdefault("atoms", sorted(item.atom_ids))
+            child.setdefault("bonds", sorted(item.bond_ids))
+            child.setdefault("trace_segments", list(item.trace_segments))
+            child.setdefault("nested_decisions", list(item.nested_decisions))
+        else:
+            child = {
+                "kind": "substituent",
+                "name": item.name,
+                "atoms": sorted(item.atom_ids),
+                "bonds": sorted(item.bond_ids),
+                "trace_segments": list(item.trace_segments),
+                "nested_decisions": list(item.nested_decisions),
+                "substituents": [],
+            }
+        child["locants"] = list(item.locants)
+        child["charge_atoms"] = sorted(item.charge_atom_ids)
+        if item.spiro is not None:
+            child["spiro"] = {
+                "parent_locant": item.spiro.parent_locant,
+                "side_locant": item.spiro.side_locant,
+                "side_parent_name": item.spiro.side_parent_name,
+                "prefixes": list(item.spiro.prefixes),
+            }
+        nodes.append(child)
+    return nodes

--- a/src/bluenamer/trace_helpers.py
+++ b/src/bluenamer/trace_helpers.py
@@ -113,7 +113,11 @@ def add_substituent_trace(
         existing.trace_segments.extend(trace_segments)
         existing.nested_decisions.extend(nested_decisions)
         if substituent_tree:
-            existing.substituent_tree = substituent_tree
+            existing.substituent_tree = _merge_substituent_tree_instances(
+                existing.substituent_tree,
+                substituent_tree,
+                existing.name,
+            )
         existing.emitted_tokens = existing.emitted_tokens + tuple(emitted_tokens)
     else:
         parts.substituents.append(
@@ -186,7 +190,11 @@ def assembly_trace_segments(parts: AssemblyParts) -> list[dict]:
             target.trace_segments.extend(item.trace_segments)
             target.nested_decisions.extend(item.nested_decisions)
             if item.substituent_tree:
-                target.substituent_tree = item.substituent_tree
+                target.substituent_tree = _merge_substituent_tree_instances(
+                    target.substituent_tree,
+                    item.substituent_tree,
+                    target.name,
+                )
         for item in grouped.values():
             if item.trace_segments and strip_outer_parentheses(item.name) != "methyl":
                 for segment in item.trace_segments:
@@ -305,9 +313,12 @@ def assembly_substituent_tree(
     atom_ids=None,
     bond_ids=None,
     decisions=None,
+    trace_segments=None,
 ) -> dict:
     """Return a nested substituent tree from the graph-bound assembly parts."""
 
+    if trace_segments is None:
+        trace_segments = assembly_trace_segments(parts)
     component_atoms = set(atom_ids or parts.parent_atom_ids)
     component_bonds = set(bond_ids or parts.parent_bond_ids)
     parent_node = {
@@ -352,10 +363,30 @@ def assembly_substituent_tree(
             }
             for item in parts.parent_charges
         ],
-        "trace_segments": assembly_trace_segments(parts),
+        "trace_segments": list(trace_segments),
         "nested_decisions": list(decisions or ()),
     }
     return parent_node
+
+
+def _merge_substituent_tree_instances(existing: dict | None, new: dict, name: str) -> dict:
+    """Preserve all tree instances when same-name substituents are grouped."""
+
+    if existing is None:
+        return new
+    if existing == new:
+        merged = dict(existing)
+        merged["instance_count"] = int(merged.get("instance_count", 1)) + 1
+        return merged
+    if existing.get("kind") == "grouped_substituent_instances":
+        merged = dict(existing)
+        merged["instances"] = [*existing.get("instances", ()), new]
+        return merged
+    return {
+        "kind": "grouped_substituent_instances",
+        "name": name,
+        "instances": [existing, new],
+    }
 
 
 def _parent_tree_node(parts: AssemblyParts) -> dict:

--- a/src/bluenamer/trace_helpers.py
+++ b/src/bluenamer/trace_helpers.py
@@ -25,8 +25,8 @@ def decision_trace_data(trace: DecisionTrace | list | tuple | None) -> list[dict
                 "phase": phase,
                 "decision": step.decision,
                 "reason": step.reason,
-                "atoms": list(step.atoms),
-                "bonds": list(step.bonds),
+                "atoms": sorted(step.atoms),
+                "bonds": sorted(step.bonds),
                 "data": step.data,
             }
         )
@@ -330,8 +330,7 @@ def assembly_substituent_tree(
             for item in parts.unsaturations
         ],
         "stereo_features": [
-            {"descriptor": descriptor, "locant": locant}
-            for descriptor, locant in parts.stereo_features
+            {"descriptor": descriptor, "locant": locant} for descriptor, locant in parts.stereo_features
         ],
         "indicated_hydrogens": list(parts.indicated_hydrogens),
         "hydro_operations": [


### PR DESCRIPTION
## Summary

This PR enriches naming trace output with a structured `substituent_tree`, allowing recursive substituent hierarchy, nested branch decisions, functional-prefix metadata, and ligand subtrees to be surfaced through the public analysis/API payloads.

It also improves nested decision tracing for recursive substituent naming, preserves that metadata through assembly trace segments, and adds tests covering the new hierarchy and trace behavior.

## Changes

- Add `substituent_tree` support to:
  - `NameAnalysis`
  - `NamingResult`
  - `NamingEngine.analyze()` / `analyze_smiles()`
  - JSON payloads emitted when `include_trace=True`

- Extend component and subgraph naming to optionally return both:
  - flat trace segments
  - nested substituent tree structures

- Preserve recursive branch metadata through:
  - `SubstituentItem`
  - `add_substituent_trace`
  - `assembly_trace_segments`
  - new `assembly_substituent_tree` helpers

- Add nested `DecisionTrace` capture for recursive substituents, including:
  - selected substituent subgraph
  - parent skeleton selection
  - numbering selection
  - final substituent assembly

- Introduce structured handling for direct functional-prefix subgraphs via `DirectSubgraphPrefix`, including functional-prefix atoms, bonds, group keys, attachment atoms, and ligand subtrees.

- Add regression coverage for:
  - nested decision preservation in trace segments
  - recursive substituent decision traces
  - public API exposure of `substituent_tree`
  - preservation of nested branch hierarchy alongside flat trace output
  - CLI JSON output including `substituent_tree`

- Fix example scripts:
  - Separate OPSIN failure output directories for ZINC22 and PubChem
  - Correct PubChem example import to use `bluenamer.utils.standardize_mol`
  - Fix QM9 batch example dataset extraction from the selected SMILES column

## Testing

- Added and updated tests in:
  - `src/bluenamer/tests/test_analysis.py`
  - `src/bluenamer/tests/test_public_api.py`

## Summary by Sourcery

Expose structured substituent hierarchy and nested decision metadata through naming analysis and public trace output.

New Features:
- Add a JSON-serializable substituent_tree structure to NameAnalysis, NamingResult, and CLI JSON output, capturing component and recursive substituent hierarchies.
- Introduce DirectSubgraphPrefix to represent direct functional-prefix subgraphs with associated atoms, bonds, attachment metadata, and ligand subtrees.
- Capture nested DecisionTrace data for recursive substituent and functional-prefix naming, including component selection, parent skeleton, numbering, and final assembly steps.

Bug Fixes:
- Correct example scripts by fixing OPSIN evaluation output directories, importing standardize_mol from the proper package, and using the correct SMILES column when constructing QM9 datasets.

Enhancements:
- Extend component, branch, and subgraph naming flows to optionally return both flat trace segments and nested substituent trees while preserving compatibility with existing call sites.
- Augment assembly trace segments to carry nested_decisions for grouped substituents and merge multiple same-name substituent tree instances into grouped structures.

Tests:
- Add regression tests ensuring nested decision metadata is preserved through substituent traces and assembly segments and that substituent_tree is exposed via the public API and CLI JSON output.
- Add tests validating grouping behavior for multiple same-name substituent tree instances and coverage for recursive substituent nested decision capture.