### PR TITLE
fix: stereo descriptor atom binding

### DIFF
--- a/src/bluenamer/assembly_parts.py
+++ b/src/bluenamer/assembly_parts.py
@@ -111,6 +111,7 @@ class AssemblyParts:
     parent_atom_symbols_by_locant: dict[str, str] = field(default_factory=dict)
     parent_atom_charges_by_locant: dict[str, int] = field(default_factory=dict)
     parent_bond_orders_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
+    parent_bond_ids_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
     name_atom_bindings: list[NameAtomBinding] = field(default_factory=list)
     name_token_spans: list[dict] = field(default_factory=list)
     name_rewrite_history: list[dict] = field(default_factory=list)

--- a/src/bluenamer/component_modifiers.py
+++ b/src/bluenamer/component_modifiers.py
@@ -10,6 +10,7 @@ from .molecule import DecisionTrace, Molecule
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .subgraph_tools import subgraph_component
+from .substituent_tokens import graph_bound_substituent_tokens
 from .trace_helpers import add_substituent_trace, bond_ids_within, decision_trace_data
 
 
@@ -156,8 +157,18 @@ def add_component_n_substituents(
                     mol, single_n, n_sub, sub_exclude, branch_namer, branch_decisions
                 )
                 if branch_name:
-                    branch_atoms = subgraph_component(mol, n_sub, sub_exclude | {single_n})
+                    branch_exclude = sub_exclude | {single_n}
+                    branch_atoms = subgraph_component(mol, n_sub, branch_exclude)
                     nested_decisions = decision_trace_data(branch_decisions)
