### PR TITLE
Dev

### DIFF
--- a/examples/opsin_eval_pubchem.py
+++ b/examples/opsin_eval_pubchem.py
@@ -10,9 +10,9 @@ import numpy as np
 import py2opsin
 from datasets import load_dataset
 from tqdm import tqdm
-from bluenamer.utils import standardize_mol
 
 from bluenamer.namer import name_smiles
+from bluenamer.utils import standardize_mol
 
 # --- Configuration ---
 N_PER_SEED = 100_000

--- a/src/bluenamer/namer.py
+++ b/src/bluenamer/namer.py
@@ -44,13 +44,13 @@ from .substituent_tokens import graph_bound_substituent_tokens
 from .trace_helpers import (
     add_substituent_trace as _add_substituent_trace,
 )
+from .trace_helpers import assembly_substituent_tree as _assembly_substituent_tree
 from .trace_helpers import (
     assembly_trace_segments as _assembly_trace_segments,
 )
 from .trace_helpers import (
     bond_ids_within as _bond_ids_within,
 )
-from .trace_helpers import assembly_substituent_tree as _assembly_substituent_tree
 from .trace_helpers import decision_trace_data, trace_decision
 
 

--- a/src/bluenamer/parent_selection.py
+++ b/src/bluenamer/parent_selection.py
@@ -40,8 +40,6 @@ class ParentSeniorityProfile:
         if criterion == "contains_principal_group":
             return -int(self.contains_principal_group)
         if criterion == "senior_element_vector":
-            if self.ring_parent:
-                return ()
             return self.senior_element_vector
         if criterion == "polycycle_parent":
             return -int(self.polycycle_parent)
@@ -79,12 +77,11 @@ class ParentSeniorityProfile:
         return tuple(self.criterion_value(criterion) for criterion in criteria)
 
     def ring_seniority_key(self) -> tuple:
-        """Return ring-system seniority criteria with a polycycle topology guard."""
+        """Return ring-system seniority criteria after ring-over-chain selection."""
 
         if not self.ring_parent:
             return ()
         return (
-            -self.ring_count if self.ring_count > 1 else 0,
             self.senior_heteroatom_vector,
             -self.ring_count,
             -self.parent_atom_count,
@@ -280,6 +277,7 @@ def select_principal_parent(
     if not candidates:
         return None
 
+    candidates = _prefer_spiro_backbone_components(candidates, ring_systems)
     candidates.sort(key=lambda m: m.score_tuple)
     best = candidates[0]
 
@@ -360,6 +358,81 @@ def _multiple_bond_count(mol: Molecule | None, path: list[int], *, include_doubl
             elif not include_double and bond.order == 2:
                 count += 1
     return count
+
+
+def _prefer_spiro_backbone_components(
+    candidates: list[ParentCandidate], ring_systems: list[RingSystem]
+) -> list[ParentCandidate]:
+    """Limit spiro-component competitions to the graph backbone component.
+
+    Spiro-connected ring components are not independent whole-parent hydride
+    candidates.  When principal-group coverage is tied, choose the component
+    that represents the shared spiro backbone before applying ordinary parent
+    seniority.  This prevents a small hetero side ring from stealing the parent
+    slot only because senior-element ordering is evaluated before ring
+    complexity.
+    """
+
+    if len(ring_systems) < 2:
+        return candidates
+
+    ring_system_by_path = {tuple(system.paths[0]): system for system in ring_systems}
+    shared_counts: dict[tuple[int, ...], int] = {}
+    for system in ring_systems:
+        path_key = tuple(system.paths[0])
+        shared_counts[path_key] = sum(1 for other in ring_systems if other is not system and system.atoms & other.atoms)
+
+    max_shared = max(shared_counts.values(), default=0)
+    if max_shared == 0:
+        return candidates
+
+    best_principal_key = min(
+        (
+            candidate.seniority_profile.criterion_value("contains_principal_group"),
+            candidate.seniority_profile.criterion_value("principal_group_count"),
+        )
+        for candidate in candidates
+    )
+    eligible = [
+        candidate
+        for candidate in candidates
+        if (
+            candidate.seniority_profile.criterion_value("contains_principal_group"),
+            candidate.seniority_profile.criterion_value("principal_group_count"),
+        )
+        == best_principal_key
+    ]
+    eligible_ring_components = [
+        candidate
+        for candidate in eligible
+        if candidate.is_ring and shared_counts.get(tuple(candidate.path), 0) > 0 and tuple(candidate.path) in ring_system_by_path
+    ]
+    if len(eligible_ring_components) < 2:
+        return candidates
+
+    best_backbone_key = min(
+        (
+            -shared_counts[tuple(candidate.path)],
+            -candidate.seniority_profile.ring_count,
+            -candidate.seniority_profile.parent_atom_count,
+            candidate.seniority_profile.path_tiebreak,
+        )
+        for candidate in eligible_ring_components
+    )
+    backbone = [
+        candidate
+        for candidate in eligible_ring_components
+        if (
+            -shared_counts[tuple(candidate.path)],
+            -candidate.seniority_profile.ring_count,
+            -candidate.seniority_profile.parent_atom_count,
+            candidate.seniority_profile.path_tiebreak,
+        )
+        == best_backbone_key
+    ]
+    if not backbone:
+        return candidates
+    return backbone
 
 
 def _ring_count_for_system(ring_system: RingSystem) -> int:

--- a/src/bluenamer/parent_selection.py
+++ b/src/bluenamer/parent_selection.py
@@ -405,7 +405,9 @@ def _prefer_spiro_backbone_components(
     eligible_ring_components = [
         candidate
         for candidate in eligible
-        if candidate.is_ring and shared_counts.get(tuple(candidate.path), 0) > 0 and tuple(candidate.path) in ring_system_by_path
+        if candidate.is_ring
+        and shared_counts.get(tuple(candidate.path), 0) > 0
+        and tuple(candidate.path) in ring_system_by_path
     ]
     if len(eligible_ring_components) < 2:
         return candidates

--- a/src/bluenamer/parent_selection.py
+++ b/src/bluenamer/parent_selection.py
@@ -376,11 +376,11 @@ def _prefer_spiro_backbone_components(
     if len(ring_systems) < 2:
         return candidates
 
-    ring_system_by_path = {tuple(system.paths[0]): system for system in ring_systems}
     shared_counts: dict[tuple[int, ...], int] = {}
     for system in ring_systems:
-        path_key = tuple(system.paths[0])
-        shared_counts[path_key] = sum(1 for other in ring_systems if other is not system and system.atoms & other.atoms)
+        shared_count = sum(1 for other in ring_systems if other is not system and system.atoms & other.atoms)
+        for path in system.paths:
+            shared_counts[tuple(path)] = shared_count
 
     max_shared = max(shared_counts.values(), default=0)
     if max_shared == 0:
@@ -402,39 +402,43 @@ def _prefer_spiro_backbone_components(
         )
         == best_principal_key
     ]
-    eligible_ring_components = [
-        candidate
-        for candidate in eligible
-        if candidate.is_ring
-        and shared_counts.get(tuple(candidate.path), 0) > 0
-        and tuple(candidate.path) in ring_system_by_path
-    ]
+    eligible_ring_components = []
+    for candidate in eligible:
+        if not candidate.is_ring:
+            continue
+        path_key = tuple(candidate.path)
+        if shared_counts.get(path_key, 0) <= 0:
+            continue
+        eligible_ring_components.append(candidate)
     if len(eligible_ring_components) < 2:
         return candidates
 
-    best_backbone_key = min(
-        (
-            -shared_counts[tuple(candidate.path)],
-            -candidate.seniority_profile.ring_count,
-            -candidate.seniority_profile.parent_atom_count,
-            candidate.seniority_profile.path_tiebreak,
-        )
+    backbone_keys = {
+        tuple(candidate.path): _spiro_backbone_rank_key(candidate, shared_counts)
         for candidate in eligible_ring_components
-    )
-    backbone = [
-        candidate
-        for candidate in eligible_ring_components
-        if (
-            -shared_counts[tuple(candidate.path)],
-            -candidate.seniority_profile.ring_count,
-            -candidate.seniority_profile.parent_atom_count,
-            candidate.seniority_profile.path_tiebreak,
-        )
-        == best_backbone_key
-    ]
-    if not backbone:
+    }
+    best_backbone_key = min(backbone_keys.values())
+    backbone_paths = {path for path, key in backbone_keys.items() if key == best_backbone_key}
+    if not backbone_paths:
         return candidates
-    return backbone
+    competing_paths = set(backbone_keys)
+    return [
+        candidate
+        for candidate in candidates
+        if tuple(candidate.path) not in competing_paths or tuple(candidate.path) in backbone_paths
+    ]
+
+
+def _spiro_backbone_rank_key(candidate: ParentCandidate, shared_counts: dict[tuple[int, ...], int]) -> tuple:
+    """Return the local rank key for competing spiro-connected ring components."""
+
+    path_key = tuple(candidate.path)
+    return (
+        -shared_counts[path_key],
+        -candidate.seniority_profile.ring_count,
+        -candidate.seniority_profile.parent_atom_count,
+        candidate.seniority_profile.path_tiebreak,
+    )
 
 
 def _ring_count_for_system(ring_system: RingSystem) -> int:

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -33,7 +33,7 @@ from bluenamer.assembly_spiro import (
     format_spiro_core,
     split_spiro_substituents,
 )
-from bluenamer.chains import find_all_carbon_paths, find_ring_systems
+from bluenamer.chains import RingSystem, find_all_carbon_paths, find_ring_systems
 from bluenamer.charge_pair_roles import charge_pair_roles, unsupported_charge_pair_roles
 from bluenamer.formatting import ensure_stereo_descriptor_boundary, format_counted_prefixes
 from bluenamer.functional_groups import (
@@ -112,6 +112,7 @@ from bluenamer.parent_selection import (
     ParentCandidate,
     ParentSelection,
     ParentSeniorityProfile,
+    _prefer_spiro_backbone_components,
     select_principal_parent,
 )
 from bluenamer.perception import PerceivedGroup, perceive_groups
@@ -3274,6 +3275,81 @@ def test_parent_selection_criteria_are_data_ordered():
         "path_tiebreak",
     )
     assert profile.score_tuple() == (-1, -1, (7,), 0, (), (-2, 0, (0, 0, 0, 0, 0, 0)), 0, 0, (0, 1))
+
+
+def test_senior_element_vector_orders_ring_and_chain_parent_profiles():
+    def profile(*, ring_parent: bool, senior_element_vector: tuple[int, ...]) -> ParentSeniorityProfile:
+        return ParentSeniorityProfile(
+            principal_group_count=0,
+            contains_principal_group=False,
+            senior_element_vector=senior_element_vector,
+            polycycle_parent=False,
+            bicycle_parent=False,
+            spiro_parent=False,
+            ring_parent=ring_parent,
+            ring_count=1 if ring_parent else 0,
+            parent_atom_count=4,
+            heteroatom_count=1,
+            senior_heteroatom_vector=(),
+            senior_heteroatom_count_vector=(0, 0, 0, 0, 0, 0),
+            multiple_bond_count=0,
+            double_bond_count=0,
+            path_tiebreak=(0, 1, 2, 3),
+        )
+
+    n_ring = profile(ring_parent=True, senior_element_vector=(1, 7))
+    o_ring = profile(ring_parent=True, senior_element_vector=(5, 7))
+    n_chain = profile(ring_parent=False, senior_element_vector=(1, 7))
+    o_chain = profile(ring_parent=False, senior_element_vector=(5, 7))
+
+    assert n_ring.score_tuple() < o_ring.score_tuple()
+    assert n_chain.score_tuple() < o_chain.score_tuple()
+
+
+def test_spiro_backbone_filter_keeps_noncompeting_candidates_and_matches_all_ring_paths():
+    backbone = ParentCandidate.build(
+        [3, 2, 1, 0],
+        is_ring=True,
+        is_bicycle=False,
+        is_spiro=True,
+        is_polycycle=False,
+        xyz=(0, 0, 0),
+        principal_groups_count=0,
+        mol=None,
+        ring_count=2,
+    )
+    side_ring = ParentCandidate.build(
+        [3, 4, 5],
+        is_ring=True,
+        is_bicycle=False,
+        is_spiro=False,
+        is_polycycle=False,
+        xyz=(0, 0, 0),
+        principal_groups_count=0,
+        mol=None,
+        ring_count=1,
+    )
+    unrelated_chain = ParentCandidate.build(
+        [10, 11, 12],
+        is_ring=False,
+        is_bicycle=False,
+        is_spiro=False,
+        is_polycycle=False,
+        xyz=(0, 0, 0),
+        principal_groups_count=0,
+        mol=None,
+    )
+    ring_systems = [
+        RingSystem(atoms={0, 1, 2, 3}, is_spiro=True, paths=[[0, 1, 2, 3], [3, 2, 1, 0]]),
+        RingSystem(atoms={3, 4, 5}, paths=[[3, 4, 5]]),
+    ]
+
+    filtered = _prefer_spiro_backbone_components([side_ring, unrelated_chain, backbone], ring_systems)
+
+    assert backbone in filtered
+    assert unrelated_chain in filtered
+    assert side_ring not in filtered
+    assert [candidate.path for candidate in filtered] == [[10, 11, 12], [3, 2, 1, 0]]
 
 
 def test_parent_seniority_profile_exposes_brief_guide_extension_fields():

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -3224,7 +3224,7 @@ def test_parent_selection_has_named_shape():
     assert selection.score_tuple
 
 
-def test_parent_selection_criteria_are_data_ordered_and_behavior_preserving():
+def test_parent_selection_criteria_are_data_ordered():
     profile = ParentSeniorityProfile(
         principal_group_count=1,
         contains_principal_group=True,
@@ -3488,8 +3488,9 @@ def test_parent_seniority_criteria_follow_brief_guide_section_6_order():
     assert min([no_group, one_group], key=lambda candidate: candidate.score_tuple) is one_group
     assert min([one_group, two_groups], key=lambda candidate: candidate.score_tuple) is two_groups
     assert min([si_parent, n_parent], key=lambda candidate: candidate.score_tuple) is n_parent
+    assert min([carbon_ring, n_parent], key=lambda candidate: candidate.score_tuple) is n_parent
     assert min([carbon_chain, carbon_ring], key=lambda candidate: candidate.score_tuple) is carbon_ring
-    assert min([p_ring, o_ring], key=lambda candidate: candidate.score_tuple) is o_ring
+    assert min([p_ring, o_ring], key=lambda candidate: candidate.score_tuple) is p_ring
     assert min([monocycle, bicycle], key=lambda candidate: candidate.score_tuple) is bicycle
     assert min([piperazine_like, oxazinane_like], key=lambda candidate: candidate.score_tuple) is oxazinane_like
     assert min([shorter_chain, longer_chain], key=lambda candidate: candidate.score_tuple) is longer_chain

--- a/tests/integration/test_corpus_golden.py
+++ b/tests/integration/test_corpus_golden.py
@@ -58,6 +58,5 @@ def test_corpus_names_match_golden(goldens, capsys):
                 print(f"    expected: {want}")
                 print(f"    got:      {got}")
         pytest.fail(
-            f"{len(mismatches)} corpus entries name differently on rdkit "
-            f"{rdkit.__version__} than the committed goldens"
+            f"{len(mismatches)} corpus entries name differently on rdkit {rdkit.__version__} than the committed goldens"
         )

--- a/tests/integration/test_diverse_corpus.py
+++ b/tests/integration/test_diverse_corpus.py
@@ -82,7 +82,7 @@ def test_corpus_naming_pass_rate(corpus):
         # Surface the offenders so the failure is actionable.
         sample = "\n".join(f"  - {s} [{c}]" for s, c in unnamed[:10])
         pytest.fail(
-            f"Naming pass rate {rate:.2%} below floor {NAME_PASS_RATE_FLOOR:.2%}.\n" f"First unnamed entries:\n{sample}"
+            f"Naming pass rate {rate:.2%} below floor {NAME_PASS_RATE_FLOOR:.2%}.\nFirst unnamed entries:\n{sample}"
         )
 
 


### PR DESCRIPTION
## Summary

This PR updates parent selection behavior for spiro-connected ring systems so that spiro ring components are evaluated through their shared backbone before ordinary parent seniority rules are applied.

The change prevents smaller hetero side rings from incorrectly taking the principal parent position solely because senior-element ordering was applied before ring-system complexity.

## Changes

* Adds `_prefer_spiro_backbone_components()` to narrow eligible parent candidates to the shared spiro backbone component when principal-group coverage is tied.
* Applies the spiro backbone preference before sorting principal parent candidates.
* Adjusts ring-system seniority ordering so ring-over-chain selection happens before ring-system-specific criteria.
* Restores senior element vector comparison for ring parents.
* Updates parent selection tests to reflect the corrected ordering behavior.
* Minor import ordering cleanup in the OPSIN PubChem evaluation example.

## Testing

* Updated existing parent selection tests to cover the revised seniority ordering.
* Added/adjusted assertions for ring-vs-chain, hetero ring ordering, and spiro-related parent selection behavior.

## Summary by Sourcery

Adjust parent selection to better handle spiro-connected ring systems and restore senior-element-based ordering for ring parents.

New Features:
- Introduce a spiro backbone preference that limits competing parent candidates in spiro-connected ring systems to the shared backbone component when principal-group coverage is tied.

Bug Fixes:
- Prevent small hetero side rings from incorrectly outranking spiro backbone components as principal parents by applying ring-system complexity before senior-element ordering.
- Restore senior element vector comparison for ring parents so hetero ordering is applied consistently across ring and chain candidates.

Enhancements:
- Refine ring-system seniority ordering so ring-over-chain selection precedes ring-system-specific criteria and adjust parent seniority tests to match the intended Brief Guide ordering.
- Tidy long failure messages and import ordering in tests and examples for improved readability.

Tests:
- Add and update unit tests covering senior element vector ordering for ring vs chain parents, spiro backbone filtering behavior, and revised ring-vs-chain and hetero ring seniority rules.