+                    emitted_tokens = graph_bound_substituent_tokens(
+                        mol,
+                        n_sub,
+                        branch_atoms,
+                        branch_name,
+                        single_n,
+                        branch_exclude,
+                        branch_namer,
+                    )
                     if _use_hydrazone_suffix_modifier(parts, principal_key):
                         parts.principal_suffix_modifiers.append(
                             SubstituentItem(
@@ -166,6 +177,7 @@ def add_component_n_substituents(
                                 atom_ids=branch_atoms,
                                 bond_ids=bond_ids_within(mol, branch_atoms | {single_n}),
                                 charge_atom_ids=_charged_atoms(mol, branch_atoms),
+                                emitted_tokens=emitted_tokens,
                                 trace_segments=branch_trace,
                                 nested_decisions=nested_decisions,
                                 substituent_tree=branch_tree,
@@ -181,6 +193,7 @@ def add_component_n_substituents(
                         _charged_atoms(mol, branch_atoms),
                         branch_trace,
                         nested_decisions,
+                        emitted_tokens,
                         substituent_tree=branch_tree,
                     )
             n_idx_global += 1

--- a/src/bluenamer/name_assembly.py
+++ b/src/bluenamer/name_assembly.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from .assembly_parts import AssemblyParts, NameAtomBinding, NameTokenBinding
 from .molecule import Molecule
 from .name_bindings import ensure_name_atom_binding_tokens, postprocess_name_atom_bindings
+from .stereo_descriptors import is_searchable_stereo_token
 
 
 @dataclass(frozen=True)
@@ -1051,7 +1052,7 @@ def _native_token_is_searchable(token: str, token_binding: NameTokenBinding | No
     if not token:
         return False
     if token_binding is not None and token_binding.token_kind == "stereo":
-        return token in {"r", "s", "e", "z", "cis", "trans"}
+        return is_searchable_stereo_token(token)
     return len(token) >= 2 or token.isdigit() or "," in token or token in _ELEMENT_LOCANT_TOKENS
 
 
@@ -1720,7 +1721,7 @@ def _token_span_from_native_binding_group(
         for binding_idx, token_binding in matches
         if token_binding.source == "renderer_stereo"
     ]
-    if stereo_matches:
+    if stereo_matches and _should_prioritize_renderer_stereo(text, stereo_matches):
         matches = stereo_matches
     atoms: set[int] = set()
     bonds: set[int] = set()
@@ -1763,6 +1764,18 @@ def _token_span_from_native_binding_group(
         grammar_role=_collapse_metadata(grammar_roles, default=""),
         binding_key=_collapse_metadata(binding_keys, default=""),
     )
+
+
+def _should_prioritize_renderer_stereo(text: str, matches: list[tuple[int, NameTokenBinding]]) -> bool:
+    """Return whether a span is owned by an explicit stereo-renderer token."""
+
+    token_text = text.lower()
+    for _binding_idx, token_binding in matches:
+        if token_binding.token_kind == "stereo" and is_searchable_stereo_token(token_text):
+            return True
+        if token_binding.token_kind == "locant" and token_binding.grammar_role in {"absolute_stereo", "bond_stereo"}:
+            return True
+    return False
 
 
 def _collapse_metadata(values: list[str], *, default: str) -> str:

--- a/src/bluenamer/name_assembly.py
+++ b/src/bluenamer/name_assembly.py
@@ -1766,12 +1766,11 @@ def _token_span_from_native_binding_group(
     )
 
 
-def _should_prioritize_renderer_stereo(text: str, matches: list[tuple[int, NameTokenBinding]]) -> bool:
+def _should_prioritize_renderer_stereo(_text: str, matches: list[tuple[int, NameTokenBinding]]) -> bool:
     """Return whether a span is owned by an explicit stereo-renderer token."""
 
-    token_text = text.lower()
     for _binding_idx, token_binding in matches:
-        if token_binding.token_kind == "stereo" and is_searchable_stereo_token(token_text):
+        if token_binding.token_kind == "stereo" and is_searchable_stereo_token(token_binding.text):
             return True
         if token_binding.token_kind == "locant" and token_binding.grammar_role in {"absolute_stereo", "bond_stereo"}:
             return True

--- a/src/bluenamer/name_assembly.py
+++ b/src/bluenamer/name_assembly.py
@@ -922,6 +922,9 @@ def _native_token_spans(
         if binding.stage == "hydro" and binding.role == "indicated_hydrogen":
             spans.extend(_indicated_hydrogen_native_token_spans(search_text, binding_idx, binding))
             continue
+        if binding.stage == "assembly" and binding.role in {"absolute_stereo", "bond_stereo"}:
+            spans.extend(_absolute_stereo_native_token_spans(search_text, binding_idx, binding))
+            continue
         if not any(_is_locant_search_token(token_binding) for token_binding in binding.emitted_tokens):
             ordered_spans = _ordered_native_token_spans(text, search_text, binding_idx, binding)
             if ordered_spans:
@@ -929,7 +932,7 @@ def _native_token_spans(
                 continue
         for token_binding in binding.emitted_tokens:
             token = token_binding.text.strip().lower()
-            if not _native_token_is_searchable(token):
+            if not _native_token_is_searchable(token, token_binding):
                 continue
             pos = 0
             for found in _native_token_occurrences(text, search_text, token_binding, pos):
@@ -961,6 +964,30 @@ def _indicated_hydrogen_native_token_spans(
     return spans
 
 
+def _absolute_stereo_native_token_spans(
+    search_text: str,
+    binding_idx: int,
+    binding: NameAtomBinding,
+) -> list[tuple[int, int, int, NameTokenBinding]]:
+    locant_token = next((token for token in binding.emitted_tokens if token.token_kind == "locant"), None)
+    stereo_token = next((token for token in binding.emitted_tokens if token.token_kind == "stereo"), None)
+    if locant_token is None or stereo_token is None:
+        return []
+    locant_text = locant_token.text.lower()
+    stereo_text = stereo_token.text.lower()
+    pattern = f"{locant_text}{stereo_text}"
+    spans: list[tuple[int, int, int, NameTokenBinding]] = []
+    pos = 0
+    while True:
+        found = search_text.find(pattern, pos)
+        if found < 0:
+            break
+        spans.append((found, found + len(locant_text), binding_idx, locant_token))
+        spans.append((found + len(locant_text), found + len(pattern), binding_idx, stereo_token))
+        pos = found + 1
+    return spans
+
+
 def _ordered_native_token_spans(
     text: str,
     search_text: str,
@@ -973,7 +1000,7 @@ def _ordered_native_token_spans(
     cursor = 0
     for token_binding in binding.emitted_tokens:
         token = token_binding.text.strip().lower()
-        if not _native_token_is_searchable(token):
+        if not _native_token_is_searchable(token, token_binding):
             continue
         found = next(iter(_native_token_occurrences(text, search_text, token_binding, cursor)), -1)
         if found < 0:
@@ -1020,8 +1047,12 @@ def _is_standalone_locant_span(text: str, start: int, end: int) -> bool:
     return (not before or before in "-,( ") and (not after or after in "-,)' ")
 
 
-def _native_token_is_searchable(token: str) -> bool:
-    return bool(token) and (len(token) >= 2 or token.isdigit() or "," in token or token in _ELEMENT_LOCANT_TOKENS)
+def _native_token_is_searchable(token: str, token_binding: NameTokenBinding | None = None) -> bool:
+    if not token:
+        return False
+    if token_binding is not None and token_binding.token_kind == "stereo":
+        return token in {"r", "s", "e", "z", "cis", "trans"}
+    return len(token) >= 2 or token.isdigit() or "," in token or token in _ELEMENT_LOCANT_TOKENS
 
 
 def _direct_binding_spans(text: str, bindings: tuple[NameAtomBinding, ...]) -> list[tuple[int, int, int]]:
@@ -1684,6 +1715,13 @@ def _token_span_from_native_binding_group(
     end: int,
     matches: list[tuple[int, NameTokenBinding]],
 ) -> NameTokenSpan:
+    stereo_matches = [
+        (binding_idx, token_binding)
+        for binding_idx, token_binding in matches
+        if token_binding.source == "renderer_stereo"
+    ]
+    if stereo_matches:
+        matches = stereo_matches
     atoms: set[int] = set()
     bonds: set[int] = set()
     charges: set[int] = set()

--- a/src/bluenamer/name_bindings.py
+++ b/src/bluenamer/name_bindings.py
@@ -12,6 +12,11 @@ from .rules import bonds, stems
 def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
     """Populate structured bindings for the current assembly parts."""
 
+    preserved_assembly_stereo = [
+        binding
+        for binding in parts.name_atom_bindings
+        if binding.stage == "assembly" and binding.role in {"relative_stereo", "small_ring_stereo"}
+    ]
     bindings: list[NameAtomBinding] = []
     if parts.parent_atom_ids:
         bindings.append(
@@ -37,6 +42,40 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
                 emitted_tokens=_hydro_operation_tokens(operation),
             )
         )
+    for locant, descriptor in parts.stereo_features:
+        if descriptor not in {"R", "S"} or not locant:
+            continue
+        atom_idx = parts.parent_atom_ids_by_locant.get(str(locant))
+        if atom_idx is None:
+            continue
+        bindings.append(
+            NameAtomBinding(
+                stage="assembly",
+                role="absolute_stereo",
+                term=f"{locant}{descriptor}",
+                atom_ids={atom_idx},
+                locants=(str(locant),),
+                emitted_tokens=_absolute_stereo_tokens(str(locant), descriptor, atom_idx),
+            )
+        )
+    for locant, descriptor in parts.stereo_features:
+        if descriptor not in {"E", "Z"} or not locant:
+            continue
+        _bond_locants, atom_ids, bond_ids = _bond_stereo_graph_scope(parts, str(locant))
+        if not atom_ids:
+            continue
+        bindings.append(
+            NameAtomBinding(
+                stage="assembly",
+                role="bond_stereo",
+                term=descriptor,
+                atom_ids=set(atom_ids),
+                bond_ids=set(bond_ids),
+                locants=(str(locant),),
+                emitted_tokens=_bond_stereo_tokens(str(locant), descriptor, set(atom_ids), set(bond_ids)),
+            )
+        )
+    bindings.extend(preserved_assembly_stereo)
     if parts.front_modifiers:
         bindings.append(
             NameAtomBinding(
@@ -328,6 +367,8 @@ def _operation_emitted_tokens(binding: NameAtomBinding) -> tuple[NameTokenBindin
         return _locanted_operation_tokens(binding, charge_from_binding=True)
     if binding.stage == "charge" or binding.role == "parent_charge":
         return _charge_operation_tokens(binding)
+    if binding.stage == "assembly" and binding.role == "relative_stereo":
+        return _relative_stereo_tokens(binding)
     if binding.stage == "assembly" and "stereo" in binding.role:
         return _locanted_operation_tokens(binding)
     if binding.stage == "modifier":
@@ -428,6 +469,114 @@ def _hydro_operation_tokens(operation) -> tuple[NameTokenBinding, ...]:
         )
     )
     return tuple(tokens)
+
+
+def _absolute_stereo_tokens(locant: str, descriptor: str, atom_idx: int) -> tuple[NameTokenBinding, ...]:
+    """Return native tokens for an absolute stereochemical descriptor."""
+
+    return (
+        NameTokenBinding(
+            text=locant,
+            token_kind="locant",
+            ownership="exact",
+            confidence="exact",
+            source="renderer_stereo",
+            grammar_role="absolute_stereo",
+            binding_key="assembly:absolute_stereo",
+            atom_ids={atom_idx},
+            locants=(locant,),
+        ),
+        NameTokenBinding(
+            text=descriptor,
+            token_kind="stereo",
+            ownership="exact",
+            confidence="exact",
+            source="renderer_stereo",
+            grammar_role="absolute_stereo",
+            binding_key="assembly:absolute_stereo",
+            atom_ids={atom_idx},
+            locants=(locant,),
+        ),
+    )
+
+
+def _bond_stereo_graph_scope(parts: AssemblyParts, locant: str) -> tuple[tuple[str, ...], set[int], set[int]]:
+    """Return the graph scope for an E/Z descriptor rendered at a parent locant."""
+
+    for locant_pair, order in parts.parent_bond_orders_by_locants.items():
+        if locant not in locant_pair or order != 2:
+            continue
+        atom_ids = {
+            atom_idx
+            for pair_locant in locant_pair
+            if (atom_idx := parts.parent_atom_ids_by_locant.get(str(pair_locant))) is not None
+        }
+        if len(atom_ids) != 2:
+            continue
+        bond_id = parts.parent_bond_ids_by_locants.get(locant_pair)
+        return (
+            tuple(str(pair_locant) for pair_locant in locant_pair),
+            atom_ids,
+            {bond_id} if bond_id is not None else set(),
+        )
+    atom_idx = parts.parent_atom_ids_by_locant.get(locant)
+    return (locant,), {atom_idx} if atom_idx is not None else set(), set()
+
+
+def _bond_stereo_tokens(
+    locant: str,
+    descriptor: str,
+    atom_ids: set[int],
+    bond_ids: set[int],
+) -> tuple[NameTokenBinding, ...]:
+    """Return native tokens for an E/Z bond stereochemical descriptor."""
+
+    return (
+        NameTokenBinding(
+            text=locant,
+            token_kind="locant",
+            ownership="exact",
+            confidence="exact",
+            source="renderer_stereo",
+            grammar_role="bond_stereo",
+            binding_key="assembly:bond_stereo",
+            atom_ids=set(atom_ids),
+            bond_ids=set(bond_ids),
+            locants=(locant,),
+        ),
+        NameTokenBinding(
+            text=descriptor,
+            token_kind="stereo",
+            ownership="exact",
+            confidence="exact",
+            source="renderer_stereo",
+            grammar_role="bond_stereo",
+            binding_key="assembly:bond_stereo",
+            atom_ids=set(atom_ids),
+            bond_ids=set(bond_ids),
+            locants=(locant,),
+        ),
+    )
+
+
+def _relative_stereo_tokens(binding: NameAtomBinding) -> tuple[NameTokenBinding, ...]:
+    """Return native token metadata for relative cis/trans descriptors."""
+
+    return (
+        NameTokenBinding(
+            text=binding.term,
+            token_kind="stereo",
+            ownership="exact",
+            confidence="exact",
+            source="renderer_stereo",
+            grammar_role=binding.role,
+            binding_key=f"{binding.stage}:{binding.role}",
+            atom_ids=set(binding.atom_ids),
+            bond_ids=set(binding.bond_ids),
+            charge_atom_ids=set(binding.charge_atom_ids),
+            locants=tuple(binding.locants),
+        ),
+    )
 
 
 def _locanted_emitted_tokens(

--- a/src/bluenamer/name_bindings.py
+++ b/src/bluenamer/name_bindings.py
@@ -7,6 +7,7 @@ from .assembly_parts import AssemblyParts, NameAtomBinding, NameTokenBinding
 from .nomenclature import RULES
 from .principal_suffixes import render_principal_suffix
 from .rules import bonds, stems
+from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, BOND_STEREO_DESCRIPTORS
 
 
 def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
@@ -43,7 +44,7 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
             )
         )
     for locant, descriptor in parts.stereo_features:
-        if descriptor not in {"R", "S"} or not locant:
+        if descriptor not in ABSOLUTE_STEREO_DESCRIPTORS or not locant:
             continue
         atom_idx = parts.parent_atom_ids_by_locant.get(str(locant))
         if atom_idx is None:
@@ -59,7 +60,7 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
             )
         )
     for locant, descriptor in parts.stereo_features:
-        if descriptor not in {"E", "Z"} or not locant:
+        if descriptor not in BOND_STEREO_DESCRIPTORS or not locant:
             continue
         _bond_locants, atom_ids, bond_ids = _bond_stereo_graph_scope(parts, str(locant))
         if not atom_ids:
@@ -69,10 +70,10 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
                 stage="assembly",
                 role="bond_stereo",
                 term=descriptor,
-                atom_ids=set(atom_ids),
-                bond_ids=set(bond_ids),
+                atom_ids=atom_ids,
+                bond_ids=bond_ids,
                 locants=(str(locant),),
-                emitted_tokens=_bond_stereo_tokens(str(locant), descriptor, set(atom_ids), set(bond_ids)),
+                emitted_tokens=_bond_stereo_tokens(str(locant), descriptor, atom_ids, bond_ids),
             )
         )
     bindings.extend(preserved_assembly_stereo)
@@ -540,8 +541,8 @@ def _bond_stereo_tokens(
             source="renderer_stereo",
             grammar_role="bond_stereo",
             binding_key="assembly:bond_stereo",
-            atom_ids=set(atom_ids),
-            bond_ids=set(bond_ids),
+            atom_ids=atom_ids,
+            bond_ids=bond_ids,
             locants=(locant,),
         ),
         NameTokenBinding(
@@ -552,8 +553,8 @@ def _bond_stereo_tokens(
             source="renderer_stereo",
             grammar_role="bond_stereo",
             binding_key="assembly:bond_stereo",
-            atom_ids=set(atom_ids),
-            bond_ids=set(bond_ids),
+            atom_ids=atom_ids,
+            bond_ids=bond_ids,
             locants=(locant,),
         ),
     )

--- a/src/bluenamer/parent_pipeline.py
+++ b/src/bluenamer/parent_pipeline.py
@@ -144,7 +144,9 @@ def build_parent_parts(
                 neighbor_locant = str(get_loc(neighbor_idx))
                 bond = mol.get_bond(atom_idx, neighbor_idx)
                 if bond is not None:
-                    parts.parent_bond_orders_by_locants[tuple(sorted((locant, neighbor_locant)))] = bond.order
+                    locant_pair = tuple(sorted((locant, neighbor_locant)))
+                    parts.parent_bond_orders_by_locants[locant_pair] = bond.order
+                    parts.parent_bond_ids_by_locants[locant_pair] = bond.idx
     return parts
 
 

--- a/src/bluenamer/stereo_descriptors.py
+++ b/src/bluenamer/stereo_descriptors.py
@@ -1,0 +1,20 @@
+"""Shared stereochemical descriptor tokens used by renderers and metadata."""
+
+ABSOLUTE_STEREO_DESCRIPTORS = frozenset({"R", "S"})
+BOND_STEREO_DESCRIPTORS = frozenset({"E", "Z"})
+RELATIVE_STEREO_DESCRIPTORS = frozenset({"cis", "trans"})
+
+SEARCHABLE_STEREO_TOKENS = frozenset(
+    descriptor.lower()
+    for descriptor in (
+        *ABSOLUTE_STEREO_DESCRIPTORS,
+        *BOND_STEREO_DESCRIPTORS,
+        *RELATIVE_STEREO_DESCRIPTORS,
+    )
+)
+
+
+def is_searchable_stereo_token(text: str) -> bool:
+    """Return whether a renderer-emitted stereo token may be matched directly."""
+
+    return text.lower() in SEARCHABLE_STEREO_TOKENS

--- a/src/bluenamer/substituent_tokens.py
+++ b/src/bluenamer/substituent_tokens.py
@@ -35,18 +35,58 @@ def _carbon_substituent_tokens(mol: Molecule, atom_ids: set[int], term: str) -> 
     term_text = strip_outer_parentheses(term)
     if not term_text:
         return ()
-    return tuple(
-        NameTokenBinding(
-            text=token_text,
-            token_kind="prefix",
-            source="substituent_renderer",
-            grammar_role="carbon_substituent",
-            binding_key="prefix:carbon_substituent",
-            atom_ids=set(atom_ids),
-            bond_ids=bond_ids_within(mol, atom_ids),
-            charge_atom_ids={idx for idx in atom_ids if mol.atoms[idx].charge != 0},
+    stereo_atoms = {idx for idx in atom_ids if mol.atoms[idx].raw_stereo and not mol.atoms[idx].stereo}
+    tokens = []
+    for token_text in _lexical_tokens(term_text):
+        if token_text.lower() in {"cis", "trans"} and len(stereo_atoms) >= 2:
+            tokens.append(
+                NameTokenBinding(
+                    text=token_text,
+                    token_kind="stereo",
+                    ownership="exact",
+                    confidence="exact",
+                    source="renderer_stereo",
+                    grammar_role="relative_stereo",
+                    binding_key="prefix:relative_stereo",
+                    atom_ids=set(stereo_atoms),
+                    bond_ids=bond_ids_within(mol, stereo_atoms),
+                )
+            )
+            continue
+        tokens.append(
+            NameTokenBinding(
+                text=token_text,
+                token_kind="prefix",
+                source="substituent_renderer",
+                grammar_role="carbon_substituent",
+                binding_key="prefix:carbon_substituent",
+                atom_ids=set(atom_ids),
+                bond_ids=bond_ids_within(mol, atom_ids),
+                charge_atom_ids={idx for idx in atom_ids if mol.atoms[idx].charge != 0},
+            )
         )
-        for token_text in _lexical_tokens(term_text)
+    return tuple(tokens)
+
+
+def _embedded_absolute_stereo_tokens(mol: Molecule, center: int, term_text: str) -> tuple[NameTokenBinding, ...]:
+    """Return graph-bound tokens for directly rendered non-parent R/S descriptors."""
+
+    descriptor = mol.atoms[center].stereo
+    if descriptor not in {"R", "S"}:
+        return ()
+    if not re.search(rf"\({re.escape(descriptor)}\)-", term_text):
+        return ()
+    return (
+        NameTokenBinding(
+            text=descriptor,
+            token_kind="stereo",
+            ownership="exact",
+            confidence="exact",
+            source="renderer_stereo",
+            grammar_role="absolute_stereo",
+            binding_key="prefix:absolute_stereo",
+            atom_ids={center},
+        ),
     )
 
 
@@ -67,7 +107,7 @@ def _generic_heteroatom_substituent_tokens(
     if not center_tokens:
         return ()
 
-    tokens: list[NameTokenBinding] = []
+    tokens: list[NameTokenBinding] = list(_embedded_absolute_stereo_tokens(mol, center, term_text))
     ligand_roots = _heteroatom_ligand_roots(mol, center, atom_ids, upstream_atom)
     ligand_atoms_by_token = _direct_ligand_tokens(mol, center, ligand_roots, atom_ids)
     for token_text, ligand_atoms in ligand_atoms_by_token:
@@ -130,7 +170,7 @@ def _nitrogen_substituent_tokens(
     if not central_tokens:
         return ()
 
-    tokens: list[NameTokenBinding] = []
+    tokens: list[NameTokenBinding] = list(_embedded_absolute_stereo_tokens(mol, nitrogen, term_text))
     uses_n_ligand_locants = "n-" in lower_term or lower_term.startswith("n")
 
     for ligand_root in _heteroatom_ligand_roots(mol, nitrogen, atom_ids, upstream_atom):

--- a/src/bluenamer/substituent_tokens.py
+++ b/src/bluenamer/substituent_tokens.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from .assembly_parts import NameTokenBinding
 from .formatting import strip_outer_parentheses
 from .molecule import Molecule
+from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, RELATIVE_STEREO_DESCRIPTORS
 from .trace_helpers import bond_ids_within
 
 BranchNamer = Callable[..., str]
@@ -36,9 +37,12 @@ def _carbon_substituent_tokens(mol: Molecule, atom_ids: set[int], term: str) -> 
     if not term_text:
         return ()
     stereo_atoms = {idx for idx in atom_ids if mol.atoms[idx].raw_stereo and not mol.atoms[idx].stereo}
+    substituent_bond_ids = bond_ids_within(mol, atom_ids)
+    substituent_charge_atom_ids = {idx for idx in atom_ids if mol.atoms[idx].charge != 0}
+    stereo_bond_ids = bond_ids_within(mol, stereo_atoms) if len(stereo_atoms) >= 2 else set()
     tokens = []
     for token_text in _lexical_tokens(term_text):
-        if token_text.lower() in {"cis", "trans"} and len(stereo_atoms) >= 2:
+        if token_text.lower() in RELATIVE_STEREO_DESCRIPTORS and len(stereo_atoms) >= 2:
             tokens.append(
                 NameTokenBinding(
                     text=token_text,
@@ -49,7 +53,7 @@ def _carbon_substituent_tokens(mol: Molecule, atom_ids: set[int], term: str) -> 
                     grammar_role="relative_stereo",
                     binding_key="prefix:relative_stereo",
                     atom_ids=set(stereo_atoms),
-                    bond_ids=bond_ids_within(mol, stereo_atoms),
+                    bond_ids=set(stereo_bond_ids),
                 )
             )
             continue
@@ -61,8 +65,8 @@ def _carbon_substituent_tokens(mol: Molecule, atom_ids: set[int], term: str) -> 
                 grammar_role="carbon_substituent",
                 binding_key="prefix:carbon_substituent",
                 atom_ids=set(atom_ids),
-                bond_ids=bond_ids_within(mol, atom_ids),
-                charge_atom_ids={idx for idx in atom_ids if mol.atoms[idx].charge != 0},
+                bond_ids=set(substituent_bond_ids),
+                charge_atom_ids=set(substituent_charge_atom_ids),
             )
         )
     return tuple(tokens)
@@ -72,7 +76,7 @@ def _embedded_absolute_stereo_tokens(mol: Molecule, center: int, term_text: str)
     """Return graph-bound tokens for directly rendered non-parent R/S descriptors."""
 
     descriptor = mol.atoms[center].stereo
-    if descriptor not in {"R", "S"}:
+    if descriptor not in ABSOLUTE_STEREO_DESCRIPTORS:
         return ()
     if not re.search(rf"\({re.escape(descriptor)}\)-", term_text):
         return ()

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -3670,6 +3670,66 @@ def test_relative_ring_stereo_is_rendered_inside_substituent():
     assert name_smiles("CC(=O)N[C@H]1CC[C@@H](C)CC1") == "N-(cis-4-methylcyclohexyl)acetamide"
 
 
+def test_relative_ring_stereo_tokens_bind_to_stereocenter_atoms():
+    parent = analyze_smiles("C[C@H]1CC[C@@H](N)CC1")
+    parent_assembly = [step for step in parent.decisions if step.decision == "assembled component name"][-1]
+    parent_cis = next(token for token in parent_assembly.data["name_token_spans"] if token["text"] == "cis")
+
+    assert parent_cis["atoms"] == [1, 4]
+    assert parent_cis["token_kind"] == "stereo"
+    assert parent_cis["source"] == "renderer_stereo"
+    assert parent_cis["confidence"] != "fallback"
+
+    substituent = analyze_smiles("CC(=O)N[C@H]1CC[C@@H](C)CC1")
+    substituent_assembly = [step for step in substituent.decisions if step.decision == "assembled component name"][-1]
+    substituent_cis = next(token for token in substituent_assembly.data["name_token_spans"] if token["text"] == "cis")
+
+    assert substituent.name == "N-(cis-4-methylcyclohexyl)acetamide"
+    assert substituent_cis["atoms"] == [4, 7]
+    assert substituent_cis["token_kind"] == "stereo"
+    assert substituent_cis["source"] == "renderer_stereo"
+    assert substituent_cis["confidence"] != "fallback"
+
+
+def test_heteroatom_subgraph_absolute_stereo_token_binds_to_center_atom():
+    mol = Molecule()
+    mol.add_atom("C", 0)
+    mol.add_atom("S", 1, stereo="R")
+    mol.add_atom("O", 2)
+    mol.add_bond(0, 1, order=1)
+    mol.add_bond(1, 2, order=2)
+
+    term = name_heteroatom_subgraph(mol, 1, exclude_atoms={0}, upstream_atom=0, branch_namer=_empty_branch_namer)
+    tokens = graph_bound_substituent_tokens(
+        mol,
+        root=1,
+        atom_ids={1, 2},
+        term=term,
+        upstream_atom=0,
+        exclude_atoms={0},
+        branch_namer=_empty_branch_namer,
+    )
+    stereo = next(token for token in tokens if token.text == "R")
+
+    assert term == "(R)-sulfinyl"
+    assert stereo.atom_ids == {1}
+    assert stereo.token_kind == "stereo"
+    assert stereo.source == "renderer_stereo"
+
+
+def test_locanted_ez_stereo_token_binds_to_double_bond_scope():
+    result = analyze_smiles(r"C/C=C\C")
+    assembly = [step for step in result.decisions if step.decision == "assembled component name"][-1]
+    z_token = next(token for token in assembly.data["name_token_spans"] if token["text"] == "Z")
+
+    assert result.name == "(2Z)-but-2-ene"
+    assert z_token["token_kind"] == "stereo"
+    assert z_token["source"] == "renderer_stereo"
+    assert z_token["confidence"] != "fallback"
+    assert z_token["atoms"]
+    assert z_token["bonds"]
+
+
 def test_scoped_small_ring_stereo_does_not_emit_unsupported_relative_locant_descriptors():
     name = name_smiles("CN1CCC[C@](O)(CC(=O)N[C@]2(C)C[C@H](NC(=O)CCC3CC3)C2)C1")
 

--- a/src/bluenamer/tests/test_public_api.py
+++ b/src/bluenamer/tests/test_public_api.py
@@ -106,6 +106,23 @@ def test_substituent_tree_preserves_nested_branch_hierarchy_and_flat_trace():
     assert assembly.data["name_token_spans"]
 
 
+def test_absolute_stereo_tokens_bind_to_stereocenter_atoms():
+    result = name(
+        "O=C(O)C[C@H](O)C[C@H](O)CCn2c(c(c(c2c1ccc(F)cc1)c3ccccc3)C(=O)Nc4ccccc4)C(C)C",
+        include_trace=True,
+    )
+    assembly = [step for step in result.decisions if step.decision == "assembled component name"][-1]
+    token_spans = assembly.data["name_token_spans"]
+
+    assert [(token["text"], token["atoms"], token["token_kind"], token["source"]) for token in token_spans[:4]] == [
+        ("3", [4], "locant", "renderer_stereo"),
+        ("R", [4], "stereo", "renderer_stereo"),
+        ("5", [7], "locant", "renderer_stereo"),
+        ("R", [7], "stereo", "renderer_stereo"),
+    ]
+    assert all(token["confidence"] != "fallback" for token in token_spans[:4])
+
+
 def test_naming_errors_become_result_error_not_exception():
     # Empty SMILES is a well-defined "no atoms" path; assert at a different angle
     # by feeding clearly malformed text — the engine must capture, not raise.

--- a/src/bluenamer/tests/test_public_api.py
+++ b/src/bluenamer/tests/test_public_api.py
@@ -114,13 +114,22 @@ def test_absolute_stereo_tokens_bind_to_stereocenter_atoms():
     assembly = [step for step in result.decisions if step.decision == "assembled component name"][-1]
     token_spans = assembly.data["name_token_spans"]
 
-    assert [(token["text"], token["atoms"], token["token_kind"], token["source"]) for token in token_spans[:4]] == [
-        ("3", [4], "locant", "renderer_stereo"),
-        ("R", [4], "stereo", "renderer_stereo"),
-        ("5", [7], "locant", "renderer_stereo"),
-        ("R", [7], "stereo", "renderer_stereo"),
+    expected_tokens = [
+        ("3", 4, "locant", "renderer_stereo"),
+        ("R", 4, "stereo", "renderer_stereo"),
+        ("5", 7, "locant", "renderer_stereo"),
+        ("R", 7, "stereo", "renderer_stereo"),
     ]
-    assert all(token["confidence"] != "fallback" for token in token_spans[:4])
+    for text, atom, token_kind, source in expected_tokens:
+        token = next(
+            token
+            for token in token_spans
+            if token["text"] == text
+            and token["atoms"] == [atom]
+            and token["token_kind"] == token_kind
+            and token["source"] == source
+        )
+        assert token["confidence"] != "fallback"
 
 
 def test_naming_errors_become_result_error_not_exception():


### PR DESCRIPTION
## Summary

This PR improves name-token binding for stereochemical descriptors so generated names can more accurately map stereochemistry tokens back to the underlying molecular graph.

It adds graph-aware token metadata for absolute R/S stereochemistry, E/Z double-bond stereochemistry, and cis/trans relative stereochemistry in parent names and substituents. The change also preserves bond IDs for parent locant pairs, allowing E/Z descriptors to bind not only to atoms but also to the relevant double bond. 

## Changes

* Adds `parent_bond_ids_by_locants` to assembly state and populates it during parent part construction.
* Emits structured `renderer_stereo` tokens for:

  * absolute R/S descriptors such as `(3R)` and `(5R)`
  * E/Z descriptors such as `(2Z)`
  * cis/trans relative ring stereochemistry
  * embedded non-parent stereocenters in heteroatom substituents
* Updates native token span matching so one-character stereo descriptors like `R`, `S`, `E`, and `Z` are searchable when they are emitted as stereo tokens.
* Prioritizes renderer-provided stereo bindings when building final token spans.
* Ensures nested N-substituent branches carry emitted graph-bound substituent tokens into assembled component metadata.

## Tests

Adds coverage for:

* cis/trans ring stereo tokens binding to the correct stereocenter atoms
* substituent-level cis/trans token binding
* embedded heteroatom R/S stereo token binding
* E/Z token binding to the relevant double-bond scope
* public API trace output for absolute stereo token spans without fallback confidence

## Summary by Sourcery

Improve stereochemical descriptor bindings so renderer-emitted stereo tokens map directly to stereocenters and double bonds in both parent structures and substituents.

New Features:
- Bind absolute R/S descriptors at parent locants to stereocenter atoms and emit dedicated renderer_stereo token metadata.
- Bind E/Z double-bond descriptors at parent locants to both participating atoms and the underlying double bond where available.
- Emit renderer_stereo tokens for relative cis/trans descriptors on small rings and carbon substituents, including substituent-level ring stereo.
- Emit graph-bound stereo tokens for embedded non-parent absolute stereocenters in heteroatom substituents.

Enhancements:
- Track parent bond IDs by locant pairs during parent construction to support bond-level stereo bindings.
- Allow native token matching to treat renderer-emitted stereo tokens (including single-character R/S/E/Z) as searchable and prioritize them when constructing final token spans.
- Extend N-substituent branch handling to propagate graph-bound substituent tokens into assembled component metadata.

Tests:
- Add analysis tests to verify cis/trans ring stereo tokens and E/Z stereo tokens bind to the correct atoms and bonds with non-fallback confidence.
- Add substituent token tests to ensure relative cis/trans and embedded heteroatom R/S descriptors bind to the correct graph scope.
- Add public API trace tests confirming absolute stereo token spans bind to the intended stereocenter atoms without fallback confidence.