### PR TITLE
feat: better describer and human describer

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ OpenAPI docs are served at `http://localhost:8000/docs`.
 
 ## Human-like description
 
-OpenBlue can generate uncanny human-like description.
+OpenBlue can generate uncanny human-like descriptions.
 ```python
 
 from bluenamer import describe_human

--- a/README.md
+++ b/README.md
@@ -164,6 +164,32 @@ curl -X POST localhost:8000/describe -H 'content-type: application/json' \
 
 OpenAPI docs are served at `http://localhost:8000/docs`.
 
+
+## Human-like description
+
+OpenBlue can generate uncanny human-like description.
+```python
+
+from bluenamer import describe_human
+
+d = describe_human("CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
+print(d.text)
+
+""" Processed SMILES: Cn1cnc2c1c(=O)n(C)c(=O)n2C
+Atom ids in that SMILES: C{0}n{1}1c{2}n{3}c{4}2c{5}1c{6}(=O{7})n{8}(C{13})c{9}(=O{10})n{11}2C{12}
+
+The molecule is named 2,4,7-trimethyl-2,4,7,9-tetraazabicyclo[4.3.0]nona-1(6),8-diene-3,5-dione.
+
+The molecule is built around a 9-membered bicyclic [4.3.0] heteroskeleton.
+Within that parent framework, there is nitrogen at positions 2 (atom id 11), 4 (atom id 8), 7 (atom id 1), and 9 (atom id 3).
+Within that parent framework, there is a double bond between position 1 (atom id 4) and position 6 (atom id 5) and a double bond between position 8 (atom id 2) and position 9 (atom id 3).
+The principal characteristic feature is oxo groups at positions 3 (atom id 9) and 5 (atom id 6).
+Attached to this framework are methyl groups at positions 2 (atom id 11), 4 (atom id 8), and 7 (atom id 1). """
+
+```
+
+
+
 ## Debugging
 
 Token binding metadata is currently available through the assembly decision trace when `include_trace=True`.

--- a/src/bluenamer/__init__.py
+++ b/src/bluenamer/__init__.py
@@ -2,9 +2,10 @@
 
 from collections.abc import Iterable
 
-from .describer import DescribedComponent, Description, describe
+from .describer import DescribedComponent, Description, DescriptionTokenSummary, describe
 from .engine import DEFAULT_NAMING_ENGINE, NamingEngine, NamingRequest, NamingResult
 from .functional_groups import register_group_detector
+from .human_descriptor import HumanDescription, describe_human
 from .molecule import (
     AtomBinding,
     BondBinding,
@@ -71,7 +72,9 @@ __all__ = [
     "DecisionTrace",
     "DescribedComponent",
     "Description",
+    "DescriptionTokenSummary",
     "FunctionalGroupMetadata",
+    "HumanDescription",
     "NameAnalysis",
     "NamingEngine",
     "NamingIntent",
@@ -87,6 +90,7 @@ __all__ = [
     "__version__",
     "analyze_smiles",
     "describe",
+    "describe_human",
     "name",
     "name_many",
     "name_smiles",

--- a/src/bluenamer/assembler.py
+++ b/src/bluenamer/assembler.py
@@ -329,6 +329,12 @@ def post_process_name(name: str) -> str:
     return _post_process_name(name)
 
 
+def post_process_rewrite_rules():
+    """Return shared post-processing rewrites for metadata-aware assembly paths."""
+
+    return (("post_process_name", _post_process_name),)
+
+
 def assemble_name_raw(parts: AssemblyParts) -> str:
     fused_ion_candidate = select_fused_ion_operation(parts)
     if fused_ion_candidate is not None:

--- a/src/bluenamer/assembly_parts.py
+++ b/src/bluenamer/assembly_parts.py
@@ -21,6 +21,10 @@ class NameTokenBinding:
     bond_ids: set[int] = field(default_factory=set)
     charge_atom_ids: set[int] = field(default_factory=set)
     locants: tuple[str, ...] = ()
+    render_order: int | None = None
+    match_priority: int = 0
+    left_context: str = ""
+    right_context: str = ""
 
 
 @dataclass

--- a/src/bluenamer/cli.py
+++ b/src/bluenamer/cli.py
@@ -86,9 +86,9 @@ def _cmd_batch(args: argparse.Namespace) -> int:
 
 
 def _cmd_describe(args: argparse.Namespace) -> int:
-    description = describe_one(args.smiles)
+    description = describe_one(args.smiles, debugging_tokens=args.debug_tokens)
     if args.json:
-        json.dump(description.to_dict(), sys.stdout, indent=2)
+        json.dump(description.to_dict(debugging_tokens=args.debug_tokens), sys.stdout, indent=2)
         sys.stdout.write("\n")
     else:
         sys.stdout.write(str(description) + "\n")
@@ -133,6 +133,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_describe.add_argument("smiles")
     p_describe.add_argument("--json", action="store_true", help="emit structured Description as JSON")
+    p_describe.add_argument("--debug-tokens", action="store_true", help="include experimental token binding details")
     p_describe.set_defaults(func=_cmd_describe)
 
     return parser

--- a/src/bluenamer/component_modifiers.py
+++ b/src/bluenamer/component_modifiers.py
@@ -2,7 +2,7 @@
 
 from typing import Literal, Protocol, overload
 
-from .assembly_parts import AssemblyParts, SubstituentItem
+from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem
 from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
@@ -169,6 +169,12 @@ def add_component_n_substituents(
                         branch_exclude,
                         branch_namer,
                     )
+                    emitted_tokens = _with_n_substituent_locant_token(
+                        emitted_tokens,
+                        loc_prefix,
+                        single_n,
+                        bond_ids_within(mol, {single_n, n_sub}),
+                    )
                     if _use_hydrazone_suffix_modifier(parts, principal_key):
                         parts.principal_suffix_modifiers.append(
                             SubstituentItem(
@@ -203,6 +209,30 @@ def _charged_atoms(mol: Molecule, atom_ids: set[int]) -> set[int]:
     """Return formally charged atoms from an already named graph fragment."""
 
     return {atom_idx for atom_idx in atom_ids if mol.atoms[atom_idx].charge != 0}
+
+
+def _with_n_substituent_locant_token(
+    emitted_tokens: tuple[NameTokenBinding, ...],
+    locant: str,
+    nitrogen_atom: int,
+    branch_bonds: set[int],
+) -> tuple[NameTokenBinding, ...]:
+    """Bind N-substituent locants to the principal nitrogen atom."""
+
+    locant_token = NameTokenBinding(
+        text=locant,
+        token_kind="locant",
+        source="n_substituent_locant",
+        grammar_role="n_substituent",
+        binding_key="prefix:n_substituent_locant",
+        atom_ids={nitrogen_atom},
+        bond_ids=set(branch_bonds),
+        locants=(locant,),
+    )
+    return (
+        locant_token,
+        *tuple(token for token in emitted_tokens if not (token.token_kind == "locant" and token.text == locant)),
+    )
 
 
 def _nitrogen_substituent_name(

--- a/src/bluenamer/component_namer.py
+++ b/src/bluenamer/component_namer.py
@@ -135,6 +135,7 @@ def collect_component_branch_substituents(
     *,
     name_subgraph: SubgraphNamer,
     name_spiro_subgraph: SpiroSubgraphNamer,
+    emit_metadata: bool = True,
 ) -> None:
     """Collect ordinary branch and spiro substituents from the component parent."""
 
@@ -167,16 +168,26 @@ def collect_component_branch_substituents(
 
         for n_idx in n_subs:
             if n_idx not in main_set and n_idx not in principal_involved_atom_ids and n_idx not in handled_prefix_atoms:
-                branch_decisions = DecisionTrace()
-                branch_name, branch_trace, branch_tree = name_subgraph(
-                    mol,
-                    n_idx,
-                    sub_exclude | main_set,
-                    upstream_atom=c_idx,
-                    return_trace=True,
-                    return_tree=True,
-                    decision_trace=branch_decisions,
-                )
+                branch_decisions = DecisionTrace() if emit_metadata else None
+                if emit_metadata:
+                    branch_name, branch_trace, branch_tree = name_subgraph(
+                        mol,
+                        n_idx,
+                        sub_exclude | main_set,
+                        upstream_atom=c_idx,
+                        return_trace=True,
+                        return_tree=True,
+                        decision_trace=branch_decisions,
+                    )
+                else:
+                    branch_name = name_subgraph(
+                        mol,
+                        n_idx,
+                        sub_exclude | main_set,
+                        upstream_atom=c_idx,
+                    )
+                    branch_trace = []
+                    branch_tree = None
                 if branch_name:
                     branch_exclude = sub_exclude | main_set
                     branch_atoms = subgraph_component(mol, n_idx, branch_exclude)
@@ -187,18 +198,22 @@ def collect_component_branch_substituents(
                             atom_ids=branch_atoms,
                             bond_ids=bond_ids_within(mol, branch_atoms | {c_idx}),
                             charge_atom_ids=_charged_atoms(mol, branch_atoms),
-                            emitted_tokens=graph_bound_substituent_tokens(
-                                mol,
-                                n_idx,
-                                branch_atoms,
-                                branch_name,
-                                c_idx,
-                                branch_exclude,
-                                name_subgraph,
+                            emitted_tokens=(
+                                graph_bound_substituent_tokens(
+                                    mol,
+                                    n_idx,
+                                    branch_atoms,
+                                    branch_name,
+                                    c_idx,
+                                    branch_exclude,
+                                    name_subgraph,
+                                )
+                                if emit_metadata
+                                else ()
                             ),
-                            trace_segments=branch_trace,
-                            nested_decisions=decision_trace_data(branch_decisions),
-                            substituent_tree=branch_tree,
+                            trace_segments=branch_trace if emit_metadata else [],
+                            nested_decisions=decision_trace_data(branch_decisions) if emit_metadata else [],
+                            substituent_tree=branch_tree if emit_metadata else None,
                         )
                     )
 
@@ -241,9 +256,12 @@ def _shortcut_component_result(
     stage: str,
     role: str,
     bindings: list[NameAtomBinding] | tuple[NameAtomBinding, ...] | None = None,
+    emit_metadata: bool = True,
 ) -> tuple[str, list[dict], list[dict], list[dict]]:
     """Build audited metadata for a component shortcut name."""
 
+    if not emit_metadata:
+        return name, [], [], []
     parts = AssemblyParts(parent_length=max(1, len(component_atoms)), parent_atom_ids=set(component_atoms))
     parts.name_atom_bindings = (
         list(bindings)
@@ -280,6 +298,8 @@ def name_component(
 ):
     """Name one connected component or recursive component of a molecule."""
 
+    emit_metadata = return_trace or return_tree or decision_trace is not None
+
     single_atom_name = single_atom_component_name(mol, component_atoms)
     if single_atom_name:
         name, bindings, token_spans, rewrite_history = _shortcut_component_result(
@@ -288,6 +308,7 @@ def name_component(
             single_atom_name,
             stage="shortcut",
             role="single_atom_component",
+            emit_metadata=emit_metadata,
         )
         trace_decision(
             decision_trace,
@@ -329,6 +350,7 @@ def name_component(
             stage="shortcut",
             role=structural_parent_result.role,
             bindings=structural_parent_result.bindings,
+            emit_metadata=emit_metadata,
         )
         trace_decision(
             decision_trace,
@@ -382,6 +404,7 @@ def name_component(
             stage="shortcut",
             role="anhydride_component",
             bindings=anhydride_result.bindings,
+            emit_metadata=emit_metadata,
         )
         trace_decision(
             decision_trace,
@@ -492,6 +515,7 @@ def name_component(
         state.sub_exclude,
         name_subgraph=name_subgraph,
         name_spiro_subgraph=name_spiro_subgraph,
+        emit_metadata=emit_metadata,
     )
     retained_fused = production_retained_fused_parent(
         mol,
@@ -572,10 +596,11 @@ def name_component(
     refresh_name_atom_bindings(parts)
     parts.stereo_audit_issues = list(audit_stereochemistry(mol, parts).issues)
     assert_component_fully_named(mol, state.component_atoms, parts, "<component>")
-    name = assemble_parent_name(mol, parts, numbered_path, get_loc)
-    final_result = NameAssemblyResult.from_final_name(name, parts.name_atom_bindings)
-    parts.name_token_spans = token_span_trace_data(final_result)
-    assert_final_name_assembly(mol, state.component_atoms, parts, final_result)
+    name = assemble_parent_name(mol, parts, numbered_path, get_loc, emit_metadata=emit_metadata)
+    if emit_metadata:
+        final_result = NameAssemblyResult.from_final_name(name, parts.name_atom_bindings)
+        parts.name_token_spans = token_span_trace_data(final_result)
+        assert_final_name_assembly(mol, state.component_atoms, parts, final_result)
     trace_decision(
         decision_trace,
         TracePhase.ASSEMBLY,

--- a/src/bluenamer/describer.py
+++ b/src/bluenamer/describer.py
@@ -1,19 +1,21 @@
-"""Natural-language description of how a structure was named.
+"""Natural-language descriptions backed by naming metadata.
 
-`describe(smiles)` returns a `Description` that bundles a deterministic
-multi-line prose explanation plus the structured components it was
-rendered from. The prose is built directly from the `DecisionTrace` and
-`trace_segments` that the engine already emits, so the output is
-faithful to what the namer actually did — not a separate model.
-
-Same input → same output. Safe to use in dataset pipelines.
+The describer is intentionally not a second naming engine. It calls the
+normal namer with tracing enabled and renders prose from the resulting
+decision trace, graph-bound token spans, and substituent tree. That keeps the
+description aligned with the name that was actually generated, including
+recursive substituents and token-to-atom confidence metadata.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import re
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
 
-from .engine import DEFAULT_NAMING_ENGINE, NamingRequest, _extract_rules_hit
+from .engine import DEFAULT_NAMING_ENGINE, NamingRequest, NamingResult, _extract_rules_hit
 from .molecule import TracePhase, TraceStep
 
 
@@ -26,8 +28,30 @@ class DescribedComponent:
 
 
 @dataclass(frozen=True)
+class DescriptionTokenSummary:
+    """Aggregate view of final-name token binding metadata."""
+
+    total: int = 0
+    by_kind: dict[str, int] = field(default_factory=dict)
+    by_ownership: dict[str, int] = field(default_factory=dict)
+    by_confidence: dict[str, int] = field(default_factory=dict)
+    by_source: dict[str, int] = field(default_factory=dict)
+    fallback_tokens: tuple[dict, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {
+            "total": self.total,
+            "by_kind": dict(self.by_kind),
+            "by_ownership": dict(self.by_ownership),
+            "by_confidence": dict(self.by_confidence),
+            "by_source": dict(self.by_source),
+            "fallback_tokens": list(self.fallback_tokens),
+        }
+
+
+@dataclass(frozen=True)
 class Description:
-    """Result of `describe`. ``str(d)`` returns the rendered prose."""
+    """Result of :func:`describe`. ``str(d)`` returns the rendered prose."""
 
     smiles: str
     name: str
@@ -35,6 +59,9 @@ class Description:
     components: tuple[DescribedComponent, ...] = ()
     rules_hit: tuple[str, ...] = ()
     rule_hints: tuple[str, ...] = ()
+    token_summary: DescriptionTokenSummary = field(default_factory=DescriptionTokenSummary)
+    token_spans: tuple[dict, ...] = ()
+    substituent_tree: tuple[dict, ...] = ()
 
     def __str__(self) -> str:
         return "\n\n".join(self.paragraphs)
@@ -52,11 +79,95 @@ class Description:
             "components": [{"phase": c.phase, "text": c.text} for c in self.components],
             "rules_hit": list(self.rules_hit),
             "rule_hints": list(self.rule_hints),
+            "token_summary": self.token_summary.to_dict(),
+            "token_spans": list(self.token_spans),
+            "substituent_tree": list(self.substituent_tree),
         }
+
+
+def describe(smiles: str) -> Description:
+    """Render a deterministic metadata-backed description for ``smiles``."""
+
+    result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, include_trace=True))
+    token_spans = tuple(_collect_token_spans(result))
+    token_summary = _summarize_tokens(token_spans)
+
+    if result.error:
+        summary = f"The structure {smiles} could not be named: {result.error}."
+    elif not result.name:
+        summary = f"The structure {smiles} could not be named by the current ruleset."
+    else:
+        summary = f"The molecule {smiles} is named **{result.name}**."
+
+    components = tuple(_decision_components(result))
+    paragraphs: list[str] = [summary]
+    if components:
+        paragraphs.append("\n".join(c.text for c in components))
+
+    tree_lines = _substituent_tree_lines(result.substituent_tree)
+    if tree_lines:
+        paragraphs.append("Component and substituent structure:\n" + "\n".join(tree_lines))
+
+    token_lines = _token_binding_lines(token_summary, token_spans)
+    if token_lines:
+        paragraphs.append("Name-token graph bindings:\n" + "\n".join(token_lines))
+
+    seg_lines = _trace_segment_lines(result.trace_segments, result.substituent_tree)
+    if seg_lines:
+        paragraphs.append("Name pieces contributed by the trace:\n" + "\n".join(seg_lines))
+
+    rules, hints = _extract_rules_hit(result.trace_segments)
+    if rules:
+        paragraphs.append("IUPAC Blue Book rules applied: " + ", ".join(rules) + ".")
+
+    return Description(
+        smiles=smiles,
+        name=result.name,
+        paragraphs=tuple(paragraphs),
+        components=components,
+        rules_hit=rules,
+        rule_hints=hints,
+        token_summary=token_summary,
+        token_spans=token_spans,
+        substituent_tree=tuple(result.substituent_tree),
+    )
 
 
 def _plural(n: int, word: str) -> str:
     return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+
+def _decision_components(result: NamingResult) -> list[DescribedComponent]:
+    components: list[DescribedComponent] = []
+    seen: set[tuple[str, str]] = set()
+    for step in result.decisions:
+        text = _render_decision_step(step)
+        if not text:
+            continue
+        key = (step.phase.value, text)
+        if key in seen:
+            continue
+        seen.add(key)
+        components.append(DescribedComponent(phase=step.phase.value, text=text))
+    return components
+
+
+def _render_decision_step(step: TraceStep) -> str | None:
+    if step.phase == TracePhase.PARSE:
+        return _render_parse(step)
+    if step.phase == TracePhase.COMPONENT:
+        return _render_component(step)
+    if step.phase == TracePhase.PERCEPTION:
+        return _render_perception(step)
+    if step.phase == TracePhase.PRIORITY:
+        return _render_priority(step)
+    if step.phase == TracePhase.PARENT_SELECTION:
+        return _render_parent_selection(step)
+    if step.phase == TracePhase.NUMBERING:
+        return _render_numbering(step)
+    if step.phase == TracePhase.ASSEMBLY:
+        return _render_assembly(step)
+    return None
 
 
 def _render_parse(step: TraceStep) -> str | None:
@@ -73,15 +184,16 @@ def _render_component(step: TraceStep) -> str | None:
         return None
     if len(components) == 1:
         return "The structure is a single connected component, named in one piece."
-    return f"The structure splits into {len(components)} connected components, named independently and joined."
+    sizes = ", ".join(str(len(component)) for component in components)
+    return f"The structure splits into {len(components)} connected components with atom counts {sizes}."
 
 
 def _render_perception(step: TraceStep) -> str | None:
     groups = step.data.get("groups") or []
     if not groups:
         return "Perception found no nameable principal groups."
-    names = sorted({g.get("key", "?") for g in groups})
-    principals = sorted({g.get("key", "?") for g in groups if g.get("principal_candidate")})
+    names = sorted({str(g.get("key", "?")) for g in groups})
+    principals = sorted({str(g.get("key", "?")) for g in groups if g.get("principal_candidate")})
     if not principals:
         return f"Perception identified non-principal groups: {', '.join(names)}."
     return (
@@ -94,122 +206,393 @@ def _render_priority(step: TraceStep) -> str | None:
     key = step.data.get("principal_key")
     if not key:
         return None
-    role = (
-        "treated as a substituent"
-        if step.data.get("is_substituent")
-        else "selected as the principal characteristic group"
-    )
-    return f"The {key} group is {role}, per the registry seniority order."
+    role = "treated as a substituent" if step.data.get("is_substituent") else "selected as the principal group"
+    return f"The {key} group is {role} by the registered seniority order."
 
 
 def _render_parent_selection(step: TraceStep) -> str | None:
     parent = step.data.get("parent_atoms") or []
     if not parent:
         return None
-    if step.data.get("is_bicycle"):
-        kind = "bicyclic ring system"
-    elif step.data.get("is_ring"):
-        kind = "ring"
-    else:
-        kind = "acyclic chain"
-    return f"The parent skeleton is a {len(parent)}-atom {kind} (atoms {sorted(parent)})."
+    kind = _parent_kind(step.data)
+    descriptor = step.data.get("polycycle_descriptor")
+    descriptor_text = f" with descriptor {descriptor}" if descriptor else ""
+    return f"The parent skeleton is a {len(parent)}-atom {kind}{descriptor_text} (atoms {sorted(parent)})."
 
 
 def _render_numbering(step: TraceStep) -> str | None:
     locants = step.data.get("locants") or {}
     if not locants:
         return None
-    sample = sorted(locants.items(), key=lambda kv: kv[1])[:4]
-    sample_str = ", ".join(f"atom {a}→{loc}" for a, loc in sample)
-    return f"Numbering minimizes locants for the principal group and substituents (e.g. {sample_str})."
+    sample = sorted(locants.items(), key=lambda kv: str(kv[1]))[:6]
+    sample_str = ", ".join(f"atom {atom}->{loc}" for atom, loc in sample)
+    return f"Parent numbering was selected from the final atom-to-locant map ({sample_str})."
 
 
 def _render_assembly(step: TraceStep) -> str | None:
     name = step.data.get("name")
     if name is None:
         return None
-    components = step.data.get("components")
-    if components is not None:
-        if len(components) == 1:
-            return f"The final assembled name is **{name}**."
-        return f"The final assembled name is **{name}** ({len(components)} pieces joined)."
-    sub_count = step.data.get("substituent_count")
-    if sub_count is None:
-        return None
-    return f"Component assembled as **{name}** with {_plural(sub_count, 'substituent')}."
+    if "components" in step.data:
+        components = step.data.get("components") or []
+        if len(components) <= 1:
+            return None
+        return f"The final assembled name is **{name}** from {len(components)} named components."
+    return None
 
 
-_RENDERERS: dict[TracePhase, callable] = {
-    TracePhase.PARSE: _render_parse,
-    TracePhase.COMPONENT: _render_component,
-    TracePhase.PERCEPTION: _render_perception,
-    TracePhase.PRIORITY: _render_priority,
-    TracePhase.PARENT_SELECTION: _render_parent_selection,
-    TracePhase.NUMBERING: _render_numbering,
-    TracePhase.ASSEMBLY: _render_assembly,
-}
+def _parent_kind(data: dict) -> str:
+    if data.get("is_spiro"):
+        return "spiro ring system"
+    if data.get("is_bicycle"):
+        return "bicyclic ring system"
+    if data.get("is_polycycle"):
+        return "polycyclic ring system"
+    if data.get("is_ring"):
+        return "ring"
+    return "acyclic chain"
 
 
-def _trace_segment_lines(trace_segments: list[dict]) -> list[str]:
-    lines = []
-    for seg in trace_segments:
-        if not isinstance(seg, dict):
-            continue
-        label = seg.get("label") or seg.get("key")
-        terms = seg.get("name_terms") or []
-        if not label or not terms:
-            continue
-        atoms = seg.get("atoms") or []
-        suffix = f" (atoms {atoms})" if atoms else ""
-        lines.append(f"- {label}: contributes “{terms[0]}”{suffix}.")
-    return lines
-
-
-def describe(smiles: str) -> Description:
-    """Render a natural-language explanation of how ``smiles`` is named."""
-
-    result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, include_trace=True))
-
-    if not result.name:
-        summary = f"The structure {smiles} could not be named by the current ruleset."
-    else:
-        summary = f"The molecule {smiles} is named **{result.name}**."
-
-    components: list[DescribedComponent] = []
-    seen: set[tuple[str, str]] = set()
+def _collect_token_spans(result: NamingResult) -> list[dict]:
+    tokens: list[dict] = []
+    seen: set[tuple] = set()
     for step in result.decisions:
-        renderer = _RENDERERS.get(step.phase)
-        if renderer is None:
+        for token in step.data.get("name_token_spans") or []:
+            if not isinstance(token, dict):
+                continue
+            key = (
+                token.get("start"),
+                token.get("end"),
+                token.get("text"),
+                tuple(token.get("atoms") or ()),
+                tuple(token.get("bonds") or ()),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            tokens.append(dict(token))
+    for token in _walk_tree_tokens(result.substituent_tree):
+        key = (
+            token.get("start"),
+            token.get("end"),
+            token.get("text"),
+            tuple(token.get("atoms") or ()),
+            tuple(token.get("bonds") or ()),
+        )
+        if key not in seen:
+            seen.add(key)
+            tokens.append(dict(token))
+    return sorted(tokens, key=lambda t: (int(t.get("start", 10**9)), int(t.get("end", 10**9)), str(t.get("text", ""))))
+
+
+def _walk_tree_tokens(nodes: Iterable[dict]) -> Iterable[dict]:
+    for node in nodes:
+        if not isinstance(node, dict):
             continue
-        text = renderer(step)
-        if not text:
-            continue
-        key = (step.phase.value, text)
-        if key in seen:
-            continue
-        seen.add(key)
-        components.append(DescribedComponent(phase=step.phase.value, text=text))
+        for token in node.get("name_token_spans") or ():
+            if isinstance(token, dict):
+                yield token
+        for segment in node.get("trace_segments") or ():
+            if isinstance(segment, dict):
+                for token in segment.get("name_token_spans") or ():
+                    if isinstance(token, dict):
+                        yield token
+        for key in ("substituents", "replacement_prefixes"):
+            yield from _walk_tree_tokens(node.get(key) or ())
+        principal = node.get("principal_group")
+        if isinstance(principal, dict):
+            yield from _walk_tree_tokens((principal,))
+        parent = node.get("parent")
+        if isinstance(parent, dict):
+            yield from _walk_tree_tokens((parent,))
 
-    paragraphs: list[str] = [summary]
-    if components:
-        paragraphs.append("\n".join(c.text for c in components))
 
-    seg_lines = _trace_segment_lines(result.trace_segments)
-    if seg_lines:
-        paragraphs.append("Name pieces contributed by the trace:\n" + "\n".join(seg_lines))
-
-    rules, hints = _extract_rules_hit(result.trace_segments)
-    if rules:
-        paragraphs.append("IUPAC Blue Book rules applied: " + ", ".join(rules) + ".")
-
-    return Description(
-        smiles=smiles,
-        name=result.name,
-        paragraphs=tuple(paragraphs),
-        components=tuple(components),
-        rules_hit=rules,
-        rule_hints=hints,
+def _summarize_tokens(tokens: tuple[dict, ...] | list[dict]) -> DescriptionTokenSummary:
+    by_kind = Counter(str(t.get("token_kind", "unknown")) for t in tokens)
+    by_ownership = Counter(str(t.get("ownership", "unknown")) for t in tokens)
+    by_confidence = Counter(str(t.get("confidence", "unknown")) for t in tokens)
+    by_source = Counter(str(t.get("source", "unknown")) for t in tokens)
+    fallback_tokens = tuple(dict(t) for t in tokens if _is_fallback_token(t))
+    return DescriptionTokenSummary(
+        total=len(tokens),
+        by_kind=dict(sorted(by_kind.items())),
+        by_ownership=dict(sorted(by_ownership.items())),
+        by_confidence=dict(sorted(by_confidence.items())),
+        by_source=dict(sorted(by_source.items())),
+        fallback_tokens=fallback_tokens,
     )
 
 
-__all__ = ["DescribedComponent", "Description", "describe"]
+def _is_fallback_token(token: dict) -> bool:
+    confidence = str(token.get("confidence", "")).lower()
+    ownership = str(token.get("ownership", "")).lower()
+    source = str(token.get("source", "")).lower()
+    return (
+        "fallback" in confidence
+        or "fallback" in ownership
+        or "fallback" in source
+        or confidence in {"ambiguous", "unbound"}
+        or ownership in {"ambiguous", "unbound"}
+    )
+
+
+def _token_binding_lines(summary: DescriptionTokenSummary, tokens: tuple[dict, ...]) -> list[str]:
+    if summary.total == 0:
+        return ["- No final-name token spans were emitted."]
+    lines = [f"- {summary.total} final-name tokens carry graph-binding metadata."]
+    for token in tokens[:12]:
+        lines.append(f"- {_token_line(token)}")
+    if len(tokens) > 12:
+        lines.append(f"- ... {len(tokens) - 12} more tokens are available in `token_spans`.")
+    if summary.by_confidence:
+        lines.append("- Confidence: " + _counter_text(summary.by_confidence) + ".")
+    if summary.fallback_tokens:
+        names = ", ".join(str(t.get("text", "")) for t in summary.fallback_tokens[:8])
+        more = "" if len(summary.fallback_tokens) <= 8 else f", plus {len(summary.fallback_tokens) - 8} more"
+        lines.append(f"- Fallback or ambiguous tokens: {names}{more}.")
+    else:
+        lines.append("- No fallback or ambiguous token bindings were needed.")
+    return lines
+
+
+def _token_line(token: dict) -> str:
+    text = token.get("text", "")
+    kind = token.get("token_kind", "unknown")
+    atoms = _atom_text(token.get("atoms") or [])
+    bonds = _bond_text(token.get("bonds") or [])
+    confidence = token.get("confidence", "unknown")
+    source = token.get("source", "unknown")
+    locants = token.get("locants") or []
+    locant_text = f"; locants {','.join(str(locant) for locant in locants)}" if locants else ""
+    return f"\"{text}\" [{kind}] -> {atoms}; {bonds}{locant_text}; confidence={confidence}; source={source}."
+
+
+def _counter_text(counter: dict[str, int]) -> str:
+    return ", ".join(f"{key}={value}" for key, value in sorted(counter.items()))
+
+
+def _substituent_tree_lines(trees: list[dict]) -> list[str]:
+    lines: list[str] = []
+    for idx, tree in enumerate(trees, start=1):
+        lines.extend(_describe_tree_node(tree, depth=0, label=f"Component {idx}"))
+    return lines
+
+
+def _describe_tree_node(node: dict, *, depth: int, label: str | None = None) -> list[str]:
+    if not isinstance(node, dict):
+        return []
+    indent = "  " * depth
+    name = str(node.get("name") or "(unnamed)")
+    atoms = node.get("atoms") or []
+    bonds = node.get("bonds") or []
+    prefix = f"{label}: " if label else ""
+    lines = [f"{indent}- {prefix}{name} covers {_plural(len(atoms), 'atom')} and {_plural(len(bonds), 'bond')}."]
+
+    parent = node.get("parent")
+    if isinstance(parent, dict):
+        parent_line = _parent_tree_line(parent)
+        if parent_line:
+            lines.append(f"{indent}  {parent_line}")
+
+    principal = node.get("principal_group")
+    if isinstance(principal, dict):
+        group = principal.get("key")
+        locants = _locant_text(principal.get("locants") or [])
+        atoms_text = _atom_text(principal.get("atoms") or [])
+        lines.append(f"{indent}  Principal group: {group}{locants} ({atoms_text}).")
+
+    for item in node.get("replacement_prefixes") or []:
+        lines.append(f"{indent}  Replacement prefix: {_named_item_text(item)}.")
+    for item in node.get("unsaturations") or []:
+        locants = _unsaturation_locant_text(item.get("locants") or [])
+        bonds_text = _bond_text(item.get("bonds") or [])
+        lines.append(f"{indent}  Unsaturation: {item.get('bond_key')}{locants} ({bonds_text}).")
+    for item in node.get("hydro_operations") or []:
+        locants = _locant_text(item.get("locants") or [])
+        atoms_text = _atom_text(item.get("atom_ids") or [])
+        lines.append(f"{indent}  Hydro operation: {item.get('operation_kind')}{locants} ({atoms_text}).")
+    for item in node.get("parent_charges") or []:
+        locant = item.get("locant")
+        atom = item.get("atom_id")
+        charge = item.get("charge")
+        lines.append(f"{indent}  Parent charge: {item.get('symbol')} {charge:+d} at locant {locant} on atom {atom}.")
+
+    substituents = node.get("substituents") or []
+    for child in substituents:
+        locants = _locant_text(child.get("locants") or [])
+        child_label = f"Substituent{locants}"
+        lines.extend(_describe_tree_node(child, depth=depth + 1, label=child_label))
+    return lines
+
+
+def _parent_tree_line(parent: dict) -> str:
+    atoms = parent.get("atoms") or []
+    retained = parent.get("retained_name")
+    kind = "parent"
+    if parent.get("is_spiro"):
+        kind = "spiro parent"
+    elif parent.get("is_bicycle"):
+        kind = "bicyclic parent"
+    elif parent.get("is_polycycle"):
+        kind = "polycyclic parent"
+    elif parent.get("is_ring"):
+        kind = "ring parent"
+    else:
+        kind = "chain parent"
+    descriptor = ""
+    if parent.get("bicycle_descriptor"):
+        descriptor = f" descriptor {parent.get('bicycle_descriptor')}"
+    elif parent.get("spiro_descriptor"):
+        descriptor = f" descriptor {parent.get('spiro_descriptor')}"
+    elif parent.get("polycycle_descriptor"):
+        descriptor = f" descriptor {parent.get('polycycle_descriptor')}"
+    retained_text = f" retained as {retained}" if retained else ""
+    locant_map = parent.get("atom_ids_by_locant") or {}
+    locants = ", ".join(f"{loc}->{atom}" for loc, atom in sorted(locant_map.items(), key=lambda item: str(item[0]))[:8])
+    map_text = f"; locants {locants}" if locants else ""
+    return f"Parent: {kind} with {_plural(len(atoms), 'atom')}{descriptor}{retained_text}{map_text}."
+
+
+def _named_item_text(item: dict) -> str:
+    name = item.get("name") or item.get("key") or "(unnamed)"
+    locants = _locant_text(item.get("locants") or [])
+    atoms = _atom_text(item.get("atoms") or item.get("atom_ids") or [])
+    return f"{name}{locants} ({atoms})"
+
+
+def _locant_text(locants: list[Any]) -> str:
+    return "" if not locants else " at " + ",".join(str(locant) for locant in locants)
+
+
+def _unsaturation_locant_text(locants: list[Any]) -> str:
+    if not locants:
+        return ""
+    displayed = ",".join(str(locant) for locant in locants)
+    explanations = []
+    for locant in locants:
+        text = str(locant)
+        match = re.fullmatch(r"([^()]+)\(([^()]+)\)", text)
+        if match:
+            explanations.append(f"{text} means a multiple bond between locants {match.group(1)} and {match.group(2)}")
+    if not explanations:
+        return f" at {displayed}"
+    return f" at {displayed}; {'; '.join(explanations)}"
+
+
+def _atom_text(atoms: list[Any]) -> str:
+    return "atoms " + ",".join(str(atom) for atom in atoms) if atoms else "no atom metadata"
+
+
+def _bond_text(bonds: list[Any]) -> str:
+    return "bonds " + ",".join(str(bond) for bond in bonds) if bonds else "no bond metadata"
+
+
+def _trace_segment_lines(trace_segments: list[dict], trees: list[dict]) -> list[str]:
+    tree_lines = _tree_trace_segment_lines(trees)
+    if tree_lines:
+        return tree_lines
+    lines = []
+    for seg in trace_segments:
+        line = _trace_segment_line(seg, depth=0)
+        if line:
+            lines.append(line)
+    return lines
+
+
+def _tree_trace_segment_lines(trees: list[dict]) -> list[str]:
+    lines: list[str] = []
+    seen: set[tuple] = set()
+    for tree in trees:
+        lines.extend(_node_trace_segment_lines(tree, depth=0, seen=seen))
+    return lines
+
+
+def _node_trace_segment_lines(node: dict, *, depth: int, seen: set[tuple]) -> list[str]:
+    if not isinstance(node, dict):
+        return []
+    lines: list[str] = []
+    segments = [seg for seg in node.get("trace_segments") or [] if isinstance(seg, dict)]
+    children = [child for child in node.get("substituents") or [] if isinstance(child, dict)]
+    child_atoms = set().union(*(set(child.get("atoms") or []) for child in children)) if children else set()
+
+    parent = node.get("parent") if isinstance(node.get("parent"), dict) else {}
+    parent_atoms = set(parent.get("atoms") or [])
+    principal = node.get("principal_group") if isinstance(node.get("principal_group"), dict) else {}
+    principal_atoms = set(principal.get("atoms") or [])
+
+    ordered: list[dict] = []
+    ordered.extend(_pop_segments(segments, lambda seg: (seg.get("label") == "parent skeleton") and _same_atoms(seg, parent_atoms)))
+    ordered.extend(_pop_segments(segments, lambda seg: bool(principal_atoms) and _same_atoms(seg, principal_atoms)))
+    ordered.extend(_pop_segments(segments, lambda seg: _is_local_segment(seg, node, child_atoms)))
+
+    for seg in ordered:
+        if not isinstance(seg, dict):
+            continue
+        key = (
+            seg.get("key"),
+            tuple(seg.get("atoms") or ()),
+            tuple(seg.get("bonds") or ()),
+            tuple(seg.get("name_terms") or ()),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        line = _trace_segment_line(seg, depth=depth)
+        if line:
+            lines.append(line)
+    for child in children:
+        lines.extend(_node_trace_segment_lines(child, depth=depth + 1, seen=seen))
+    return lines
+
+
+def _pop_segments(segments: list[dict], predicate) -> list[dict]:
+    selected: list[dict] = []
+    remaining: list[dict] = []
+    for seg in segments:
+        if predicate(seg):
+            selected.append(seg)
+        else:
+            remaining.append(seg)
+    segments[:] = remaining
+    return selected
+
+
+def _same_atoms(seg: dict, atoms: set[int]) -> bool:
+    return bool(atoms) and set(seg.get("atoms") or []) == atoms
+
+
+def _is_local_segment(seg: dict, node: dict, child_atoms: set[int]) -> bool:
+    atoms = set(seg.get("atoms") or [])
+    if not atoms:
+        return False
+    node_atoms = set(node.get("atoms") or [])
+    if node_atoms and not atoms <= node_atoms:
+        return False
+    return not atoms <= child_atoms
+
+
+def _trace_segment_line(seg: dict, *, depth: int) -> str | None:
+    if not isinstance(seg, dict):
+        return None
+    label = seg.get("label") or seg.get("key")
+    terms = seg.get("name_terms") or []
+    if not label or not terms:
+        return None
+    atoms = seg.get("atoms") or []
+    bonds = seg.get("bonds") or []
+    graph = []
+    if atoms:
+        graph.append(_atom_text(atoms))
+    if bonds:
+        graph.append(_bond_text(bonds))
+    suffix = f" ({'; '.join(graph)})" if graph else ""
+    indent = "  " * depth
+    return f"{indent}- {label}: contributes \"{terms[0]}\"{suffix}."
+
+
+__all__ = [
+    "DescribedComponent",
+    "Description",
+    "DescriptionTokenSummary",
+    "describe",
+]

--- a/src/bluenamer/describer.py
+++ b/src/bluenamer/describer.py
@@ -374,7 +374,7 @@ def _token_line(token: dict) -> str:
     source = token.get("source", "unknown")
     locants = token.get("locants") or []
     locant_text = f"; locants {','.join(str(locant) for locant in locants)}" if locants else ""
-    return f"\"{text}\" [{kind}] -> {atoms}; {bonds}{locant_text}; confidence={confidence}; source={source}."
+    return f'"{text}" [{kind}] -> {atoms}; {bonds}{locant_text}; confidence={confidence}; source={source}.'
 
 
 def _counter_text(counter: dict[str, int]) -> str:
@@ -531,7 +531,9 @@ def _node_trace_segment_lines(node: dict, *, depth: int, seen: set[tuple]) -> li
     principal_atoms = set(principal.get("atoms") or [])
 
     ordered: list[dict] = []
-    ordered.extend(_pop_segments(segments, lambda seg: (seg.get("label") == "parent skeleton") and _same_atoms(seg, parent_atoms)))
+    ordered.extend(
+        _pop_segments(segments, lambda seg: (seg.get("label") == "parent skeleton") and _same_atoms(seg, parent_atoms))
+    )
     ordered.extend(_pop_segments(segments, lambda seg: bool(principal_atoms) and _same_atoms(seg, principal_atoms)))
     ordered.extend(_pop_segments(segments, lambda seg: _is_local_segment(seg, node, child_atoms)))
 
@@ -597,7 +599,7 @@ def _trace_segment_line(seg: dict, *, depth: int) -> str | None:
         graph.append(_bond_text(bonds))
     suffix = f" ({'; '.join(graph)})" if graph else ""
     indent = "  " * depth
-    return f"{indent}- {label}: contributes \"{terms[0]}\"{suffix}."
+    return f'{indent}- {label}: contributes "{terms[0]}"{suffix}.'
 
 
 __all__ = [

--- a/src/bluenamer/describer.py
+++ b/src/bluenamer/describer.py
@@ -2,9 +2,10 @@
 
 The describer is intentionally not a second naming engine. It calls the
 normal namer with tracing enabled and renders prose from the resulting
-decision trace, graph-bound token spans, and substituent tree. That keeps the
-description aligned with the name that was actually generated, including
-recursive substituents and token-to-atom confidence metadata.
+decision trace and substituent tree. Optional debug mode also exposes
+graph-bound token spans. That keeps the description aligned with the name
+that was actually generated without showing experimental token metadata by
+default.
 """
 
 from __future__ import annotations
@@ -62,6 +63,7 @@ class Description:
     token_summary: DescriptionTokenSummary = field(default_factory=DescriptionTokenSummary)
     token_spans: tuple[dict, ...] = ()
     substituent_tree: tuple[dict, ...] = ()
+    debugging_tokens: bool = False
 
     def __str__(self) -> str:
         return "\n\n".join(self.paragraphs)
@@ -70,8 +72,9 @@ class Description:
     def summary(self) -> str:
         return self.paragraphs[0] if self.paragraphs else ""
 
-    def to_dict(self) -> dict:
-        return {
+    def to_dict(self, *, debugging_tokens: bool | None = None) -> dict:
+        include_tokens = self.debugging_tokens if debugging_tokens is None else debugging_tokens
+        payload = {
             "smiles": self.smiles,
             "name": self.name,
             "summary": self.summary,
@@ -79,18 +82,24 @@ class Description:
             "components": [{"phase": c.phase, "text": c.text} for c in self.components],
             "rules_hit": list(self.rules_hit),
             "rule_hints": list(self.rule_hints),
-            "token_summary": self.token_summary.to_dict(),
-            "token_spans": list(self.token_spans),
             "substituent_tree": list(self.substituent_tree),
         }
+        if include_tokens:
+            payload["token_summary"] = self.token_summary.to_dict()
+            payload["token_spans"] = list(self.token_spans)
+        return payload
 
 
-def describe(smiles: str) -> Description:
+def describe(
+    smiles: str,
+    *,
+    debugging_tokens: bool = False,
+) -> Description:
     """Render a deterministic metadata-backed description for ``smiles``."""
 
     result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, include_trace=True))
-    token_spans = tuple(_collect_token_spans(result))
-    token_summary = _summarize_tokens(token_spans)
+    token_spans = tuple(_collect_token_spans(result)) if debugging_tokens else ()
+    token_summary = _summarize_tokens(token_spans) if debugging_tokens else DescriptionTokenSummary()
 
     if result.error:
         summary = f"The structure {smiles} could not be named: {result.error}."
@@ -108,8 +117,8 @@ def describe(smiles: str) -> Description:
     if tree_lines:
         paragraphs.append("Component and substituent structure:\n" + "\n".join(tree_lines))
 
-    token_lines = _token_binding_lines(token_summary, token_spans)
-    if token_lines:
+    token_lines = _token_binding_lines(token_summary, token_spans) if debugging_tokens else []
+    if debugging_tokens and token_lines:
         paragraphs.append("Name-token graph bindings:\n" + "\n".join(token_lines))
 
     seg_lines = _trace_segment_lines(result.trace_segments, result.substituent_tree)
@@ -130,6 +139,7 @@ def describe(smiles: str) -> Description:
         token_summary=token_summary,
         token_spans=token_spans,
         substituent_tree=tuple(result.substituent_tree),
+        debugging_tokens=debugging_tokens,
     )
 
 

--- a/src/bluenamer/human_descriptor.py
+++ b/src/bluenamer/human_descriptor.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from rdkit import Chem
+
 from .engine import DEFAULT_NAMING_ENGINE, NamingRequest, NamingResult
 from .graph_io import read_smiles
 from .molecule import Molecule
+from .rules import stems
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,9 @@ def describe_human(smiles: str) -> HumanDescription:
     result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, include_trace=True))
     mol = read_smiles(smiles)
     paragraphs: list[str] = []
+    smiles_sentence = _processed_smiles_sentence(smiles)
+    if smiles_sentence:
+        paragraphs.append(smiles_sentence)
     if result.error:
         paragraphs.append(f"The structure could not be named: {result.error}.")
     elif not result.name:
@@ -65,6 +71,63 @@ def describe_human(smiles: str) -> HumanDescription:
             paragraphs.append(description)
 
     return HumanDescription(smiles=smiles, name=result.name, paragraphs=tuple(paragraphs), result=result)
+
+
+def _processed_smiles_sentence(smiles: str) -> str:
+    rdmol = Chem.MolFromSmiles(smiles)
+    if rdmol is None:
+        return ""
+    processed = Chem.MolToSmiles(rdmol, canonical=False)
+    atom_order = _smiles_atom_output_order(rdmol)
+    annotated = _annotated_smiles_atom_order(processed, atom_order)
+    if annotated:
+        return f"Processed SMILES: {processed}\nAtom ids in that SMILES: {annotated}"
+    return f"Processed SMILES: {processed}\nAtom ids in that SMILES order: {atom_order}"
+
+
+def _smiles_atom_output_order(rdmol: Chem.Mol) -> list[int]:
+    """Return RDKit's atom order for the most recent SMILES write."""
+
+    if not rdmol.HasProp("_smilesAtomOutputOrder"):
+        return []
+    raw = rdmol.GetProp("_smilesAtomOutputOrder")
+    return [int(part) for part in raw.strip("[]").split(",") if part.strip()]
+
+
+def _annotated_smiles_atom_order(smiles: str, atom_order: list[int]) -> str:
+    if not atom_order:
+        return ""
+    pieces: list[str] = []
+    atom_idx = 0
+    pos = 0
+    while pos < len(smiles):
+        token, end = _next_smiles_atom_token(smiles, pos)
+        if token is None:
+            pieces.append(smiles[pos])
+            pos += 1
+            continue
+        if atom_idx >= len(atom_order):
+            return ""
+        pieces.append(f"{token}{{{atom_order[atom_idx]}}}")
+        atom_idx += 1
+        pos = end
+    if atom_idx != len(atom_order):
+        return ""
+    return "".join(pieces)
+
+
+def _next_smiles_atom_token(smiles: str, pos: int) -> tuple[str | None, int]:
+    char = smiles[pos]
+    if char == "[":
+        end = smiles.find("]", pos + 1)
+        if end != -1:
+            return smiles[pos : end + 1], end + 1
+        return None, pos
+    if smiles.startswith(("Cl", "Br"), pos):
+        return smiles[pos : pos + 2], pos + 2
+    if char in {"B", "C", "N", "O", "P", "S", "F", "I", "b", "c", "n", "o", "p", "s"}:
+        return char, pos + 1
+    return None, pos
 
 
 def _describe_node(node: dict[str, Any], mol: Molecule, *, subject: str, depth: int) -> str:
@@ -90,7 +153,7 @@ def _describe_node(node: dict[str, Any], mol: Molecule, *, subject: str, depth: 
     if charge_sentence:
         sentences.append(charge_sentence)
 
-    substituent_sentence = _substituent_summary_sentence(node)
+    substituent_sentence = _substituent_summary_sentence(node, mol)
     if substituent_sentence:
         sentences.append(substituent_sentence)
 
@@ -98,14 +161,14 @@ def _describe_node(node: dict[str, Any], mol: Molecule, *, subject: str, depth: 
     for child in _iter_child_nodes(node):
         if not _should_expand_child(child):
             continue
-        child_subject = _child_subject(child)
+        child_subject = _child_subject(child, parent, mol)
         rendered = _describe_node(child, mol, subject=child_subject, depth=depth + 1)
         if rendered:
             child_sentences.append(rendered)
 
     if child_sentences:
         sentences.extend(child_sentences)
-    return " ".join(sentences)
+    return "\n".join(sentences)
 
 
 def _parent_sentence(subject: str, parent: dict[str, Any]) -> str:
@@ -147,7 +210,7 @@ def _heteroatom_sentence(parent: dict[str, Any]) -> str:
     phrases = []
     for symbol, locants in groups:
         element = _element_name(symbol)
-        phrases.append(f"{element} at {_positions(locants)}")
+        phrases.append(f"{element} at {_positions(locants, parent)}")
     return "Within that parent framework, there is " + _join_phrases(phrases) + "."
 
 
@@ -169,17 +232,18 @@ def _unsaturation_sentence(node: dict[str, Any], parent: dict[str, Any], mol: Mo
         kind = "triple" if item.get("bond_key") == "triple" else "double"
         for loc_pair in _unsaturation_position_pairs(item, parent, mol):
             if len(loc_pair) == 2:
-                bond_phrases.append(f"a {kind} bond between positions {loc_pair[0]} and {loc_pair[1]}")
+                bond_phrases.append(
+                    f"a {kind} bond between {_position_label(loc_pair[0], parent)} "
+                    f"and {_position_label(loc_pair[1], parent)}"
+                )
             elif loc_pair:
-                bond_phrases.append(f"a {kind} bond at position {loc_pair[0]}")
+                bond_phrases.append(f"a {kind} bond at {_position_label(loc_pair[0], parent)}")
     if not bond_phrases:
         return ""
     return "Within that parent framework, there is " + _join_phrases(bond_phrases) + "."
 
 
-def _unsaturation_position_pairs(
-    item: dict[str, Any], parent: dict[str, Any], mol: Molecule
-) -> list[tuple[str, ...]]:
+def _unsaturation_position_pairs(item: dict[str, Any], parent: dict[str, Any], mol: Molecule) -> list[tuple[str, ...]]:
     atom_to_locant = {int(atom): str(locant) for locant, atom in (parent.get("atom_ids_by_locant") or {}).items()}
     pairs: list[tuple[str, ...]] = []
     used_bonds: set[int] = set()
@@ -217,7 +281,7 @@ def _principal_group_sentence(node: dict[str, Any]) -> str:
     label = _principal_group_label(key, len(locants))
     article = "" if label.endswith("s") else "an " if label[0].lower() in "aeiou" else "a "
     if locants:
-        return f"The principal characteristic feature is {article}{label} at {_positions(locants)}."
+        return f"The principal characteristic feature is {article}{label} at {_positions(locants, node.get('parent') or {})}."
     return f"The principal characteristic feature is {article}{label}."
 
 
@@ -246,26 +310,28 @@ def _charge_sentence(node: dict[str, Any]) -> str:
         value = int(charge.get("charge") or 0)
         if value:
             sign = "positive" if value > 0 else "negative"
-            phrases.append(f"a {sign} {_element_name(symbol)} center at position {locant}")
+            phrases.append(
+                f"a {sign} {_element_name(symbol)} center at {_position_label(str(locant), node.get('parent') or {})}"
+            )
     if not phrases:
         return ""
     return "The parent carries " + _join_phrases(phrases) + "."
 
 
-def _substituent_summary_sentence(node: dict[str, Any]) -> str:
+def _substituent_summary_sentence(node: dict[str, Any], mol: Molecule) -> str:
     children = list(_iter_child_nodes(node, recurse_group_instances=False))
     if not children:
         return ""
     phrases = []
     has_plural = False
     for child in children:
-        name = _clean_name(child.get("name") or "substituent")
+        name = _display_substituent_name(child, mol)
         locants = [str(loc) for loc in child.get("locants") or ()]
         count = _child_instance_count(child)
         has_plural = has_plural or count > 1
         display_name = _pluralized_substituent_name(name, count)
         if locants:
-            phrases.append(f"{display_name} at {_positions(locants)}")
+            phrases.append(f"{display_name} at {_positions(locants, node.get('parent') or {})}")
         else:
             phrases.append(display_name)
     verb = "are" if has_plural or len(phrases) > 1 else "is"
@@ -276,23 +342,21 @@ def _iter_child_nodes(node: dict[str, Any], *, recurse_group_instances: bool = T
     for child in node.get("substituents") or ():
         if child.get("kind") == "grouped_substituent_instances":
             if recurse_group_instances:
-                for instance in child.get("instances") or ():
-                    yield instance
+                yield from child.get("instances") or ()
             else:
                 yield child
             continue
         yield child
     functional_prefix = node.get("functional_prefix")
     if isinstance(functional_prefix, dict):
-        for ligand in functional_prefix.get("ligands") or ():
-            yield ligand
+        yield from functional_prefix.get("ligands") or ()
 
 
-def _child_subject(child: dict[str, Any]) -> str:
-    name = _clean_name(child.get("name") or "substituent")
+def _child_subject(child: dict[str, Any], containing_parent: dict[str, Any], mol: Molecule) -> str:
+    name = _display_substituent_name(child, mol)
     locants = [str(loc) for loc in child.get("locants") or ()]
     if locants:
-        return f"The {name} substituent at {_positions(locants)}"
+        return f"The {name} substituent at {_positions(locants, containing_parent)}"
     return f"The {name} substituent"
 
 
@@ -320,10 +384,100 @@ def _child_instance_count(child: dict[str, Any]) -> int:
 
 def _pluralized_substituent_name(name: str, count: int) -> str:
     if count <= 1:
-        return f"a {name} group"
-    if name.endswith("yl"):
-        return f"{name} groups"
+        return f"{_article_for(name)} {name} group"
     return f"{name} groups"
+
+
+def _article_for(word: str) -> str:
+    return "an" if word[:1].lower() in "aeiou" else "a"
+
+
+def _display_substituent_name(child: dict[str, Any], mol: Molecule) -> str:
+    """Return the local substituent role from tree and graph metadata."""
+
+    if child.get("kind") == "grouped_substituent_instances":
+        for instance in child.get("instances") or ():
+            if isinstance(instance, dict):
+                return _display_substituent_name(instance, mol)
+
+    parent = child.get("parent") if isinstance(child.get("parent"), dict) else {}
+    parent_label = _parent_substituent_label(parent)
+    if parent_label:
+        return parent_label
+    graph_label = _graph_substituent_label(child, mol)
+    if graph_label:
+        return graph_label
+    return _readable_key(str(child.get("kind") or "substituent"))
+
+
+def _parent_substituent_label(parent: dict[str, Any]) -> str:
+    suffix = parent.get("substituent_suffix") if isinstance(parent.get("substituent_suffix"), dict) else {}
+    suffix_text = str(suffix.get("suffix") or "")
+    if not suffix_text:
+        return ""
+    retained = str(parent.get("retained_name") or "")
+    if retained == "benzene" and suffix_text == "yl":
+        return "phenyl"
+    length = parent.get("parent_length")
+    if isinstance(length, int) and length > 0 and not retained:
+        try:
+            return stems.stem_for(length) + suffix_text
+        except KeyError:
+            return ""
+    if retained:
+        return f"{retained}-derived"
+    return ""
+
+
+def _graph_substituent_label(child: dict[str, Any], mol: Molecule) -> str:
+    own_atoms = _local_role_atoms(child)
+    if not own_atoms:
+        return ""
+    symbols = [mol.atoms[idx].symbol for idx in sorted(own_atoms) if idx in mol.atoms]
+    symbol_set = set(symbols)
+    if len(own_atoms) == 1 and symbols:
+        symbol = symbols[0]
+        has_nested_ligand = bool(list(_iter_child_nodes(child)))
+        return {
+            "N": "amino",
+            "O": "oxy" if has_nested_ligand else "hydroxy",
+            "S": "sulfanyl",
+            "F": "fluoro",
+            "Cl": "chloro",
+            "Br": "bromo",
+            "I": "iodo",
+        }.get(symbol, "")
+    if "S" in symbol_set and symbols.count("O") >= 2:
+        return "sulfonyl"
+    if "S" in symbol_set and symbols.count("O") == 1:
+        return "sulfinyl"
+    if "C" in symbol_set and "O" in symbol_set and _has_double_bond_between(mol, own_atoms, "C", "O"):
+        return "carbonyl"
+    return ""
+
+
+def _local_role_atoms(child: dict[str, Any]) -> set[int]:
+    atoms = {int(atom) for atom in child.get("atoms") or ()}
+    nested_atoms: set[int] = set()
+    for nested in _iter_child_nodes(child):
+        nested_atoms.update(int(atom) for atom in nested.get("atoms") or ())
+    local = atoms - nested_atoms
+    return local or atoms
+
+
+def _has_double_bond_between(mol: Molecule, atom_ids: set[int], symbol_a: str, symbol_b: str) -> bool:
+    for atom_idx in atom_ids:
+        atom = mol.atoms.get(atom_idx)
+        if atom is None or atom.symbol != symbol_a:
+            continue
+        for neighbor in mol.get_neighbors(atom_idx):
+            if neighbor not in atom_ids:
+                continue
+            neighbor_atom = mol.atoms.get(neighbor)
+            bond = mol.get_bond(atom_idx, neighbor)
+            if neighbor_atom is not None and neighbor_atom.symbol == symbol_b and bond is not None and bond.order == 2:
+                return True
+    return False
 
 
 def _element_name(symbol: str) -> str:
@@ -344,12 +498,31 @@ def _readable_key(key: str) -> str:
     return key.replace("_", " ").replace("-", " ")
 
 
-def _clean_name(name: str) -> str:
-    return name.strip().strip("()")
+def _positions(locants: list[str], parent: dict[str, Any] | None = None) -> str:
+    sorted_locants = _sort_locants(locants)
+    if len(sorted_locants) == 1:
+        return _position_label(sorted_locants[0], parent or {})
+    return "positions " + _join_phrases([_locant_with_atom_id(locant, parent or {}) for locant in sorted_locants])
 
 
-def _positions(locants: list[str]) -> str:
-    return "position " + locants[0] if len(locants) == 1 else "positions " + _join_phrases(_sort_locants(locants))
+def _position_label(locant: str, parent: dict[str, Any] | None = None) -> str:
+    return "position " + _locant_with_atom_id(locant, parent or {})
+
+
+def _locant_with_atom_id(locant: str, parent: dict[str, Any]) -> str:
+    atom_id = _atom_id_for_locant(locant, parent)
+    return f"{locant} (atom id {atom_id})" if atom_id is not None else locant
+
+
+def _atom_id_for_locant(locant: str, parent: dict[str, Any]) -> int | None:
+    locant_map = parent.get("atom_ids_by_locant") if isinstance(parent, dict) else None
+    if not isinstance(locant_map, dict):
+        return None
+    atom_id = locant_map.get(str(locant))
+    try:
+        return int(atom_id)
+    except (TypeError, ValueError):
+        return None
 
 
 def _join_phrases(items: list[str]) -> str:

--- a/src/bluenamer/human_descriptor.py
+++ b/src/bluenamer/human_descriptor.py
@@ -1,0 +1,374 @@
+"""Human-oriented molecule descriptions from structured naming metadata.
+
+This module is separate from :mod:`bluenamer.describer` on purpose.  The
+existing describer is useful for debugging the naming pipeline and token
+bindings; this descriptor renders a compact, chemistry-facing explanation from
+the nested component/substituent tree.  It does not inspect final token spans.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .engine import DEFAULT_NAMING_ENGINE, NamingRequest, NamingResult
+from .graph_io import read_smiles
+from .molecule import Molecule
+
+
+@dataclass(frozen=True)
+class HumanDescription:
+    """Human-oriented description of the generated name."""
+
+    smiles: str
+    name: str
+    paragraphs: tuple[str, ...]
+    result: NamingResult
+
+    @property
+    def text(self) -> str:
+        return "\n\n".join(self.paragraphs)
+
+    def __str__(self) -> str:
+        return self.text
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "smiles": self.smiles,
+            "name": self.name,
+            "paragraphs": list(self.paragraphs),
+            "text": self.text,
+        }
+
+
+def describe_human(smiles: str) -> HumanDescription:
+    """Return a readable metadata-backed description for ``smiles``.
+
+    The descriptor intentionally uses ``substituent_tree`` and graph metadata,
+    not final ``name_token_spans``.  That keeps the prose independent from the
+    currently evolving token-span alignment layer.
+    """
+
+    result = DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, include_trace=True))
+    mol = read_smiles(smiles)
+    paragraphs: list[str] = []
+    if result.error:
+        paragraphs.append(f"The structure could not be named: {result.error}.")
+    elif not result.name:
+        paragraphs.append("The structure could not be named by the current ruleset.")
+    else:
+        paragraphs.append(f"The molecule is named {result.name}.")
+
+    for node in result.substituent_tree:
+        description = _describe_node(node, mol, subject="The molecule", depth=0)
+        if description:
+            paragraphs.append(description)
+
+    return HumanDescription(smiles=smiles, name=result.name, paragraphs=tuple(paragraphs), result=result)
+
+
+def _describe_node(node: dict[str, Any], mol: Molecule, *, subject: str, depth: int) -> str:
+    sentences: list[str] = []
+    parent = node.get("parent") or {}
+    parent_sentence = _parent_sentence(subject, parent)
+    if parent_sentence:
+        sentences.append(parent_sentence)
+
+    hetero_sentence = _heteroatom_sentence(parent)
+    if hetero_sentence:
+        sentences.append(hetero_sentence)
+
+    unsaturation_sentence = _unsaturation_sentence(node, parent, mol)
+    if unsaturation_sentence:
+        sentences.append(unsaturation_sentence)
+
+    principal_sentence = _principal_group_sentence(node)
+    if principal_sentence:
+        sentences.append(principal_sentence)
+
+    charge_sentence = _charge_sentence(node)
+    if charge_sentence:
+        sentences.append(charge_sentence)
+
+    substituent_sentence = _substituent_summary_sentence(node)
+    if substituent_sentence:
+        sentences.append(substituent_sentence)
+
+    child_sentences: list[str] = []
+    for child in _iter_child_nodes(node):
+        if not _should_expand_child(child):
+            continue
+        child_subject = _child_subject(child)
+        rendered = _describe_node(child, mol, subject=child_subject, depth=depth + 1)
+        if rendered:
+            child_sentences.append(rendered)
+
+    if child_sentences:
+        sentences.extend(child_sentences)
+    return " ".join(sentences)
+
+
+def _parent_sentence(subject: str, parent: dict[str, Any]) -> str:
+    if not parent:
+        return ""
+    retained = parent.get("retained_name")
+    parent_kind = _parent_kind(parent)
+    if retained:
+        return f"{subject} is built around the retained {retained} parent, {parent_kind}."
+    return f"{subject} is built around a {parent_kind}."
+
+
+def _parent_kind(parent: dict[str, Any]) -> str:
+    length = parent.get("parent_length")
+    length_text = f"{length}-membered " if isinstance(length, int) and length > 0 else ""
+    hetero = _hetero_locants(parent)
+    skeleton = "heteroskeleton" if hetero else "carbon skeleton"
+    if parent.get("is_spiro"):
+        descriptor = ".".join(str(x) for x in parent.get("spiro_descriptor") or ())
+        prefix = f"spiro[{descriptor}] " if descriptor else "spiro "
+        return f"{length_text}{prefix}{skeleton}".strip()
+    if parent.get("is_bicycle"):
+        descriptor = ".".join(str(x) for x in parent.get("bicycle_descriptor") or ())
+        prefix = f"bicyclic [{descriptor}] " if descriptor else "bicyclic "
+        return f"{length_text}{prefix}{skeleton}".strip()
+    if parent.get("is_polycycle"):
+        descriptor = parent.get("polycycle_descriptor")
+        prefix = f"polycyclic {descriptor} " if descriptor else "polycyclic "
+        return f"{length_text}{prefix}{skeleton}".strip()
+    if parent.get("is_ring"):
+        return f"{length_text}ring {skeleton}".strip()
+    return f"{length_text}acyclic {skeleton}".strip()
+
+
+def _heteroatom_sentence(parent: dict[str, Any]) -> str:
+    groups = _hetero_locants(parent)
+    if not groups:
+        return ""
+    phrases = []
+    for symbol, locants in groups:
+        element = _element_name(symbol)
+        phrases.append(f"{element} at {_positions(locants)}")
+    return "Within that parent framework, there is " + _join_phrases(phrases) + "."
+
+
+def _hetero_locants(parent: dict[str, Any]) -> list[tuple[str, list[str]]]:
+    symbols = parent.get("atom_symbols_by_locant") or {}
+    groups: dict[str, list[str]] = {}
+    for locant, symbol in symbols.items():
+        if symbol and symbol not in {"C", "H"}:
+            groups.setdefault(str(symbol), []).append(str(locant))
+    return [(symbol, _sort_locants(locants)) for symbol, locants in sorted(groups.items(), key=lambda item: item[0])]
+
+
+def _unsaturation_sentence(node: dict[str, Any], parent: dict[str, Any], mol: Molecule) -> str:
+    unsaturations = node.get("unsaturations") or []
+    if not unsaturations:
+        return ""
+    bond_phrases: list[str] = []
+    for item in unsaturations:
+        kind = "triple" if item.get("bond_key") == "triple" else "double"
+        for loc_pair in _unsaturation_position_pairs(item, parent, mol):
+            if len(loc_pair) == 2:
+                bond_phrases.append(f"a {kind} bond between positions {loc_pair[0]} and {loc_pair[1]}")
+            elif loc_pair:
+                bond_phrases.append(f"a {kind} bond at position {loc_pair[0]}")
+    if not bond_phrases:
+        return ""
+    return "Within that parent framework, there is " + _join_phrases(bond_phrases) + "."
+
+
+def _unsaturation_position_pairs(
+    item: dict[str, Any], parent: dict[str, Any], mol: Molecule
+) -> list[tuple[str, ...]]:
+    atom_to_locant = {int(atom): str(locant) for locant, atom in (parent.get("atom_ids_by_locant") or {}).items()}
+    pairs: list[tuple[str, ...]] = []
+    used_bonds: set[int] = set()
+    for bond_id in item.get("bonds") or ():
+        bond = mol.bonds.get(int(bond_id))
+        if bond is None:
+            continue
+        locants = [atom_to_locant.get(bond.u), atom_to_locant.get(bond.v)]
+        if all(locants):
+            pairs.append(tuple(_sort_locants([loc for loc in locants if loc])))
+            used_bonds.add(int(bond_id))
+    if pairs:
+        return sorted(pairs, key=lambda pair: [_locant_sort_key(locant) for locant in pair])
+    for locant in item.get("locants") or ():
+        parsed = _parse_unsaturation_locant(str(locant))
+        if parsed:
+            pairs.append(parsed)
+    return pairs
+
+
+def _parse_unsaturation_locant(locant: str) -> tuple[str, ...]:
+    if "(" in locant and locant.endswith(")"):
+        first, second = locant[:-1].split("(", 1)
+        if first and second:
+            return (first, second)
+    return (locant,) if locant else ()
+
+
+def _principal_group_sentence(node: dict[str, Any]) -> str:
+    group = node.get("principal_group")
+    if not group:
+        return ""
+    key = str(group.get("key") or "functional group")
+    locants = [str(loc) for loc in group.get("locants") or ()]
+    label = _principal_group_label(key, len(locants))
+    article = "" if label.endswith("s") else "an " if label[0].lower() in "aeiou" else "a "
+    if locants:
+        return f"The principal characteristic feature is {article}{label} at {_positions(locants)}."
+    return f"The principal characteristic feature is {article}{label}."
+
+
+def _principal_group_label(key: str, count: int) -> str:
+    labels = {
+        "ketone": "oxo group" if count <= 1 else "oxo groups",
+        "alcohol": "hydroxy group" if count <= 1 else "hydroxy groups",
+        "amine": "amino group" if count <= 1 else "amino groups",
+        "imino": "imino group" if count <= 1 else "imino groups",
+        "carboxylic_acid": "carboxylic acid group" if count <= 1 else "carboxylic acid groups",
+        "amide": "amide group" if count <= 1 else "amide groups",
+        "nitrile": "nitrile group" if count <= 1 else "nitrile groups",
+        "aldehyde": "formyl group" if count <= 1 else "formyl groups",
+    }
+    return labels.get(key, _readable_key(key) + (" group" if count <= 1 else " groups"))
+
+
+def _charge_sentence(node: dict[str, Any]) -> str:
+    charges = node.get("parent_charges") or []
+    if not charges:
+        return ""
+    phrases = []
+    for charge in charges:
+        locant = charge.get("locant")
+        symbol = charge.get("symbol") or "atom"
+        value = int(charge.get("charge") or 0)
+        if value:
+            sign = "positive" if value > 0 else "negative"
+            phrases.append(f"a {sign} {_element_name(symbol)} center at position {locant}")
+    if not phrases:
+        return ""
+    return "The parent carries " + _join_phrases(phrases) + "."
+
+
+def _substituent_summary_sentence(node: dict[str, Any]) -> str:
+    children = list(_iter_child_nodes(node, recurse_group_instances=False))
+    if not children:
+        return ""
+    phrases = []
+    has_plural = False
+    for child in children:
+        name = _clean_name(child.get("name") or "substituent")
+        locants = [str(loc) for loc in child.get("locants") or ()]
+        count = _child_instance_count(child)
+        has_plural = has_plural or count > 1
+        display_name = _pluralized_substituent_name(name, count)
+        if locants:
+            phrases.append(f"{display_name} at {_positions(locants)}")
+        else:
+            phrases.append(display_name)
+    verb = "are" if has_plural or len(phrases) > 1 else "is"
+    return f"Attached to this framework {verb} " + _join_phrases(phrases) + "."
+
+
+def _iter_child_nodes(node: dict[str, Any], *, recurse_group_instances: bool = True):
+    for child in node.get("substituents") or ():
+        if child.get("kind") == "grouped_substituent_instances":
+            if recurse_group_instances:
+                for instance in child.get("instances") or ():
+                    yield instance
+            else:
+                yield child
+            continue
+        yield child
+    functional_prefix = node.get("functional_prefix")
+    if isinstance(functional_prefix, dict):
+        for ligand in functional_prefix.get("ligands") or ():
+            yield ligand
+
+
+def _child_subject(child: dict[str, Any]) -> str:
+    name = _clean_name(child.get("name") or "substituent")
+    locants = [str(loc) for loc in child.get("locants") or ()]
+    if locants:
+        return f"The {name} substituent at {_positions(locants)}"
+    return f"The {name} substituent"
+
+
+def _should_expand_child(child: dict[str, Any]) -> bool:
+    parent = child.get("parent") or {}
+    if child.get("substituents") or child.get("functional_prefix"):
+        return True
+    if child.get("principal_group") or child.get("unsaturations") or child.get("replacement_prefixes"):
+        return True
+    if child.get("parent_charges"):
+        return True
+    if parent.get("retained_name"):
+        return True
+    if parent.get("is_ring") or parent.get("is_bicycle") or parent.get("is_spiro") or parent.get("is_polycycle"):
+        return True
+    return False
+
+
+def _child_instance_count(child: dict[str, Any]) -> int:
+    if child.get("kind") == "grouped_substituent_instances":
+        instances = child.get("instances") or ()
+        return len(instances) if instances else int(child.get("instance_count") or 1)
+    return int(child.get("instance_count") or 1)
+
+
+def _pluralized_substituent_name(name: str, count: int) -> str:
+    if count <= 1:
+        return f"a {name} group"
+    if name.endswith("yl"):
+        return f"{name} groups"
+    return f"{name} groups"
+
+
+def _element_name(symbol: str) -> str:
+    names = {
+        "B": "boron",
+        "C": "carbon",
+        "N": "nitrogen",
+        "O": "oxygen",
+        "P": "phosphorus",
+        "S": "sulfur",
+        "Se": "selenium",
+        "Si": "silicon",
+    }
+    return names.get(symbol, symbol)
+
+
+def _readable_key(key: str) -> str:
+    return key.replace("_", " ").replace("-", " ")
+
+
+def _clean_name(name: str) -> str:
+    return name.strip().strip("()")
+
+
+def _positions(locants: list[str]) -> str:
+    return "position " + locants[0] if len(locants) == 1 else "positions " + _join_phrases(_sort_locants(locants))
+
+
+def _join_phrases(items: list[str]) -> str:
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
+def _sort_locants(locants: list[str]) -> list[str]:
+    return sorted(locants, key=_locant_sort_key)
+
+
+def _locant_sort_key(locant: str):
+    primary = locant.split("(", 1)[0].rstrip("'")
+    try:
+        return (0, int(primary), locant)
+    except ValueError:
+        return (1, primary, locant)

--- a/src/bluenamer/name_assembly.py
+++ b/src/bluenamer/name_assembly.py
@@ -10,6 +10,7 @@ from .assembly_parts import AssemblyParts, NameAtomBinding, NameTokenBinding
 from .molecule import Molecule
 from .name_bindings import ensure_name_atom_binding_tokens, postprocess_name_atom_bindings
 from .stereo_descriptors import is_searchable_stereo_token
+from .token_grammar import is_locant_binding_token, lexical_token_spans
 
 
 @dataclass(frozen=True)
@@ -331,7 +332,7 @@ class NameAssemblyResult:
             )
             if operation.edits:
                 token_spans = _rewrite_token_spans(before_text, text, token_spans, operation.edits)
-            else:
+            elif before_text != text:
                 token_spans = build_name_token_spans(text, binding_tuple)
             history.append(operation)
         token_spans = _complete_token_spans(text, binding_tuple, token_spans)
@@ -641,8 +642,7 @@ def _rewrite_token_spans(
             rewritten.append(_shift_token_span(token, _rewrite_delta_before(token.start, edits), after_text))
             continue
         rewritten.extend(_token_spans_from_edit_segments(token, edit, after_text))
-    rewritten.sort(key=lambda token: (token.start, token.end, token.text))
-    return tuple(rewritten)
+    return _merge_same_span_token_metadata(rewritten)
 
 
 def _covering_edit(token: NameTokenSpan, edits: tuple[NameRewriteEdit, ...]) -> NameRewriteEdit | None:
@@ -679,15 +679,13 @@ def _token_spans_from_edit_segments(
         matched_segment = True
         if segment.after_start == segment.after_end:
             continue
-        spans.append(
-            _copy_token_span(
+        spans.extend(
+            _copy_token_span_over_replacement_tokens(
                 token,
                 segment.after_start,
                 segment.after_end,
-                after_text[segment.after_start : segment.after_end],
+                after_text,
                 segment.ownership,
-                "typed_rewrite",
-                "derived",
             )
         )
     if spans:
@@ -704,6 +702,97 @@ def _token_spans_from_edit_segments(
             "typed_rewrite",
             "derived",
         ),
+    )
+
+
+def _copy_token_span_over_replacement_tokens(
+    token: NameTokenSpan,
+    start: int,
+    end: int,
+    after_text: str,
+    ownership: str,
+) -> tuple[NameTokenSpan, ...]:
+    replacement = after_text[start:end]
+    lexical = lexical_token_spans(replacement)
+    if not lexical:
+        return (
+            _copy_token_span(
+                token,
+                start,
+                end,
+                replacement,
+                ownership,
+                "typed_rewrite",
+                "derived",
+            ),
+        )
+    return tuple(
+        _copy_token_span(
+            token,
+            start + item.start,
+            start + item.end,
+            item.text,
+            ownership,
+            "typed_rewrite",
+            "derived",
+        )
+        for item in lexical
+    )
+
+
+def _merge_same_span_token_metadata(tokens: list[NameTokenSpan]) -> tuple[NameTokenSpan, ...]:
+    grouped: dict[tuple[int, int, str], list[NameTokenSpan]] = {}
+    for token in tokens:
+        grouped.setdefault((token.start, token.end, token.text), []).append(token)
+    merged = [_merge_token_group(group) for group in grouped.values()]
+    merged.sort(key=lambda token: (token.start, token.end, token.text))
+    return tuple(merged)
+
+
+def _merge_token_group(tokens: list[NameTokenSpan]) -> NameTokenSpan:
+    if len(tokens) == 1:
+        return tokens[0]
+    first = tokens[0]
+    binding_indices: set[int] = set()
+    atoms: set[int] = set()
+    bonds: set[int] = set()
+    charges: set[int] = set()
+    locants: list[str] = []
+    token_kinds: list[str] = []
+    ownerships: list[str] = []
+    confidences: list[str] = []
+    sources: list[str] = []
+    grammar_roles: list[str] = []
+    binding_keys: list[str] = []
+    for token in tokens:
+        binding_indices.update(token.binding_indices)
+        atoms.update(token.atom_ids)
+        bonds.update(token.bond_ids)
+        charges.update(token.charge_atom_ids)
+        locants.extend(token.locants)
+        token_kinds.append(token.token_kind)
+        ownerships.append(token.ownership)
+        confidences.append(token.confidence)
+        sources.append(token.source)
+        if token.grammar_role:
+            grammar_roles.append(token.grammar_role)
+        if token.binding_key:
+            binding_keys.append(token.binding_key)
+    return NameTokenSpan(
+        text=first.text,
+        start=first.start,
+        end=first.end,
+        binding_indices=tuple(sorted(binding_indices)),
+        atom_ids=frozenset(atoms),
+        bond_ids=frozenset(bonds),
+        charge_atom_ids=frozenset(charges),
+        locants=tuple(locants),
+        token_kind=_collapse_metadata(token_kinds, default=first.token_kind),
+        ownership=_collapse_metadata(ownerships, default=first.ownership),
+        confidence=_weakest_confidence(confidences),
+        source=_collapse_metadata(sources, default=first.source),
+        grammar_role=_collapse_metadata(grammar_roles, default=first.grammar_role),
+        binding_key=_collapse_metadata(binding_keys, default=first.binding_key),
     )
 
 
@@ -880,12 +969,13 @@ def _format_atom_error(label: str, mol: Molecule, atom_ids: set[int]) -> str:
 def build_name_token_spans(text: str, bindings: tuple[NameAtomBinding, ...]) -> tuple[NameTokenSpan, ...]:
     """Bind every lexical final-name token to graph metadata where possible."""
 
+    bindings = _ensure_emitted_token_bindings(bindings)
     native_spans = _native_token_spans(text, bindings)
     direct_spans = _direct_binding_spans(text, bindings)
     tokens = []
-    for match in _LEXICAL_TOKEN_RE.finditer(text):
-        start, end = match.span()
-        token_text = match.group(0)
+    for token in lexical_token_spans(text):
+        start, end = token.start, token.end
+        token_text = token.text
         native_matches = [
             (span_start, span_end, binding_idx, token_binding)
             for span_start, span_end, binding_idx, token_binding in native_spans
@@ -919,6 +1009,7 @@ def _native_token_spans(
 ) -> list[tuple[int, int, int, NameTokenBinding]]:
     spans: list[tuple[int, int, int, NameTokenBinding]] = []
     search_text = text.lower()
+    spans.extend(_ordered_renderer_native_token_spans(text, search_text, bindings))
     for binding_idx, binding in enumerate(bindings):
         if binding.stage == "hydro" and binding.role == "indicated_hydrogen":
             spans.extend(_indicated_hydrogen_native_token_spans(search_text, binding_idx, binding))
@@ -931,12 +1022,14 @@ def _native_token_spans(
             if unsaturation_spans:
                 spans.extend(unsaturation_spans)
                 continue
-        if not any(_is_locant_search_token(token_binding) for token_binding in binding.emitted_tokens):
+        if not any(is_locant_binding_token(token_binding) for token_binding in binding.emitted_tokens):
             ordered_spans = _ordered_native_token_spans(text, search_text, binding_idx, binding)
             if ordered_spans:
                 spans.extend(ordered_spans)
                 continue
         for token_binding in binding.emitted_tokens:
+            if token_binding.render_order is not None:
+                continue
             token = token_binding.text.strip().lower()
             if not _native_token_is_searchable(token, token_binding):
                 continue
@@ -944,6 +1037,36 @@ def _native_token_spans(
             for found in _native_token_occurrences(text, search_text, token_binding, pos):
                 spans.append((found, found + len(token), binding_idx, token_binding))
                 pos = found + 1
+    return spans
+
+
+def _ordered_renderer_native_token_spans(
+    text: str,
+    search_text: str,
+    bindings: tuple[NameAtomBinding, ...],
+) -> list[tuple[int, int, int, NameTokenBinding]]:
+    """Place explicitly ordered renderer tokens once, in rendered order."""
+
+    ordered_items = []
+    for binding_idx, binding in enumerate(bindings):
+        for token_idx, token in enumerate(binding.emitted_tokens):
+            if token.render_order is not None:
+                ordered_items.append((token.render_order, binding_idx, token_idx, token))
+    ordered_tokens = sorted(
+        ordered_items,
+        key=lambda item: (item[0], item[1], item[2]),
+    )
+    spans: list[tuple[int, int, int, NameTokenBinding]] = []
+    cursor = 0
+    for _render_order, binding_idx, _token_idx, token_binding in ordered_tokens:
+        token = token_binding.text.strip().lower()
+        if not _native_token_is_searchable(token, token_binding):
+            continue
+        found = next(iter(_native_token_occurrences(text, search_text, token_binding, cursor)), -1)
+        if found < 0:
+            continue
+        spans.append((found, found + len(token), binding_idx, token_binding))
+        cursor = found + len(token)
     return spans
 
 
@@ -1044,63 +1167,19 @@ def _native_token_occurrences(
 ) -> tuple[int, ...]:
     raw_token = token_binding.text.strip()
     token = raw_token.lower()
-    if token_binding.binding_key == "prefix:alkenyl_bridge_stereo" and token_binding.token_kind == "locant":
-        return tuple(
-            match.start()
-            for match in re.finditer(re.escape(raw_token), text)
-            if match.start() >= start
-            and match.end() < len(text)
-            and text[match.end()] in "EZ"
-        )
-    if token_binding.grammar_role == "alkenyl_bridge_unsaturation" and token == "en":
-        return tuple(
-            match.start()
-            for match in re.finditer(re.escape(raw_token), search_text)
-            if match.start() >= start
-            and search_text[match.end() : match.end() + 2] == "yl"
-        )
-    if (
-        token_binding.binding_key == "prefix:substituent"
-        and token_binding.source == "substituent_renderer"
-        and token in {"dihydr", "trihydr", "tetrahydr", "oxy"}
-        and len(token_binding.locants) > 1
-    ):
-        locant_prefix = ",".join(str(locant).lower() for locant in token_binding.locants)
-        return tuple(
-            match.start()
-            for match in re.finditer(re.escape(raw_token), search_text)
-            if match.start() >= start
-            and (
-                search_text[max(0, match.start() - len(locant_prefix) - 1) : match.start()]
-                == f"{locant_prefix}-"
-                or search_text[max(0, match.start() - len(locant_prefix) - len("-dihydr")) : match.start()]
-                == f"{locant_prefix}-dihydr"
-            )
-        )
-    if token_binding.grammar_role == "alkenyl_bridge_suffix" and token == "yl":
-        return tuple(
-            match.start()
-            for match in re.finditer(re.escape(raw_token), search_text)
-            if match.start() >= start and search_text[max(0, match.start() - 2) : match.start()] == "en"
-        )
-    if token_binding.binding_key == "prefix:heteroatom_center" and token == "oxy":
-        return tuple(
-            match.start()
-            for match in re.finditer(re.escape(raw_token), search_text)
-            if match.start() >= start
-            and search_text[max(0, match.start() - len("carbonyl")) : match.start()] == "carbonyl"
-        )
     if token_binding.token_kind == "stereo" and len(raw_token) == 1:
         return tuple(
             match.start()
             for match in re.finditer(re.escape(raw_token), text)
-            if match.start() >= start
+            if match.start() >= start and _token_context_matches(search_text, token_binding, match.start(), match.end())
         )
-    if _is_locant_search_token(token_binding):
+    if is_locant_binding_token(token_binding):
         return tuple(
             match.start()
             for match in re.finditer(re.escape(raw_token), text)
-            if match.start() >= start and _is_standalone_locant_span(text, match.start(), match.end())
+            if match.start() >= start
+            and _is_standalone_locant_span(text, match.start(), match.end())
+            and _token_context_matches(search_text, token_binding, match.start(), match.end())
         )
     positions: list[int] = []
     pos = start
@@ -1108,15 +1187,20 @@ def _native_token_occurrences(
         found = search_text.find(token, pos)
         if found < 0:
             break
-        positions.append(found)
+        if _token_context_matches(search_text, token_binding, found, found + len(token)):
+            positions.append(found)
         pos = found + 1
     return tuple(positions)
 
 
-def _is_locant_search_token(token_binding: NameTokenBinding) -> bool:
-    return token_binding.token_kind == "locant" and bool(
-        re.fullmatch(r"(?:[0-9]+|N|O|P|S)(?:,(?:[0-9]+|N|O|P|S))*", token_binding.text)
-    )
+def _token_context_matches(search_text: str, token_binding: NameTokenBinding, start: int, end: int) -> bool:
+    left_context = token_binding.left_context.lower()
+    right_context = token_binding.right_context.lower()
+    if left_context and search_text[max(0, start - len(left_context)) : start] != left_context:
+        return False
+    if right_context and search_text[end : end + len(right_context)] != right_context:
+        return False
+    return True
 
 
 def _is_standalone_locant_span(text: str, start: int, end: int) -> bool:
@@ -1180,17 +1264,6 @@ def _fallback_token_binding_resolution(
                 confidence="derived",
                 source="locant_fallback",
                 grammar_role="locant",
-            )
-    if not indices:
-        indices.update(_charge_suffix_binding_indices(token_norm, start, text, bindings))
-        if indices:
-            return TokenBindingResolution(
-                tuple(sorted(indices)),
-                token_kind="charge",
-                ownership="exact",
-                confidence="derived",
-                source="charge_suffix_fallback",
-                grammar_role="charge",
             )
     if not indices:
         indices.update(_indicated_hydrogen_binding_indices(token_norm, start, text, bindings))
@@ -1333,30 +1406,6 @@ def _locant_binding_indices(token: str, bindings: tuple[NameAtomBinding, ...]) -
 
 def _normalise_locant_token(locant: str) -> str:
     return locant.strip().strip("'").strip('"')
-
-
-def _charge_suffix_binding_indices(
-    token: str,
-    start: int,
-    text: str,
-    bindings: tuple[NameAtomBinding, ...],
-) -> set[int]:
-    """Bind charge suffix words to adjacent locanted charge operations."""
-
-    if token not in _CHARGE_SUFFIX_TOKENS:
-        return set()
-    locant_match = re.search(r"(\d+(?:,\d+)*)-$", text[:start])
-    locants = set(locant_match.group(1).split(",")) if locant_match else set()
-    charge_indices = {
-        idx
-        for idx, binding in enumerate(bindings)
-        if binding.stage == "charge" or binding.role == "parent_charge" or binding.charge_atom_ids
-    }
-    if not locants:
-        return charge_indices
-    return {
-        idx for idx in charge_indices if locants <= {str(locant).strip("'") for locant in bindings[idx].locants}
-    } or charge_indices
 
 
 def _indicated_hydrogen_binding_indices(
@@ -1656,8 +1705,8 @@ def _token_spans_from_native_matches(
         for span_start, span_end, binding_idx, token_binding in matches
         if span_start == start and span_end == end
     ]
+    exact_matches = _prefer_highest_priority_matches(exact_matches)
     exact_matches = _disambiguate_locant_exact_matches(text, start, end, exact_matches, all_matches or matches)
-    exact_matches = _disambiguate_structural_exact_matches(text, start, end, exact_matches)
     if exact_matches and _should_split_broad_exact_match(text, start, end, exact_matches, matches):
         exact_matches = []
     if exact_matches:
@@ -1700,7 +1749,7 @@ def _token_spans_from_native_matches(
                     text,
                     clipped_start,
                     clipped_end,
-                    grouped_matches[(clipped_start, clipped_end)],
+                    _prefer_highest_priority_matches(grouped_matches[(clipped_start, clipped_end)]),
                     all_matches or matches,
                 ),
             )
@@ -1763,14 +1812,6 @@ def _disambiguate_locant_exact_matches(
         return exact_matches
     if not all(token.token_kind == "locant" for _binding_idx, token in exact_matches):
         return exact_matches
-    if end < len(text) and text[end] in "EZRS":
-        stereo_locants = [
-            (binding_idx, token)
-            for binding_idx, token in exact_matches
-            if token.source == "renderer_stereo" or token.grammar_role in {"absolute_stereo", "bond_stereo"}
-        ]
-        if stereo_locants:
-            return stereo_locants
     preferred_element_locants = _preferred_element_locant_matches(token_text, exact_matches)
     if preferred_element_locants:
         return preferred_element_locants
@@ -1807,49 +1848,15 @@ def _disambiguate_locant_exact_matches(
     return exact_matches
 
 
-def _disambiguate_structural_exact_matches(
-    text: str,
-    start: int,
-    end: int,
-    exact_matches: list[tuple[int, NameTokenBinding]],
+def _prefer_highest_priority_matches(
+    matches: list[tuple[int, NameTokenBinding]],
 ) -> list[tuple[int, NameTokenBinding]]:
-    if len(exact_matches) <= 1:
-        return exact_matches
-    token_text = text[start:end].lower()
-    if token_text == "en":
-        if text[end : end + 2].lower() == "yl":
-            preferred = [
-                (binding_idx, token)
-                for binding_idx, token in exact_matches
-                if token.grammar_role == "alkenyl_bridge_unsaturation" or token.binding_key == "prefix:alkenyl_bridge"
-            ]
-            if preferred:
-                return preferred
-        if text[end : end + 1].lower() == "e":
-            preferred = [
-                (binding_idx, token)
-                for binding_idx, token in exact_matches
-                if token.binding_key == "unsaturation:double"
-            ]
-            if preferred:
-                return preferred
-    if token_text == "oxy" and text[max(0, start - len("carbonyl")) : start].lower() == "carbonyl":
-        preferred = [
-            (binding_idx, token)
-            for binding_idx, token in exact_matches
-            if token.binding_key == "prefix:heteroatom_center"
-        ]
-        if preferred:
-            return preferred
-    if token_text == "oxy" and text[max(0, start - len("dihydr")) : start].lower() == "dihydr":
-        preferred = [
-            (binding_idx, token)
-            for binding_idx, token in exact_matches
-            if token.binding_key.startswith("prefix:")
-        ]
-        if preferred:
-            return preferred
-    return exact_matches
+    if len(matches) <= 1:
+        return matches
+    max_priority = max(token.match_priority for _binding_idx, token in matches)
+    if max_priority <= 0:
+        return matches
+    return [(binding_idx, token) for binding_idx, token in matches if token.match_priority == max_priority]
 
 
 def _prune_overlapping_native_match_groups(
@@ -2004,13 +2011,11 @@ def _next_structural_native_scope(
     end: int,
     all_matches: list[tuple[int, int, int, NameTokenBinding]],
 ) -> set[int]:
-    next_lexical = _LEXICAL_TOKEN_RE.search(text, end)
-    while next_lexical:
-        token_norm = _normalise_name_text(next_lexical.group(0))
+    for next_lexical in lexical_token_spans(text, end):
+        token_norm = _normalise_name_text(next_lexical.text)
         if token_norm in _NON_STRUCTURAL_GRAMMAR_TOKENS:
-            next_lexical = _LEXICAL_TOKEN_RE.search(text, next_lexical.end())
             continue
-        next_start, next_end = next_lexical.span()
+        next_start, next_end = next_lexical.start, next_lexical.end
         atom_ids: set[int] = set()
         for span_start, span_end, _binding_idx, token in all_matches:
             if token.token_kind == "locant":
@@ -2019,7 +2024,6 @@ def _next_structural_native_scope(
                 atom_ids.update(token.atom_ids)
         if atom_ids:
             return atom_ids
-        next_lexical = _LEXICAL_TOKEN_RE.search(text, next_lexical.end())
     return set()
 
 
@@ -2156,37 +2160,7 @@ def _token_span_from_native_binding_group(
     end: int,
     matches: list[tuple[int, NameTokenBinding]],
 ) -> NameTokenSpan:
-    if text.lower() == "en":
-        bridge_matches = [
-            (binding_idx, token_binding)
-            for binding_idx, token_binding in matches
-            if token_binding.binding_key == "prefix:alkenyl_bridge"
-        ]
-        if bridge_matches:
-            matches = bridge_matches
-    if text.lower() == "oxy":
-        oxy_matches = [
-            (binding_idx, token_binding)
-            for binding_idx, token_binding in matches
-            if token_binding.binding_key == "prefix:heteroatom_center"
-        ]
-        if oxy_matches:
-            matches = oxy_matches
-        else:
-            prefix_oxy_matches = [
-                (binding_idx, token_binding)
-                for binding_idx, token_binding in matches
-                if token_binding.binding_key.startswith("prefix:")
-            ]
-            if prefix_oxy_matches:
-                matches = prefix_oxy_matches
-    stereo_matches = [
-        (binding_idx, token_binding)
-        for binding_idx, token_binding in matches
-        if token_binding.source == "renderer_stereo"
-    ]
-    if stereo_matches and _should_prioritize_renderer_stereo(text, stereo_matches):
-        matches = stereo_matches
+    matches = _prefer_highest_priority_matches(matches)
     atoms: set[int] = set()
     bonds: set[int] = set()
     charges: set[int] = set()
@@ -2228,17 +2202,6 @@ def _token_span_from_native_binding_group(
         grammar_role=_collapse_metadata(grammar_roles, default=""),
         binding_key=_collapse_metadata(binding_keys, default=""),
     )
-
-
-def _should_prioritize_renderer_stereo(_text: str, matches: list[tuple[int, NameTokenBinding]]) -> bool:
-    """Return whether a span is owned by an explicit stereo-renderer token."""
-
-    for _binding_idx, token_binding in matches:
-        if token_binding.token_kind == "stereo" and is_searchable_stereo_token(token_binding.text):
-            return True
-        if token_binding.token_kind == "locant" and token_binding.grammar_role in {"absolute_stereo", "bond_stereo"}:
-            return True
-    return False
 
 
 def _collapse_metadata(values: list[str], *, default: str) -> str:
@@ -2415,8 +2378,6 @@ _ABSTRACT_BINDING_TERMS = frozenset(
 
 _REPLACEMENT_PREFIX_CERTIFICATE_TERMS = frozenset({"aza", "oxa", "thia"})
 
-_LEXICAL_TOKEN_RE = re.compile(r"[A-Za-z]+(?:\^[0-9]+)?|\d+(?:,\d+)*(?:'\")?|[0-9]+(?:\([0-9,]+\))?")
-
 _ROLE_TOKEN_ALIASES = {
     "ketone": ("one", "dione", "trione", "oxo"),
     "aldehyde": ("al", "formyl", "carbaldehyde"),
@@ -2455,7 +2416,6 @@ _STRUCTURAL_SUFFIX_TOKENS = frozenset(
 )
 
 _STRUCTURAL_SUFFIX_ENDINGS = ("one", "dione", "trione", "ol", "al", "amide", "nitrile", "oate", "ate", "ide", "ium")
-_CHARGE_SUFFIX_TOKENS = frozenset({"ide", "ium", "aminium", "ylium", "uide"})
 _PARENT_DESCRIPTOR_TOKENS = frozenset(
     {
         "bicyclo",

--- a/src/bluenamer/name_assembly.py
+++ b/src/bluenamer/name_assembly.py
@@ -892,7 +892,7 @@ def build_name_token_spans(text: str, bindings: tuple[NameAtomBinding, ...]) -> 
             if _spans_overlap(start, end, span_start, span_end)
         ]
         if native_matches:
-            tokens.extend(_token_spans_from_native_matches(text, start, end, native_matches))
+            tokens.extend(_token_spans_from_native_matches(text, start, end, native_matches, native_spans, bindings))
             continue
         binding_indices = {
             binding_idx
@@ -926,6 +926,11 @@ def _native_token_spans(
         if binding.stage == "assembly" and binding.role in {"absolute_stereo", "bond_stereo"}:
             spans.extend(_absolute_stereo_native_token_spans(search_text, binding_idx, binding))
             continue
+        if binding.stage == "unsaturation":
+            unsaturation_spans = _unsaturation_native_token_spans(search_text, binding_idx, binding)
+            if unsaturation_spans:
+                spans.extend(unsaturation_spans)
+                continue
         if not any(_is_locant_search_token(token_binding) for token_binding in binding.emitted_tokens):
             ordered_spans = _ordered_native_token_spans(text, search_text, binding_idx, binding)
             if ordered_spans:
@@ -989,6 +994,26 @@ def _absolute_stereo_native_token_spans(
     return spans
 
 
+def _unsaturation_native_token_spans(
+    search_text: str,
+    binding_idx: int,
+    binding: NameAtomBinding,
+) -> list[tuple[int, int, int, NameTokenBinding]]:
+    locant_token = next((token for token in binding.emitted_tokens if token.token_kind == "locant"), None)
+    unsat_token = next((token for token in binding.emitted_tokens if token.token_kind == "unsaturation"), None)
+    if locant_token is None or unsat_token is None:
+        return []
+    locant_text = locant_token.text.lower()
+    unsat_text = unsat_token.text.lower()
+    pattern = re.compile(rf"{re.escape(locant_text)}-{re.escape(unsat_text)}(?=e?\\b)")
+    spans: list[tuple[int, int, int, NameTokenBinding]] = []
+    for match in pattern.finditer(search_text):
+        spans.append((match.start(), match.start() + len(locant_text), binding_idx, locant_token))
+        unsat_start = match.start() + len(locant_text) + 1
+        spans.append((unsat_start, unsat_start + len(unsat_text), binding_idx, unsat_token))
+    return spans
+
+
 def _ordered_native_token_spans(
     text: str,
     search_text: str,
@@ -1019,6 +1044,58 @@ def _native_token_occurrences(
 ) -> tuple[int, ...]:
     raw_token = token_binding.text.strip()
     token = raw_token.lower()
+    if token_binding.binding_key == "prefix:alkenyl_bridge_stereo" and token_binding.token_kind == "locant":
+        return tuple(
+            match.start()
+            for match in re.finditer(re.escape(raw_token), text)
+            if match.start() >= start
+            and match.end() < len(text)
+            and text[match.end()] in "EZ"
+        )
+    if token_binding.grammar_role == "alkenyl_bridge_unsaturation" and token == "en":
+        return tuple(
+            match.start()
+            for match in re.finditer(re.escape(raw_token), search_text)
+            if match.start() >= start
+            and search_text[match.end() : match.end() + 2] == "yl"
+        )
+    if (
+        token_binding.binding_key == "prefix:substituent"
+        and token_binding.source == "substituent_renderer"
+        and token in {"dihydr", "trihydr", "tetrahydr", "oxy"}
+        and len(token_binding.locants) > 1
+    ):
+        locant_prefix = ",".join(str(locant).lower() for locant in token_binding.locants)
+        return tuple(
+            match.start()
+            for match in re.finditer(re.escape(raw_token), search_text)
+            if match.start() >= start
+            and (
+                search_text[max(0, match.start() - len(locant_prefix) - 1) : match.start()]
+                == f"{locant_prefix}-"
+                or search_text[max(0, match.start() - len(locant_prefix) - len("-dihydr")) : match.start()]
+                == f"{locant_prefix}-dihydr"
+            )
+        )
+    if token_binding.grammar_role == "alkenyl_bridge_suffix" and token == "yl":
+        return tuple(
+            match.start()
+            for match in re.finditer(re.escape(raw_token), search_text)
+            if match.start() >= start and search_text[max(0, match.start() - 2) : match.start()] == "en"
+        )
+    if token_binding.binding_key == "prefix:heteroatom_center" and token == "oxy":
+        return tuple(
+            match.start()
+            for match in re.finditer(re.escape(raw_token), search_text)
+            if match.start() >= start
+            and search_text[max(0, match.start() - len("carbonyl")) : match.start()] == "carbonyl"
+        )
+    if token_binding.token_kind == "stereo" and len(raw_token) == 1:
+        return tuple(
+            match.start()
+            for match in re.finditer(re.escape(raw_token), text)
+            if match.start() >= start
+        )
     if _is_locant_search_token(token_binding):
         return tuple(
             match.start()
@@ -1045,7 +1122,7 @@ def _is_locant_search_token(token_binding: NameTokenBinding) -> bool:
 def _is_standalone_locant_span(text: str, start: int, end: int) -> bool:
     before = text[start - 1] if start > 0 else ""
     after = text[end] if end < len(text) else ""
-    return (not before or before in "-,( ") and (not after or after in "-,)' ")
+    return (not before or before in "-,( ") and (not after or after in "-,()' " or after in "EZRS")
 
 
 def _native_token_is_searchable(token: str, token_binding: NameTokenBinding | None = None) -> bool:
@@ -1571,15 +1648,22 @@ def _token_spans_from_native_matches(
     start: int,
     end: int,
     matches: list[tuple[int, int, int, NameTokenBinding]],
+    all_matches: list[tuple[int, int, int, NameTokenBinding]] | None = None,
+    bindings: tuple[NameAtomBinding, ...] = (),
 ) -> list[NameTokenSpan]:
     exact_matches = [
         (binding_idx, token_binding)
         for span_start, span_end, binding_idx, token_binding in matches
         if span_start == start and span_end == end
     ]
+    exact_matches = _disambiguate_locant_exact_matches(text, start, end, exact_matches, all_matches or matches)
+    exact_matches = _disambiguate_structural_exact_matches(text, start, end, exact_matches)
+    if exact_matches and _should_split_broad_exact_match(text, start, end, exact_matches, matches):
+        exact_matches = []
     if exact_matches:
         return [_token_span_from_native_binding_group(text[start:end], start, end, exact_matches)]
 
+    matches = _filter_locant_matches_by_governing_scope(text, start, end, matches, all_matches or matches)
     spans = []
     sorted_matches = sorted(matches, key=lambda item: (item[0], item[1], item[2]))
     grouped_matches: dict[tuple[int, int], list[tuple[int, NameTokenBinding]]] = {}
@@ -1588,6 +1672,7 @@ def _token_spans_from_native_matches(
         clipped_end = min(end, span_end)
         if clipped_start < clipped_end:
             grouped_matches.setdefault((clipped_start, clipped_end), []).append((binding_idx, token_binding))
+    grouped_matches = _prune_overlapping_native_match_groups(grouped_matches)
     ordered_keys = sorted(grouped_matches)
     cursor = start
     previous_key: tuple[int, int] | None = None
@@ -1603,6 +1688,7 @@ def _token_spans_from_native_matches(
                         clipped_start,
                         text,
                         _adjacent_native_gap_matches(grouped_matches, previous_key, next_key),
+                        bindings,
                     )
                 )
         spans.append(
@@ -1610,7 +1696,13 @@ def _token_spans_from_native_matches(
                 text[clipped_start:clipped_end],
                 clipped_start,
                 clipped_end,
-                grouped_matches[(clipped_start, clipped_end)],
+                _disambiguate_locant_exact_matches(
+                    text,
+                    clipped_start,
+                    clipped_end,
+                    grouped_matches[(clipped_start, clipped_end)],
+                    all_matches or matches,
+                ),
             )
         )
         cursor = max(cursor, clipped_end)
@@ -1625,9 +1717,310 @@ def _token_spans_from_native_matches(
                     end,
                     text,
                     _adjacent_native_gap_matches(grouped_matches, previous_key, None),
+                    bindings,
                 )
             )
     return spans
+
+
+def _filter_locant_matches_by_governing_scope(
+    text: str,
+    start: int,
+    end: int,
+    matches: list[tuple[int, int, int, NameTokenBinding]],
+    all_matches: list[tuple[int, int, int, NameTokenBinding]],
+) -> list[tuple[int, int, int, NameTokenBinding]]:
+    token_text = text[start:end]
+    if not re.fullmatch(r"(?:[0-9]+|N|O|P|S)(?:,(?:[0-9]+|N|O|P|S))*", token_text):
+        return matches
+    next_scope = _governing_structural_scope_after_locant_cluster(text, end, all_matches)
+    if not next_scope:
+        return matches
+    filtered = []
+    for span_start, span_end, binding_idx, token in matches:
+        if token.token_kind != "locant" or not token.atom_ids:
+            filtered.append((span_start, span_end, binding_idx, token))
+            continue
+        atom_ids = set(token.atom_ids)
+        if atom_ids <= next_scope or atom_ids & next_scope:
+            filtered.append((span_start, span_end, binding_idx, token))
+    return filtered or matches
+
+
+def _disambiguate_locant_exact_matches(
+    text: str,
+    start: int,
+    end: int,
+    exact_matches: list[tuple[int, NameTokenBinding]],
+    all_matches: list[tuple[int, int, int, NameTokenBinding]],
+) -> list[tuple[int, NameTokenBinding]]:
+    """Resolve repeated locants by the structural token they introduce."""
+
+    if len(exact_matches) <= 1:
+        return exact_matches
+    token_text = text[start:end]
+    if not re.fullmatch(r"(?:[0-9]+|N|O|P|S)(?:,(?:[0-9]+|N|O|P|S))*", token_text):
+        return exact_matches
+    if not all(token.token_kind == "locant" for _binding_idx, token in exact_matches):
+        return exact_matches
+    if end < len(text) and text[end] in "EZRS":
+        stereo_locants = [
+            (binding_idx, token)
+            for binding_idx, token in exact_matches
+            if token.source == "renderer_stereo" or token.grammar_role in {"absolute_stereo", "bond_stereo"}
+        ]
+        if stereo_locants:
+            return stereo_locants
+    preferred_element_locants = _preferred_element_locant_matches(token_text, exact_matches)
+    if preferred_element_locants:
+        return preferred_element_locants
+    if _following_text_starts_suffix(text, end):
+        return _widest_locant_scope(exact_matches)
+    if start == 0 and text[end : end + 2] == "-(":
+        return _widest_locant_scope(exact_matches)
+    next_scope = _governing_structural_scope_after_locant_cluster(text, end, all_matches)
+    if not next_scope:
+        next_scope = _next_structural_native_scope(text, end, all_matches)
+    if text[end : end + 2] == "-(" and not next_scope:
+        return _widest_locant_scope(exact_matches)
+    if not next_scope:
+        return exact_matches
+    contained = [
+        (binding_idx, token)
+        for binding_idx, token in exact_matches
+        if token.atom_ids and set(token.atom_ids) <= next_scope
+    ]
+    if contained:
+        min_size = min(len(token.atom_ids) + len(token.bond_ids) for _binding_idx, token in contained)
+        return [
+            (binding_idx, token)
+            for binding_idx, token in contained
+            if len(token.atom_ids) + len(token.bond_ids) == min_size
+        ]
+    overlapping = [
+        (binding_idx, token)
+        for binding_idx, token in exact_matches
+        if token.atom_ids and bool(set(token.atom_ids) & next_scope)
+    ]
+    if overlapping:
+        return overlapping
+    return exact_matches
+
+
+def _disambiguate_structural_exact_matches(
+    text: str,
+    start: int,
+    end: int,
+    exact_matches: list[tuple[int, NameTokenBinding]],
+) -> list[tuple[int, NameTokenBinding]]:
+    if len(exact_matches) <= 1:
+        return exact_matches
+    token_text = text[start:end].lower()
+    if token_text == "en":
+        if text[end : end + 2].lower() == "yl":
+            preferred = [
+                (binding_idx, token)
+                for binding_idx, token in exact_matches
+                if token.grammar_role == "alkenyl_bridge_unsaturation" or token.binding_key == "prefix:alkenyl_bridge"
+            ]
+            if preferred:
+                return preferred
+        if text[end : end + 1].lower() == "e":
+            preferred = [
+                (binding_idx, token)
+                for binding_idx, token in exact_matches
+                if token.binding_key == "unsaturation:double"
+            ]
+            if preferred:
+                return preferred
+    if token_text == "oxy" and text[max(0, start - len("carbonyl")) : start].lower() == "carbonyl":
+        preferred = [
+            (binding_idx, token)
+            for binding_idx, token in exact_matches
+            if token.binding_key == "prefix:heteroatom_center"
+        ]
+        if preferred:
+            return preferred
+    if token_text == "oxy" and text[max(0, start - len("dihydr")) : start].lower() == "dihydr":
+        preferred = [
+            (binding_idx, token)
+            for binding_idx, token in exact_matches
+            if token.binding_key.startswith("prefix:")
+        ]
+        if preferred:
+            return preferred
+    return exact_matches
+
+
+def _prune_overlapping_native_match_groups(
+    grouped_matches: dict[tuple[int, int], list[tuple[int, NameTokenBinding]]],
+) -> dict[tuple[int, int], list[tuple[int, NameTokenBinding]]]:
+    """Drop broader helper matches when graph-local subpieces explain the same text."""
+
+    pruned = {key: list(matches) for key, matches in grouped_matches.items()}
+    for key, matches in list(grouped_matches.items()):
+        start, end = key
+        kept: list[tuple[int, NameTokenBinding]] = []
+        for binding_idx, token in matches:
+            if _is_redundant_tree_container(start, end, token, grouped_matches):
+                continue
+            if _has_longer_same_start_token(start, end, token, grouped_matches):
+                continue
+            kept.append((binding_idx, token))
+        if kept:
+            pruned[key] = kept
+        else:
+            pruned.pop(key, None)
+    return pruned
+
+
+def _is_redundant_tree_container(
+    start: int,
+    end: int,
+    token: NameTokenBinding,
+    grouped_matches: dict[tuple[int, int], list[tuple[int, NameTokenBinding]]],
+) -> bool:
+    if token.source != "substituent_tree" or not token.atom_ids:
+        return False
+    covered = set()
+    for (other_start, other_end), other_matches in grouped_matches.items():
+        if other_start < start or other_end > end or (other_start, other_end) == (start, end):
+            continue
+        for _binding_idx, other in other_matches:
+            if other.source != "substituent_renderer":
+                continue
+            if set(other.atom_ids) != set(token.atom_ids) or set(other.bond_ids) != set(token.bond_ids):
+                continue
+            covered.update(range(other_start, other_end))
+    return len(covered) >= max(1, (end - start) // 2)
+
+
+def _has_longer_same_start_token(
+    start: int,
+    end: int,
+    token: NameTokenBinding,
+    grouped_matches: dict[tuple[int, int], list[tuple[int, NameTokenBinding]]],
+) -> bool:
+    if token.source != "substituent_renderer" or not token.atom_ids:
+        return False
+    for (other_start, other_end), other_matches in grouped_matches.items():
+        if other_start != start or other_end <= end:
+            continue
+        for _binding_idx, other in other_matches:
+            if other.source != token.source:
+                continue
+            if other.binding_key != token.binding_key:
+                continue
+            if set(other.atom_ids) == set(token.atom_ids) and set(other.bond_ids) == set(token.bond_ids):
+                return True
+    return False
+
+
+def _should_split_broad_exact_match(
+    text: str,
+    start: int,
+    end: int,
+    exact_matches: list[tuple[int, NameTokenBinding]],
+    matches: list[tuple[int, int, int, NameTokenBinding]],
+) -> bool:
+    """Prefer graph-local sub-tokens over broad recursive fragment names."""
+
+    if not exact_matches:
+        return False
+    if not all(token.source == "substituent_tree" for _binding_idx, token in exact_matches):
+        return False
+    exact_atoms = set().union(*(set(token.atom_ids) for _binding_idx, token in exact_matches))
+    if not exact_atoms:
+        return False
+    contained_renderer_matches = [
+        (span_start, span_end, token)
+        for span_start, span_end, _binding_idx, token in matches
+        if start <= span_start
+        and span_end <= end
+        and not (span_start == start and span_end == end)
+        and token.source == "substituent_renderer"
+        and token.atom_ids
+        and set(token.atom_ids) <= exact_atoms
+    ]
+    if not contained_renderer_matches:
+        return False
+    covered = {
+        index
+        for span_start, span_end, _token in contained_renderer_matches
+        for index in range(max(start, span_start), min(end, span_end))
+        if text[index].isalnum()
+    }
+    alnum_positions = {index for index in range(start, end) if text[index].isalnum()}
+    return bool(alnum_positions) and len(covered) >= max(1, len(alnum_positions) // 2)
+
+
+def _following_text_starts_suffix(text: str, end: int) -> bool:
+    following = text[end:].lower()
+    return following.startswith("-carboxylic") or following.startswith("-carboxylate") or following.startswith("-amide")
+
+
+def _preferred_element_locant_matches(
+    token_text: str,
+    exact_matches: list[tuple[int, NameTokenBinding]],
+) -> list[tuple[int, NameTokenBinding]]:
+    if token_text not in _ELEMENT_LOCANT_TOKENS:
+        return []
+    preferred = [
+        (binding_idx, token)
+        for binding_idx, token in exact_matches
+        if token.source == "n_substituent_locant" or token.binding_key == "prefix:n_substituent_locant"
+    ]
+    return preferred
+
+
+def _widest_locant_scope(exact_matches: list[tuple[int, NameTokenBinding]]) -> list[tuple[int, NameTokenBinding]]:
+    if len(exact_matches) <= 1:
+        return exact_matches
+    max_size = max(len(token.atom_ids) + len(token.bond_ids) for _binding_idx, token in exact_matches)
+    if max_size <= 0:
+        return exact_matches
+    return [
+        (binding_idx, token)
+        for binding_idx, token in exact_matches
+        if len(token.atom_ids) + len(token.bond_ids) == max_size
+    ]
+
+
+def _governing_structural_scope_after_locant_cluster(
+    text: str,
+    end: int,
+    all_matches: list[tuple[int, int, int, NameTokenBinding]],
+) -> set[int]:
+    pos = end
+    while pos < len(text) and (text[pos].isdigit() or text[pos] in {",", "'", '"', "(", ")"}):
+        pos += 1
+    if pos >= len(text) or text[pos] != "-":
+        return set()
+    return _next_structural_native_scope(text, pos + 1, all_matches)
+
+
+def _next_structural_native_scope(
+    text: str,
+    end: int,
+    all_matches: list[tuple[int, int, int, NameTokenBinding]],
+) -> set[int]:
+    next_lexical = _LEXICAL_TOKEN_RE.search(text, end)
+    while next_lexical:
+        token_norm = _normalise_name_text(next_lexical.group(0))
+        if token_norm in _NON_STRUCTURAL_GRAMMAR_TOKENS:
+            next_lexical = _LEXICAL_TOKEN_RE.search(text, next_lexical.end())
+            continue
+        next_start, next_end = next_lexical.span()
+        atom_ids: set[int] = set()
+        for span_start, span_end, _binding_idx, token in all_matches:
+            if token.token_kind == "locant":
+                continue
+            if _spans_overlap(next_start, next_end, span_start, span_end):
+                atom_ids.update(token.atom_ids)
+        if atom_ids:
+            return atom_ids
+        next_lexical = _LEXICAL_TOKEN_RE.search(text, next_lexical.end())
+    return set()
 
 
 def _adjacent_native_gap_matches(
@@ -1649,8 +2042,20 @@ def _token_span_for_native_gap(
     end: int,
     full_text: str,
     adjacent_matches: list[tuple[int, NameTokenBinding]] | None = None,
+    bindings: tuple[NameAtomBinding, ...] = (),
 ) -> NameTokenSpan:
     token_norm = _normalise_name_text(text)
+    if _is_punctuation_only_gap(text):
+        return NameTokenSpan(
+            text=text,
+            start=start,
+            end=end,
+            token_kind="grammar",
+            ownership="grammar_scope",
+            confidence="derived",
+            source="compound_gap_token",
+            grammar_role="punctuation",
+        )
     if token_norm in _COMPOUND_CONNECTIVE_TOKENS and adjacent_matches:
         bridged = _token_span_from_native_binding_group(text, start, end, adjacent_matches)
         return NameTokenSpan(
@@ -1681,6 +2086,9 @@ def _token_span_for_native_gap(
             grammar_role=token_norm,
         )
     if adjacent_matches:
+        parent_suffix_gap = _parent_suffix_morphology_gap_resolution(adjacent_matches, bindings)
+        if parent_suffix_gap is not None:
+            return _token_span_from_binding_indices(text, start, end, parent_suffix_gap, bindings)
         bridged = _token_span_from_native_binding_group(text, start, end, adjacent_matches)
         return NameTokenSpan(
             text=bridged.text,
@@ -1710,12 +2118,68 @@ def _token_span_for_native_gap(
     )
 
 
+def _is_punctuation_only_gap(text: str) -> bool:
+    return bool(text) and all(not char.isalnum() for char in text)
+
+
+def _parent_suffix_morphology_gap_resolution(
+    adjacent_matches: list[tuple[int, NameTokenBinding]],
+    bindings: tuple[NameAtomBinding, ...],
+) -> TokenBindingResolution | None:
+    """Bind parent/suffix morphology gaps without pulling in prefix scope."""
+
+    if not bindings:
+        return None
+    adjacent_indices = {binding_idx for binding_idx, _token in adjacent_matches}
+    has_prefix = any(bindings[idx].stage == "prefix" for idx in adjacent_indices)
+    suffix_indices = {idx for idx in adjacent_indices if bindings[idx].stage == "suffix"}
+    if not has_prefix or not suffix_indices:
+        return None
+    parent_indices = _parent_binding_indices(bindings)
+    scoped = tuple(sorted(parent_indices | suffix_indices))
+    if not scoped:
+        return None
+    return TokenBindingResolution(
+        binding_indices=scoped,
+        token_kind="parent",
+        ownership="morphology_gap",
+        confidence="derived",
+        source="parent_suffix_gap",
+        grammar_role="parent_suffix_morphology",
+        binding_key="parent_suffix_gap",
+    )
+
+
 def _token_span_from_native_binding_group(
     text: str,
     start: int,
     end: int,
     matches: list[tuple[int, NameTokenBinding]],
 ) -> NameTokenSpan:
+    if text.lower() == "en":
+        bridge_matches = [
+            (binding_idx, token_binding)
+            for binding_idx, token_binding in matches
+            if token_binding.binding_key == "prefix:alkenyl_bridge"
+        ]
+        if bridge_matches:
+            matches = bridge_matches
+    if text.lower() == "oxy":
+        oxy_matches = [
+            (binding_idx, token_binding)
+            for binding_idx, token_binding in matches
+            if token_binding.binding_key == "prefix:heteroatom_center"
+        ]
+        if oxy_matches:
+            matches = oxy_matches
+        else:
+            prefix_oxy_matches = [
+                (binding_idx, token_binding)
+                for binding_idx, token_binding in matches
+                if token_binding.binding_key.startswith("prefix:")
+            ]
+            if prefix_oxy_matches:
+                matches = prefix_oxy_matches
     stereo_matches = [
         (binding_idx, token_binding)
         for binding_idx, token_binding in matches

--- a/src/bluenamer/name_bindings.py
+++ b/src/bluenamer/name_bindings.py
@@ -939,7 +939,7 @@ def _extend_tree_substituent_tokens(tokens: list[NameTokenBinding], node: dict, 
         parent_bonds = set(parent.get("bonds") or [])
         parent_name = str(parent.get("retained_name") or "")
         _append_parent_locant_tokens(tokens, node.get("name") or "", parent, parent_bonds, node_charges)
-        _append_substituent_suffix_tokens(tokens, parent, parent_bonds, node_charges)
+        _append_substituent_suffix_tokens(tokens, node.get("name") or "", parent, parent_bonds, node_charges)
         if parent_name and _term_visible_in_name(parent_name, node_name):
             _append_name_tokens(tokens, parent_name, parent_atoms, parent_bonds, node_charges)
         for segment in node.get("trace_segments") or ():
@@ -986,20 +986,21 @@ def _extend_tree_substituent_tokens(tokens: list[NameTokenBinding], node: dict, 
             child_atoms = set(child.get("atoms") or [])
             child_bonds = set(child.get("bonds") or [])
             child_charges = set(child.get("charge_atoms") or [])
-            for locant in child.get("locants") or ():
-                tokens.append(
-                    NameTokenBinding(
-                        text=str(locant),
-                        token_kind="locant",
-                        source="substituent_tree",
-                        grammar_role=child.get("kind") or simple_key,
-                        binding_key="prefix:tree_locant",
-                        atom_ids=set(child_atoms),
-                        bond_ids=set(child_bonds),
-                        charge_atom_ids=set(child_charges),
-                        locants=(str(locant),),
+            if not isinstance(child.get("parent"), dict):
+                for locant in child.get("locants") or ():
+                    tokens.append(
+                        NameTokenBinding(
+                            text=str(locant),
+                            token_kind="locant",
+                            source="substituent_tree",
+                            grammar_role=child.get("kind") or simple_key,
+                            binding_key="prefix:tree_locant",
+                            atom_ids=set(child_atoms),
+                            bond_ids=set(child_bonds),
+                            charge_atom_ids=set(child_charges),
+                            locants=(str(locant),),
+                        )
                     )
-                )
             if not emitted_node_name:
                 _extend_tree_substituent_tokens(tokens, child, include_node_name=True)
 
@@ -1073,6 +1074,7 @@ def _append_parent_locant_tokens(
 
 def _append_substituent_suffix_tokens(
     tokens: list[NameTokenBinding],
+    name: str,
     parent: dict,
     bond_ids: set[int],
     charge_atom_ids: set[int],
@@ -1084,6 +1086,8 @@ def _append_substituent_suffix_tokens(
     suffix = str(suffix_data.get("suffix") or "")
     atom_id = suffix_data.get("atom_id")
     if not locant or not suffix:
+        return
+    if locant not in set(locant_tokens_in_text(name)):
         return
     try:
         atom_idx = int(atom_id)

--- a/src/bluenamer/name_bindings.py
+++ b/src/bluenamer/name_bindings.py
@@ -112,7 +112,12 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
     for item in parts.substituents:
         role = "spiro_substituent" if item.spiro is not None else "substituent"
         term = item.spiro.side_parent_name if item.spiro is not None else item.name
-        prefix_tokens = tuple(item.emitted_tokens) or _rendered_term_tokens(
+        prefix_tokens = (
+            _tree_substituent_emitted_tokens(item)
+            if _use_tree_substituent_tokens(item)
+            else tuple(item.emitted_tokens)
+        )
+        prefix_tokens = prefix_tokens or _rendered_term_tokens(
             term,
             token_kind="prefix",
             grammar_role=role,
@@ -152,6 +157,7 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
                 atom_ids=set(item.atom_ids),
                 bond_ids=set(item.bond_ids),
                 locants=tuple(str(locant) for locant in item.locants),
+                emitted_tokens=_unsaturation_emitted_tokens(parts, item),
             )
         )
     if parts.principal_group is not None:
@@ -318,6 +324,8 @@ def _with_default_emitted_tokens(binding: NameAtomBinding) -> NameAtomBinding:
 def _with_required_locant_tokens(binding: NameAtomBinding) -> NameAtomBinding:
     if not binding.locants:
         return binding
+    if binding.stage == "unsaturation" and binding.emitted_tokens:
+        return binding
     locant_text = ",".join(str(locant) for locant in binding.locants)
     required_tokens = []
     if not any(token.text == locant_text for token in binding.emitted_tokens):
@@ -472,6 +480,70 @@ def _hydro_operation_tokens(operation) -> tuple[NameTokenBinding, ...]:
     return tuple(tokens)
 
 
+def _unsaturation_emitted_tokens(parts: AssemblyParts, item) -> tuple[NameTokenBinding, ...]:
+    """Emit per-locant tokens for parent unsaturation from the locant map."""
+
+    tokens: list[NameTokenBinding] = []
+    locants = tuple(str(locant) for locant in item.locants)
+    for locant in reversed(_displayed_unsaturation_locants(locants)):
+        atom_ids, bond_ids = _unsaturation_locant_scope(parts, locant, set(item.bond_ids))
+        if not atom_ids and not bond_ids:
+            continue
+        tokens.insert(
+            0,
+            NameTokenBinding(
+                text=locant,
+                token_kind="locant",
+                source="default_binding",
+                grammar_role=item.bond_key,
+                binding_key=f"unsaturation:{item.bond_key}",
+                atom_ids=atom_ids,
+                bond_ids=bond_ids,
+                locants=(locant,),
+            ),
+        )
+    tokens.append(
+        NameTokenBinding(
+            text=bonds.get(item.bond_key).suffix,
+            token_kind="unsaturation",
+            source="default_binding",
+            grammar_role=item.bond_key,
+            binding_key=f"unsaturation:{item.bond_key}",
+            atom_ids=set(item.atom_ids),
+            bond_ids=set(item.bond_ids),
+            locants=locants,
+        )
+    )
+    return tuple(tokens)
+
+
+def _displayed_unsaturation_locants(locants: tuple[str, ...]) -> tuple[str, ...]:
+    displayed: list[str] = []
+    for locant in locants:
+        match = re.fullmatch(r"([^()]+)\(([^()]+)\)", locant)
+        if match:
+            displayed.extend([match.group(1), match.group(2)])
+        else:
+            displayed.append(locant)
+    return tuple(displayed)
+
+
+def _unsaturation_locant_scope(
+    parts: AssemblyParts,
+    locant: str,
+    allowed_bond_ids: set[int],
+) -> tuple[set[int], set[int]]:
+    atom_idx = parts.parent_atom_ids_by_locant.get(str(locant))
+    atom_ids = {atom_idx} if atom_idx is not None else set()
+    bond_ids = {
+        bond_id
+        for locant_pair, bond_id in parts.parent_bond_ids_by_locants.items()
+        if str(locant) in {str(value) for value in locant_pair}
+        and (not allowed_bond_ids or bond_id in allowed_bond_ids)
+    }
+    return atom_ids, bond_ids
+
+
 def _absolute_stereo_tokens(locant: str, descriptor: str, atom_idx: int) -> tuple[NameTokenBinding, ...]:
     """Return native tokens for an absolute stereochemical descriptor."""
 
@@ -593,9 +665,25 @@ def _locanted_emitted_tokens(
 ) -> tuple[NameTokenBinding, ...]:
     if not locants:
         return emitted_tokens
+    instance_tokens = _instance_tokens_for_locants(emitted_tokens, locants)
     locant_text = ",".join(locants)
     tokens = list(emitted_tokens)
-    if not any(token.text == locant_text for token in tokens):
+    tokens.extend(
+        _multiplied_hydroxy_tokens(
+            tokens,
+            locants,
+            grammar_role=grammar_role,
+            binding_key=binding_key,
+            atom_ids=atom_ids,
+            bond_ids=bond_ids,
+            charge_atom_ids=charge_atom_ids,
+        )
+    )
+    has_required_locant = any(_same_required_locant_token(token, locant_text, binding_key) for token in tokens)
+    has_existing_element_locant = locant_text in {"N", "O", "P", "S"} and any(
+        token.text == locant_text and token.token_kind == "locant" for token in tokens
+    )
+    if not has_required_locant and not has_existing_element_locant:
         tokens.insert(
             0,
             NameTokenBinding(
@@ -613,8 +701,14 @@ def _locanted_emitted_tokens(
     for locant in reversed(locants):
         if len(locants) <= 1:
             continue
-        if any(token.text == locant for token in tokens):
+        if any(token.text == locant and token.token_kind == "locant" for token in tokens):
             continue
+        instance_token = instance_tokens.get(locant)
+        locant_atom_ids = set(instance_token.atom_ids) if instance_token is not None else set(atom_ids)
+        locant_bond_ids = set(instance_token.bond_ids) if instance_token is not None else set(bond_ids)
+        locant_charge_atom_ids = (
+            set(instance_token.charge_atom_ids) if instance_token is not None else set(charge_atom_ids)
+        )
         tokens.insert(
             0,
             NameTokenBinding(
@@ -623,13 +717,79 @@ def _locanted_emitted_tokens(
                 source="default_binding",
                 grammar_role=grammar_role,
                 binding_key=binding_key,
-                atom_ids=set(atom_ids),
-                bond_ids=set(bond_ids),
-                charge_atom_ids=set(charge_atom_ids),
-                locants=locants,
+                atom_ids=locant_atom_ids,
+                bond_ids=locant_bond_ids,
+                charge_atom_ids=locant_charge_atom_ids,
+                locants=(locant,),
             ),
         )
     return tuple(tokens)
+
+
+def _multiplied_hydroxy_tokens(
+    tokens: list[NameTokenBinding],
+    locants: tuple[str, ...],
+    *,
+    grammar_role: str,
+    binding_key: str,
+    atom_ids: set[int],
+    bond_ids: set[int],
+    charge_atom_ids: set[int],
+) -> tuple[NameTokenBinding, ...]:
+    if len(locants) <= 1:
+        return ()
+    if not any(token.text in {"hydroxy", "oxy", "carboxy"} for token in tokens):
+        return ()
+    if any(token.text in {"dihydr", "trihydr", "tetrahydr"} for token in tokens):
+        return ()
+    multiplier_stem = {2: "dihydr", 3: "trihydr", 4: "tetrahydr"}.get(len(locants))
+    if multiplier_stem is None:
+        return ()
+    return (
+        NameTokenBinding(
+            text=multiplier_stem,
+            token_kind="grammar",
+            source="substituent_renderer",
+            grammar_role=grammar_role,
+            binding_key=binding_key,
+            atom_ids=set(atom_ids),
+            bond_ids=set(bond_ids),
+            charge_atom_ids=set(charge_atom_ids),
+            locants=locants,
+        ),
+        NameTokenBinding(
+            text="oxy",
+            token_kind="prefix",
+            source="substituent_renderer",
+            grammar_role=grammar_role,
+            binding_key=binding_key,
+            atom_ids=set(atom_ids),
+            bond_ids=set(bond_ids),
+            charge_atom_ids=set(charge_atom_ids),
+            locants=locants,
+        ),
+    )
+
+
+def _same_required_locant_token(token: NameTokenBinding, text: str, binding_key: str) -> bool:
+    return token.text == text and token.token_kind == "locant" and token.binding_key == binding_key
+
+
+def _instance_tokens_for_locants(
+    emitted_tokens: tuple[NameTokenBinding, ...],
+    locants: tuple[str, ...],
+) -> dict[str, NameTokenBinding]:
+    locant_count = len(locants)
+    if locant_count <= 1:
+        return {}
+    structural_tokens = [
+        token
+        for token in emitted_tokens
+        if token.token_kind != "locant" and (token.atom_ids or token.bond_ids or token.charge_atom_ids)
+    ]
+    if len(structural_tokens) != locant_count:
+        return {}
+    return {str(locant): token for locant, token in zip(locants, structural_tokens, strict=False)}
 
 
 def _principal_suffix_emitted_tokens(group) -> tuple[NameTokenBinding, ...]:
@@ -681,6 +841,281 @@ def _rendered_term_tokens(
             )
         )
     return tuple(tokens)
+
+
+def _tree_substituent_emitted_tokens(item) -> tuple[NameTokenBinding, ...]:
+    """Emit precise tokens for a recursive substituent tree.
+
+    A complex substituent such as
+    ``(2-(4-fluorophenyl)-...-1H-pyrrol-1-yl)`` has one top-level graph scope
+    but many nested name pieces with narrower graph ownership. Tokenizing the
+    whole top-level phrase would make every child token inherit the full
+    substituent graph. Instead, reuse the recursive tree's local fragments.
+    """
+
+    tree = item.substituent_tree
+    if not isinstance(tree, dict):
+        return tuple(item.emitted_tokens)
+    tokens: list[NameTokenBinding] = []
+    _extend_tree_substituent_tokens(tokens, tree, include_node_name=False)
+    tokens.extend(_preserved_renderer_tokens_for_tree_substituent(item.emitted_tokens))
+    return _dedupe_token_bindings(tokens) or tuple(item.emitted_tokens)
+
+
+def _use_tree_substituent_tokens(item) -> bool:
+    tree = item.substituent_tree
+    if not isinstance(tree, dict):
+        return False
+    return any(_is_recursive_fragment_child(child) for child in tree.get("substituents") or ())
+
+
+def _is_recursive_fragment_child(child: dict) -> bool:
+    return isinstance(child, dict) and (
+        child.get("kind") == "fragment"
+        or isinstance(child.get("parent"), dict)
+        or bool(child.get("substituents"))
+    )
+
+
+def _preserved_renderer_tokens_for_tree_substituent(
+    emitted_tokens: tuple[NameTokenBinding, ...],
+) -> tuple[NameTokenBinding, ...]:
+    return tuple(
+        token
+        for token in emitted_tokens
+        if token.token_kind == "stereo"
+        or token.source == "renderer_stereo"
+        or token.source == "n_substituent_locant"
+        or (
+            token.source == "substituent_renderer"
+            and token.binding_key
+            in {
+                "prefix:alkenyl_branch_locant",
+                "prefix:alkenyl_bridge",
+                "prefix:alkenyl_bridge_stereo",
+                "prefix:aryl_branch",
+                "prefix:aryl_branch_locants",
+                "prefix:carbonyl_like_core",
+                "prefix:heteroatom_center",
+            }
+        )
+    )
+
+
+def _extend_tree_substituent_tokens(tokens: list[NameTokenBinding], node: dict, *, include_node_name: bool) -> None:
+    if not isinstance(node, dict):
+        return
+    node_atoms = set(node.get("atoms") or [])
+    node_bonds = set(node.get("bonds") or [])
+    node_charges = set(node.get("charge_atoms") or [])
+    emitted_node_name = False
+    if include_node_name:
+        emitted_node_name = _append_name_tokens(tokens, node.get("name") or "", node_atoms, node_bonds, node_charges)
+    parent = node.get("parent") if isinstance(node.get("parent"), dict) else None
+    node_name = str(node.get("name") or "")
+    if parent is not None:
+        parent_atoms = set(parent.get("atoms") or [])
+        parent_bonds = set(parent.get("bonds") or [])
+        parent_name = str(parent.get("retained_name") or "")
+        _append_parent_locant_tokens(tokens, node.get("name") or "", parent, parent_bonds, node_charges)
+        _append_substituent_suffix_tokens(tokens, node_name, parent, parent_bonds, node_charges)
+        if parent_name and _term_visible_in_name(parent_name, node_name):
+            _append_name_tokens(tokens, parent_name, parent_atoms, parent_bonds, node_charges)
+        for segment in node.get("trace_segments") or ():
+            if not isinstance(segment, dict):
+                continue
+            if segment.get("label") != "parent skeleton":
+                continue
+            if set(segment.get("atoms") or []) != parent_atoms:
+                continue
+            for term in segment.get("name_terms") or ():
+                if not _term_visible_in_name(str(term), node_name):
+                    continue
+                _append_name_tokens(tokens, str(term), parent_atoms, parent_bonds, node_charges)
+    for hydro in node.get("hydro_operations") or ():
+        if not isinstance(hydro, dict):
+            continue
+        atoms = set(hydro.get("atom_ids") or [])
+        for locant in hydro.get("locants") or ():
+            tokens.append(
+                NameTokenBinding(
+                    text=str(locant),
+                    token_kind="locant",
+                    source="substituent_tree",
+                    grammar_role="indicated_hydrogen",
+                    binding_key="prefix:tree_hydro",
+                    atom_ids=set(atoms),
+                    locants=(str(locant),),
+                )
+            )
+        tokens.append(
+            NameTokenBinding(
+                text="H",
+                token_kind="hydro",
+                source="substituent_tree",
+                grammar_role="indicated_hydrogen",
+                binding_key="prefix:tree_hydro",
+                atom_ids=set(atoms),
+            )
+        )
+    for simple_key in ("replacement_prefixes", "substituents"):
+        for child in node.get(simple_key) or ():
+            if not isinstance(child, dict):
+                continue
+            child_atoms = set(child.get("atoms") or [])
+            child_bonds = set(child.get("bonds") or [])
+            child_charges = set(child.get("charge_atoms") or [])
+            for locant in child.get("locants") or ():
+                tokens.append(
+                    NameTokenBinding(
+                        text=str(locant),
+                        token_kind="locant",
+                        source="substituent_tree",
+                        grammar_role=child.get("kind") or simple_key,
+                        binding_key="prefix:tree_locant",
+                        atom_ids=set(child_atoms),
+                        bond_ids=set(child_bonds),
+                        charge_atom_ids=set(child_charges),
+                        locants=(str(locant),),
+                    )
+                )
+            if not emitted_node_name:
+                _extend_tree_substituent_tokens(tokens, child, include_node_name=True)
+
+
+def _append_name_tokens(
+    tokens: list[NameTokenBinding],
+    name: str,
+    atom_ids: set[int],
+    bond_ids: set[int],
+    charge_atom_ids: set[int],
+) -> bool:
+    emitted = False
+    for token_text in _binding_term_tokens(name):
+        if _is_locant_like_token(token_text):
+            continue
+        emitted = True
+        tokens.append(
+            NameTokenBinding(
+                text=token_text,
+                token_kind="prefix",
+                source="substituent_tree",
+                grammar_role="recursive_substituent",
+                binding_key="prefix:tree_substituent",
+                atom_ids=set(atom_ids),
+                bond_ids=set(bond_ids),
+                charge_atom_ids=set(charge_atom_ids),
+            )
+        )
+    return emitted
+
+
+def _term_visible_in_name(term: str, name: str) -> bool:
+    term_norm = re.sub(r"[^a-z0-9]+", "", term.lower())
+    name_norm = re.sub(r"[^a-z0-9]+", "", name.lower())
+    return bool(term_norm) and term_norm in name_norm
+
+
+def _append_parent_locant_tokens(
+    tokens: list[NameTokenBinding],
+    name: str,
+    parent: dict,
+    bond_ids: set[int],
+    charge_atom_ids: set[int],
+) -> None:
+    locant_map = parent.get("atom_ids_by_locant")
+    if not isinstance(locant_map, dict):
+        return
+    name_locants = set(_locant_like_tokens_in_name(name))
+    for locant, atom_id in locant_map.items():
+        locant_text = str(locant)
+        if locant_text not in name_locants:
+            continue
+        try:
+            atom_idx = int(atom_id)
+        except (TypeError, ValueError):
+            continue
+        tokens.append(
+            NameTokenBinding(
+                text=locant_text,
+                token_kind="locant",
+                source="substituent_tree",
+                grammar_role="recursive_parent_locant",
+                binding_key="prefix:tree_parent_locant",
+                atom_ids={atom_idx},
+                bond_ids=set(bond_ids),
+                charge_atom_ids=set(charge_atom_ids) & {atom_idx},
+                locants=(locant_text,),
+            )
+        )
+
+
+def _append_substituent_suffix_tokens(
+    tokens: list[NameTokenBinding],
+    name: str,
+    parent: dict,
+    bond_ids: set[int],
+    charge_atom_ids: set[int],
+) -> None:
+    match = re.search(r"(?:^|[-(])([0-9]+|N|O|P|S)-(?P<suffix>yl|ylidene|ylidyne)\)?$", name)
+    if not match:
+        return
+    locant = match.group(1)
+    atom_id = _parent_atom_for_locant(parent, locant)
+    if atom_id is None:
+        return
+    suffix = match.group("suffix")
+    tokens.append(
+        NameTokenBinding(
+            text=suffix,
+            token_kind="prefix",
+            source="substituent_tree",
+            grammar_role="recursive_substituent_suffix",
+            binding_key="prefix:tree_substituent_suffix",
+            atom_ids={atom_id},
+            bond_ids=set(bond_ids),
+            charge_atom_ids=set(charge_atom_ids) & {atom_id},
+            locants=(locant,),
+        )
+    )
+
+
+def _parent_atom_for_locant(parent: dict, locant: str) -> int | None:
+    locant_map = parent.get("atom_ids_by_locant")
+    if not isinstance(locant_map, dict):
+        return None
+    atom_id = locant_map.get(str(locant))
+    try:
+        return int(atom_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _locant_like_tokens_in_name(name: str) -> tuple[str, ...]:
+    return tuple(token for token in _binding_term_tokens(name) if _is_locant_like_token(token))
+
+
+def _is_locant_like_token(token: str) -> bool:
+    return bool(re.fullmatch(r"(?:[0-9]+|N|O|P|S)(?:,(?:[0-9]+|N|O|P|S))*", token))
+
+
+def _dedupe_token_bindings(tokens: list[NameTokenBinding]) -> tuple[NameTokenBinding, ...]:
+    deduped: list[NameTokenBinding] = []
+    seen: set[tuple] = set()
+    for token in tokens:
+        key = (
+            token.text,
+            token.token_kind,
+            tuple(sorted(token.atom_ids)),
+            tuple(sorted(token.bond_ids)),
+            tuple(sorted(token.charge_atom_ids)),
+            tuple(token.locants),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(token)
+    return tuple(deduped)
 
 
 def _data_backed_prefix_subtokens(term: str) -> tuple[str, ...]:

--- a/src/bluenamer/name_bindings.py
+++ b/src/bluenamer/name_bindings.py
@@ -118,9 +118,7 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
         role = "spiro_substituent" if item.spiro is not None else "substituent"
         term = item.spiro.side_parent_name if item.spiro is not None else item.name
         prefix_tokens = (
-            _tree_substituent_emitted_tokens(item)
-            if _use_tree_substituent_tokens(item)
-            else tuple(item.emitted_tokens)
+            _tree_substituent_emitted_tokens(item) if _use_tree_substituent_tokens(item) else tuple(item.emitted_tokens)
         )
         prefix_tokens = prefix_tokens or _rendered_term_tokens(
             term,
@@ -892,9 +890,7 @@ def _use_tree_substituent_tokens(item) -> bool:
 
 def _is_recursive_fragment_child(child: dict) -> bool:
     return isinstance(child, dict) and (
-        child.get("kind") == "fragment"
-        or isinstance(child.get("parent"), dict)
-        or bool(child.get("substituents"))
+        child.get("kind") == "fragment" or isinstance(child.get("parent"), dict) or bool(child.get("substituents"))
     )
 
 

--- a/src/bluenamer/name_bindings.py
+++ b/src/bluenamer/name_bindings.py
@@ -8,6 +8,11 @@ from .nomenclature import RULES
 from .principal_suffixes import render_principal_suffix
 from .rules import bonds, stems
 from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, BOND_STEREO_DESCRIPTORS
+from .token_grammar import (
+    binding_term_tokens,
+    is_locant_token,
+    locant_tokens_in_text,
+)
 
 
 def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
@@ -207,6 +212,10 @@ def binding_trace_data(bindings: list[NameAtomBinding]) -> list[dict]:
             "emitted_tokens": [
                 {
                     "text": token.text,
+                    "render_order": token.render_order,
+                    "match_priority": token.match_priority,
+                    "left_context": token.left_context,
+                    "right_context": token.right_context,
                     "locants": list(token.locants),
                     "atoms": sorted(token.atom_ids),
                     "bonds": sorted(token.bond_ids),
@@ -288,6 +297,7 @@ def _postprocess_token_binding(
     token_changed = processed_text != token.text
     return NameTokenBinding(
         text=processed_text,
+        render_order=token.render_order,
         token_kind=token.token_kind,
         ownership=rewritten_token_ownership if token_changed and rewritten_token_ownership else token.ownership,
         confidence="derived" if token.confidence == "exact" else token.confidence,
@@ -298,6 +308,9 @@ def _postprocess_token_binding(
         bond_ids=set(token.bond_ids),
         charge_atom_ids=set(token.charge_atom_ids),
         locants=tuple(token.locants),
+        match_priority=token.match_priority,
+        left_context=token.left_context,
+        right_context=token.right_context,
     )
 
 
@@ -558,6 +571,7 @@ def _absolute_stereo_tokens(locant: str, descriptor: str, atom_idx: int) -> tupl
             binding_key="assembly:absolute_stereo",
             atom_ids={atom_idx},
             locants=(locant,),
+            match_priority=100,
         ),
         NameTokenBinding(
             text=descriptor,
@@ -569,6 +583,7 @@ def _absolute_stereo_tokens(locant: str, descriptor: str, atom_idx: int) -> tupl
             binding_key="assembly:absolute_stereo",
             atom_ids={atom_idx},
             locants=(locant,),
+            match_priority=100,
         ),
     )
 
@@ -616,6 +631,7 @@ def _bond_stereo_tokens(
             atom_ids=atom_ids,
             bond_ids=bond_ids,
             locants=(locant,),
+            match_priority=100,
         ),
         NameTokenBinding(
             text=descriptor,
@@ -628,6 +644,7 @@ def _bond_stereo_tokens(
             atom_ids=atom_ids,
             bond_ids=bond_ids,
             locants=(locant,),
+            match_priority=100,
         ),
     )
 
@@ -648,6 +665,7 @@ def _relative_stereo_tokens(binding: NameAtomBinding) -> tuple[NameTokenBinding,
             bond_ids=set(binding.bond_ids),
             charge_atom_ids=set(binding.charge_atom_ids),
             locants=tuple(binding.locants),
+            match_priority=100,
         ),
     )
 
@@ -756,6 +774,7 @@ def _multiplied_hydroxy_tokens(
             bond_ids=set(bond_ids),
             charge_atom_ids=set(charge_atom_ids),
             locants=locants,
+            match_priority=50,
         ),
         NameTokenBinding(
             text="oxy",
@@ -767,6 +786,8 @@ def _multiplied_hydroxy_tokens(
             bond_ids=set(bond_ids),
             charge_atom_ids=set(charge_atom_ids),
             locants=locants,
+            match_priority=50,
+            left_context=multiplier_stem,
         ),
     )
 
@@ -918,7 +939,7 @@ def _extend_tree_substituent_tokens(tokens: list[NameTokenBinding], node: dict, 
         parent_bonds = set(parent.get("bonds") or [])
         parent_name = str(parent.get("retained_name") or "")
         _append_parent_locant_tokens(tokens, node.get("name") or "", parent, parent_bonds, node_charges)
-        _append_substituent_suffix_tokens(tokens, node_name, parent, parent_bonds, node_charges)
+        _append_substituent_suffix_tokens(tokens, parent, parent_bonds, node_charges)
         if parent_name and _term_visible_in_name(parent_name, node_name):
             _append_name_tokens(tokens, parent_name, parent_atoms, parent_bonds, node_charges)
         for segment in node.get("trace_segments") or ():
@@ -992,7 +1013,7 @@ def _append_name_tokens(
 ) -> bool:
     emitted = False
     for token_text in _binding_term_tokens(name):
-        if _is_locant_like_token(token_text):
+        if is_locant_token(token_text):
             continue
         emitted = True
         tokens.append(
@@ -1026,7 +1047,7 @@ def _append_parent_locant_tokens(
     locant_map = parent.get("atom_ids_by_locant")
     if not isinstance(locant_map, dict):
         return
-    name_locants = set(_locant_like_tokens_in_name(name))
+    name_locants = set(locant_tokens_in_text(name))
     for locant, atom_id in locant_map.items():
         locant_text = str(locant)
         if locant_text not in name_locants:
@@ -1052,19 +1073,24 @@ def _append_parent_locant_tokens(
 
 def _append_substituent_suffix_tokens(
     tokens: list[NameTokenBinding],
-    name: str,
     parent: dict,
     bond_ids: set[int],
     charge_atom_ids: set[int],
 ) -> None:
-    match = re.search(r"(?:^|[-(])([0-9]+|N|O|P|S)-(?P<suffix>yl|ylidene|ylidyne)\)?$", name)
-    if not match:
+    suffix_data = parent.get("substituent_suffix")
+    if not isinstance(suffix_data, dict):
         return
-    locant = match.group(1)
-    atom_id = _parent_atom_for_locant(parent, locant)
-    if atom_id is None:
+    locant = str(suffix_data.get("locant") or "")
+    suffix = str(suffix_data.get("suffix") or "")
+    atom_id = suffix_data.get("atom_id")
+    if not locant or not suffix:
         return
-    suffix = match.group("suffix")
+    try:
+        atom_idx = int(atom_id)
+    except (TypeError, ValueError):
+        atom_idx = _parent_atom_for_locant(parent, locant)
+    if atom_idx is None:
+        return
     tokens.append(
         NameTokenBinding(
             text=suffix,
@@ -1072,9 +1098,9 @@ def _append_substituent_suffix_tokens(
             source="substituent_tree",
             grammar_role="recursive_substituent_suffix",
             binding_key="prefix:tree_substituent_suffix",
-            atom_ids={atom_id},
+            atom_ids={atom_idx},
             bond_ids=set(bond_ids),
-            charge_atom_ids=set(charge_atom_ids) & {atom_id},
+            charge_atom_ids=set(charge_atom_ids) & {atom_idx},
             locants=(locant,),
         )
     )
@@ -1089,14 +1115,6 @@ def _parent_atom_for_locant(parent: dict, locant: str) -> int | None:
         return int(atom_id)
     except (TypeError, ValueError):
         return None
-
-
-def _locant_like_tokens_in_name(name: str) -> tuple[str, ...]:
-    return tuple(token for token in _binding_term_tokens(name) if _is_locant_like_token(token))
-
-
-def _is_locant_like_token(token: str) -> bool:
-    return bool(re.fullmatch(r"(?:[0-9]+|N|O|P|S)(?:,(?:[0-9]+|N|O|P|S))*", token))
 
 
 def _dedupe_token_bindings(tokens: list[NameTokenBinding]) -> tuple[NameTokenBinding, ...]:
@@ -1187,6 +1205,7 @@ def _charge_operation_tokens(binding: NameAtomBinding) -> tuple[NameTokenBinding
                 atom_ids=set(binding.atom_ids),
                 charge_atom_ids=set(binding.charge_atom_ids or binding.atom_ids),
                 locants=tuple(binding.locants),
+                match_priority=90,
             )
         )
     charge_atoms = set(binding.charge_atom_ids or binding.atom_ids)
@@ -1201,6 +1220,7 @@ def _charge_operation_tokens(binding: NameAtomBinding) -> tuple[NameTokenBinding
                 atom_ids=set(binding.atom_ids),
                 charge_atom_ids=set(charge_atoms),
                 locants=tuple(binding.locants),
+                match_priority=90,
             )
         )
     return tuple(tokens)
@@ -1274,7 +1294,7 @@ def _binding_term_tokens(term: str) -> tuple[str, ...]:
 
     if not term.strip() or "_" in term:
         return ()
-    return tuple(match.group(0) for match in _BINDING_TOKEN_RE.finditer(term) if match.group(0).lower() != "parent")
+    return binding_term_tokens(term)
 
 
 def _token_kind_for_binding(binding: NameAtomBinding) -> str:
@@ -1354,9 +1374,6 @@ def _contextual_postprocess_replacements() -> tuple[tuple[str, str], ...]:
 
 def _normalise_name_text(text: str) -> str:
     return text.lower().replace(" ", "").replace("(", "").replace(")", "")
-
-
-_BINDING_TOKEN_RE = re.compile(r"[A-Za-z]+(?:\^[0-9]+)?|\d+(?:,\d+)*(?:'\")?|[0-9]+(?:\([0-9,]+\))?")
 
 
 def _replacement_charge_atom_ids(parts: AssemblyParts, item) -> set[int]:

--- a/src/bluenamer/namer.py
+++ b/src/bluenamer/namer.py
@@ -3,7 +3,7 @@
 import re
 from dataclasses import dataclass, field
 
-from .assembler import assemble_name_raw, post_process_name
+from .assembler import assemble_name_raw, post_process_rewrite_rules
 from .assembly_parts import AssemblyParts, SubstituentItem
 from .assembly_spiro import extract_spiro_side_prefixes
 from .chains import find_ring_systems, get_cyclic_atoms
@@ -816,6 +816,8 @@ def _collect_subgraph_substituents(
     candidate_path: list[int],
     sub_perceived: list[PerceivedGroup],
     sub_exclude: set[int],
+    *,
+    emit_metadata: bool = True,
 ) -> dict[int, list[SubstituentItem]]:
     """Collect prefixes attached to a recursive subgraph parent.
 
@@ -869,20 +871,43 @@ def _collect_subgraph_substituents(
 
         for n_idx in n_subs:
             if n_idx not in main_set and n_idx not in sub_handled_atoms and n_idx not in sub_exclude:
-                branch_decisions = DecisionTrace()
-                branch_name, branch_trace, branch_tree = name_subgraph(
-                    mol,
-                    n_idx,
-                    sub_exclude | main_set,
-                    upstream_atom=c_idx,
-                    return_trace=True,
-                    return_tree=True,
-                    decision_trace=branch_decisions,
-                )
+                branch_decisions = DecisionTrace() if emit_metadata else None
+                branch_exclude = sub_exclude | main_set
+                if emit_metadata:
+                    branch_name, branch_trace, branch_tree = name_subgraph(
+                        mol,
+                        n_idx,
+                        branch_exclude,
+                        upstream_atom=c_idx,
+                        return_trace=True,
+                        return_tree=True,
+                        decision_trace=branch_decisions,
+                    )
+                else:
+                    branch_name = name_subgraph(
+                        mol,
+                        n_idx,
+                        branch_exclude,
+                        upstream_atom=c_idx,
+                    )
+                    branch_trace = []
+                    branch_tree = None
                 if branch_name:
-                    branch_exclude = sub_exclude | main_set
                     branch_atoms = _subgraph_component(mol, n_idx, branch_exclude)
                     branch_with_attachment = branch_atoms | {c_idx}
+                    emitted_tokens = (
+                        graph_bound_substituent_tokens(
+                            mol,
+                            n_idx,
+                            branch_atoms,
+                            branch_name,
+                            c_idx,
+                            branch_exclude,
+                            name_subgraph,
+                        )
+                        if emit_metadata
+                        else ()
+                    )
                     subst_mapping.setdefault(c_idx, []).append(
                         SubstituentItem(
                             name=branch_name,
@@ -890,17 +915,9 @@ def _collect_subgraph_substituents(
                             atom_ids=branch_atoms,
                             bond_ids=_bond_ids_within(mol, branch_with_attachment),
                             charge_atom_ids=_charged_atoms(mol, branch_atoms),
-                            emitted_tokens=graph_bound_substituent_tokens(
-                                mol,
-                                n_idx,
-                                branch_atoms,
-                                branch_name,
-                                c_idx,
-                                branch_exclude,
-                                name_subgraph,
-                            ),
+                            emitted_tokens=emitted_tokens,
                             trace_segments=branch_trace,
-                            nested_decisions=decision_trace_data(branch_decisions),
+                            nested_decisions=decision_trace_data(branch_decisions) if emit_metadata else [],
                             substituent_tree=branch_tree,
                         )
                     )
@@ -970,6 +987,7 @@ def _assemble_parent_name(
     get_loc,
     *,
     finalize_subgraph: bool = False,
+    emit_metadata: bool = True,
 ) -> str:
     """Assemble a parent name and apply shared post-assembly charge rules."""
 
@@ -996,7 +1014,14 @@ def _assemble_parent_name(
             ("apply_cationic_imino_names", lambda text: apply_cationic_imino_names(text, mol)),
         )
     )
-    rewrites.append(("post_process_name", post_process_name))
+    rewrites.extend(post_process_rewrite_rules())
+    if not emit_metadata:
+        for rewrite in rewrites:
+            if isinstance(rewrite, tuple):
+                name = rewrite[1](name)
+            else:
+                name = rewrite.rewrite(name)
+        return name
     result = NameAssemblyResult.from_rewrite_pipeline(name, parts.name_atom_bindings, rewrites=tuple(rewrites))
     parts.name_atom_bindings = list(result.bindings)
     parts.name_token_spans = token_span_trace_data(result)
@@ -1091,36 +1116,39 @@ def name_subgraph(
     ``data/namer_rules.json``.
     """
 
+    emit_metadata = return_trace or return_tree or decision_trace is not None
     start_atom = mol.atoms[start_idx]
     cyclic_atoms_global = get_cyclic_atoms(mol, exclude_atoms)
     component = _subgraph_component(mol, start_idx, exclude_atoms)
-    trace_decision(
-        decision_trace,
-        TracePhase.COMPONENT,
-        "selected substituent subgraph",
-        "Recursive branch naming starts from the atom attached to the parent and stops at the parent boundary.",
-        atoms=component,
-        bonds=_bond_ids_within(mol, component),
-        data={
-            "start_atom": start_idx,
-            "upstream_atom": upstream_atom,
-            "excluded_atom_count": len(exclude_atoms),
-        },
-    )
+    if decision_trace is not None:
+        trace_decision(
+            decision_trace,
+            TracePhase.COMPONENT,
+            "selected substituent subgraph",
+            "Recursive branch naming starts from the atom attached to the parent and stops at the parent boundary.",
+            atoms=component,
+            bonds=_bond_ids_within(mol, component),
+            data={
+                "start_atom": start_idx,
+                "upstream_atom": upstream_atom,
+                "excluded_atom_count": len(exclude_atoms),
+            },
+        )
 
     if not start_atom.is_carbon and start_idx not in cyclic_atoms_global:
         name = name_heteroatom_subgraph(mol, start_idx, exclude_atoms, upstream_atom, name_subgraph)
         if name is not None:
-            trace_decision(
-                decision_trace,
-                TracePhase.ASSEMBLY,
-                "assembled heteroatom substituent shortcut",
-                "A terminal non-carbon branch was rendered by the heteroatom-subgraph renderer.",
-                atoms=component,
-                bonds=_bond_ids_within(mol, component),
-                data={"name": name},
-            )
-            tree = _shortcut_substituent_tree(name, component, mol, decision_trace)
+            if decision_trace is not None:
+                trace_decision(
+                    decision_trace,
+                    TracePhase.ASSEMBLY,
+                    "assembled heteroatom substituent shortcut",
+                    "A terminal non-carbon branch was rendered by the heteroatom-subgraph renderer.",
+                    atoms=component,
+                    bonds=_bond_ids_within(mol, component),
+                    data={"name": name},
+                )
+            tree = _shortcut_substituent_tree(name, component, mol, decision_trace) if return_tree else None
             if return_trace and return_tree:
                 return name, [], tree
             if return_trace:
@@ -1132,16 +1160,21 @@ def name_subgraph(
     direct_prefix = _direct_subgraph_prefix(mol, start_idx, component)
     if direct_prefix:
         direct_prefix_name = direct_prefix.name
-        trace_decision(
-            decision_trace,
-            TracePhase.ASSEMBLY,
-            "assembled direct substituent prefix",
-            "The complete recursive component matches a direct functional-prefix role.",
-            atoms=component,
-            bonds=_bond_ids_within(mol, component),
-            data=direct_prefix.trace_data(),
+        if decision_trace is not None:
+            trace_decision(
+                decision_trace,
+                TracePhase.ASSEMBLY,
+                "assembled direct substituent prefix",
+                "The complete recursive component matches a direct functional-prefix role.",
+                atoms=component,
+                bonds=_bond_ids_within(mol, component),
+                data=direct_prefix.trace_data(),
+            )
+        tree = (
+            _shortcut_substituent_tree(direct_prefix_name, component, mol, decision_trace, direct_prefix)
+            if return_tree
+            else None
         )
-        tree = _shortcut_substituent_tree(direct_prefix_name, component, mol, decision_trace, direct_prefix)
         if return_trace and return_tree:
             return direct_prefix_name, [], tree
         if return_trace:
@@ -1153,14 +1186,15 @@ def name_subgraph(
     sub_exclude = set(mol.atoms.keys()) - component
     parent_selection = _select_subgraph_parent(mol, start_idx, component, sub_exclude)
     if parent_selection is None:
-        trace_decision(
-            decision_trace,
-            TracePhase.PARENT_SELECTION,
-            "failed substituent parent selection",
-            "No chain or ring parent could be selected inside the recursive component.",
-            atoms=component,
-            bonds=_bond_ids_within(mol, component),
-        )
+        if decision_trace is not None:
+            trace_decision(
+                decision_trace,
+                TracePhase.PARENT_SELECTION,
+                "failed substituent parent selection",
+                "No chain or ring parent could be selected inside the recursive component.",
+                atoms=component,
+                bonds=_bond_ids_within(mol, component),
+            )
         if return_trace and return_tree:
             return "", [], None
         if return_trace:
@@ -1168,22 +1202,23 @@ def name_subgraph(
         if return_tree:
             return "", None
         return ""
-    trace_decision(
-        decision_trace,
-        TracePhase.PARENT_SELECTION,
-        "selected substituent parent skeleton",
-        "The recursive branch uses the same parent-candidate ranking as ordinary components, scoped to the branch graph.",
-        atoms=set(parent_selection.primary_path),
-        bonds=_bond_ids_within(mol, set(parent_selection.primary_path)),
-        data={
-            "primary_path": list(parent_selection.primary_path),
-            "is_ring": parent_selection.is_ring,
-            "is_bicycle": parent_selection.is_bicycle,
-            "is_spiro": parent_selection.is_spiro,
-            "is_polycycle": parent_selection.is_polycycle,
-            "fixed_start_required": parent_selection.fixed_start_required,
-        },
-    )
+    if decision_trace is not None:
+        trace_decision(
+            decision_trace,
+            TracePhase.PARENT_SELECTION,
+            "selected substituent parent skeleton",
+            "The recursive branch uses the same parent-candidate ranking as ordinary components, scoped to the branch graph.",
+            atoms=set(parent_selection.primary_path),
+            bonds=_bond_ids_within(mol, set(parent_selection.primary_path)),
+            data={
+                "primary_path": list(parent_selection.primary_path),
+                "is_ring": parent_selection.is_ring,
+                "is_bicycle": parent_selection.is_bicycle,
+                "is_spiro": parent_selection.is_spiro,
+                "is_polycycle": parent_selection.is_polycycle,
+                "fixed_start_required": parent_selection.fixed_start_required,
+            },
+        )
 
     retained_name_val, locant_maps = resolve_retained_parent(
         mol,
@@ -1193,7 +1228,13 @@ def name_subgraph(
         parent_selection.is_polycycle,
     )
     sub_perceived = perceive_groups(mol)
-    subst_mapping = _collect_subgraph_substituents(mol, parent_selection.primary_path, sub_perceived, sub_exclude)
+    subst_mapping = _collect_subgraph_substituents(
+        mol,
+        parent_selection.primary_path,
+        sub_perceived,
+        sub_exclude,
+        emit_metadata=emit_metadata,
+    )
     parent_plan = build_parent_assembly_plan(
         mol,
         parent_selection,
@@ -1209,19 +1250,20 @@ def name_subgraph(
     numbered_path = parent_plan.numbered_path
     get_loc = parent_plan.get_loc
     parts = parent_plan.parts
-    trace_decision(
-        decision_trace,
-        TracePhase.NUMBERING,
-        "selected substituent numbering",
-        "The branch parent numbering was selected before replacement, unsaturation, suffix, and substituent locants were emitted.",
-        atoms=set(numbered_path),
-        bonds=_bond_ids_within(mol, set(numbered_path)),
-        data={
-            "numbered_path": list(numbered_path),
-            "atom_to_locant": {atom_idx: get_loc(atom_idx) for atom_idx in numbered_path},
-            "retained_name": retained_name_val,
-        },
-    )
+    if decision_trace is not None:
+        trace_decision(
+            decision_trace,
+            TracePhase.NUMBERING,
+            "selected substituent numbering",
+            "The branch parent numbering was selected before replacement, unsaturation, suffix, and substituent locants were emitted.",
+            atoms=set(numbered_path),
+            bonds=_bond_ids_within(mol, set(numbered_path)),
+            data={
+                "numbered_path": list(numbered_path),
+                "atom_to_locant": {atom_idx: get_loc(atom_idx) for atom_idx in numbered_path},
+                "retained_name": retained_name_val,
+            },
+        )
     _emit_bond_stereo(mol, parts, numbered_path, get_loc, sub_exclude, upstream_atom)
     _add_indicated_hydrogens(mol, parts, numbered_path, get_loc)
     _add_subgraph_substituents(parts, subst_mapping, get_loc)
@@ -1235,20 +1277,28 @@ def name_subgraph(
         parent_selection.is_polycycle,
     )
 
-    name = _assemble_parent_name(mol, parts, numbered_path, get_loc, finalize_subgraph=True)
-    trace_segments = _assembly_trace_segments(parts) if return_trace or return_tree else []
-    trace_decision(
-        decision_trace,
-        TracePhase.ASSEMBLY,
-        "assembled substituent name",
-        "The scoped branch assembly was rendered as a substituent name.",
-        atoms=component,
-        bonds=_bond_ids_within(mol, component),
-        data={
-            "name": name,
-            "trace_segment_count": len(trace_segments),
-        },
+    name = _assemble_parent_name(
+        mol,
+        parts,
+        numbered_path,
+        get_loc,
+        finalize_subgraph=True,
+        emit_metadata=emit_metadata,
     )
+    trace_segments = _assembly_trace_segments(parts) if return_trace or return_tree else []
+    if decision_trace is not None:
+        trace_decision(
+            decision_trace,
+            TracePhase.ASSEMBLY,
+            "assembled substituent name",
+            "The scoped branch assembly was rendered as a substituent name.",
+            atoms=component,
+            bonds=_bond_ids_within(mol, component),
+            data={
+                "name": name,
+                "trace_segment_count": len(trace_segments),
+            },
+        )
     if return_trace:
         if return_tree:
             return (

--- a/src/bluenamer/namer.py
+++ b/src/bluenamer/namer.py
@@ -1319,7 +1319,321 @@ def _shortcut_substituent_tree(
             node["substituents"] = list(direct_prefix.ligand_trees)
         if direct_prefix.ligand_trace_segments:
             node["trace_segments"] = list(direct_prefix.ligand_trace_segments)
+    else:
+        shortcut_children = _oxygen_carbonyl_shortcut_children(name, component, mol)
+        if not shortcut_children:
+            shortcut_children = _heteroatom_shortcut_children(name, component, mol)
+        if shortcut_children:
+            node["substituents"] = shortcut_children
     return node
+
+
+def _heteroatom_shortcut_children(name: str, component: set[int], mol: Molecule) -> list[dict]:
+    """Return nested ligand nodes for heteroatom-starting shortcut substituents."""
+
+    center = _shortcut_heteroatom_center(component, mol)
+    if center is None:
+        return []
+    center_token = _heteroatom_center_token_in_name(mol.atoms[center].symbol, name)
+    if not center_token:
+        return []
+    direct_ligands = {
+        neighbor
+        for neighbor in mol.get_neighbors(center)
+        if neighbor in component
+        and mol.atoms[neighbor].symbol in {"O", "S", "N"}
+        and (bond := mol.get_bond(center, neighbor)) is not None
+        and bond.order >= 2
+    }
+    organic_roots = [
+        neighbor
+        for neighbor in mol.get_neighbors(center)
+        if neighbor in component and neighbor not in direct_ligands and mol.atoms[neighbor].symbol != "H"
+    ]
+    children = []
+    for root in organic_roots:
+        ligand_exclude = (set(mol.atoms) - component) | {center, *direct_ligands}
+        ligand_atoms = _subgraph_component(mol, root, ligand_exclude)
+        if not ligand_atoms:
+            continue
+        ligand_name = _organic_ligand_name_from_heteroatom_shortcut(name, center_token)
+        if not ligand_name:
+            ligand_name = _simple_ligand_node_name(mol, ligand_atoms)
+        ligand_children = _carbonyl_ligand_substituent_nodes(mol, center, root, ligand_atoms)
+        if not ligand_children:
+            ligand_tree = _recursive_ligand_tree(mol, root, ligand_exclude, upstream_atom=center)
+            if isinstance(ligand_tree, dict):
+                ligand_node = dict(ligand_tree)
+                if ligand_name:
+                    ligand_node["name"] = ligand_name
+                children.append(ligand_node)
+                continue
+            ligand_children = _terminal_ligand_substituent_nodes(mol, ligand_atoms, ligand_name)
+        children.append(_shortcut_ligand_node(ligand_name, ligand_atoms, ligand_children, mol))
+    return children
+
+
+def _shortcut_heteroatom_center(component: set[int], mol: Molecule) -> int | None:
+    candidates = [
+        atom_idx
+        for atom_idx in component
+        if mol.atoms[atom_idx].symbol not in {"C", "H", "O", "N"}
+        and any(neighbor not in component for neighbor in mol.get_neighbors(atom_idx))
+    ]
+    if candidates:
+        return candidates[0]
+    candidates = [
+        atom_idx
+        for atom_idx in component
+        if mol.atoms[atom_idx].symbol not in {"C", "H"}
+        and any(neighbor not in component for neighbor in mol.get_neighbors(atom_idx))
+    ]
+    return candidates[0] if candidates else None
+
+
+def _heteroatom_center_token_in_name(symbol: str, name: str) -> str:
+    tokens = {
+        "S": ("sulfonimidoyl", "sulfanylidene", "sulfaniumyl", "sulfonyl", "sulfinyl", "sulfanyl", "sulfo", "thioxo"),
+        "Se": ("selenanylidene", "selanylidene", "selenanyl", "selanyl", "selenido", "seleno"),
+        "Te": ("telluranylidene", "tellanyl", "tellurido", "telluro"),
+        "P": ("phosphoryl", "phosphono", "phosphanylidene", "phosphanylidynemethyl", "phosphanyl", "phosphino"),
+        "B": ("borylidene", "boryl", "boranuide"),
+        "Si": ("silylidene", "silyl"),
+        "O": ("hydroperoxy", "peroxy", "hydroxy", "oxy", "oxido"),
+        "N": ("ammonio", "azanidyl", "iminio", "amino", "imino", "nitrilo"),
+    }.get(symbol, ())
+    lower = strip_outer_parentheses(name).lower()
+    return next((token for token in tokens if token in lower), "")
+
+
+def _organic_ligand_name_from_heteroatom_shortcut(name: str, center_token: str) -> str:
+    text = strip_outer_parentheses(name)
+    lower = text.lower()
+    index = lower.rfind(center_token)
+    if index <= 0:
+        return ""
+    ligand = text[:index].strip("-")
+    return ligand
+
+
+def _simple_ligand_node_name(mol: Molecule, ligand_atoms: set[int]) -> str:
+    symbols = {mol.atoms[atom_idx].symbol for atom_idx in ligand_atoms}
+    if symbols <= {"C", "H"} and len(ligand_atoms) == 1:
+        return "methyl"
+    return "ligand"
+
+
+def _recursive_ligand_tree(
+    mol: Molecule,
+    root: int,
+    excluded_atoms: set[int],
+    *,
+    upstream_atom: int,
+) -> dict | None:
+    branch_result = name_subgraph(
+        mol,
+        root,
+        excluded_atoms,
+        upstream_atom=upstream_atom,
+        return_trace=True,
+        return_tree=True,
+        decision_trace=DecisionTrace(),
+    )
+    if isinstance(branch_result, tuple) and len(branch_result) == 3 and isinstance(branch_result[2], dict):
+        return branch_result[2]
+    return None
+
+
+def _shortcut_ligand_node(name: str, ligand_atoms: set[int], children: list[dict], mol: Molecule) -> dict:
+    return {
+        "kind": "fragment",
+        "name": name,
+        "atoms": sorted(ligand_atoms),
+        "bonds": sorted(_bond_ids_within(mol, ligand_atoms)),
+        "substituents": children,
+    }
+
+
+def _carbonyl_ligand_substituent_nodes(
+    mol: Molecule,
+    heteroatom_center: int,
+    ligand_root: int,
+    ligand_atoms: set[int],
+) -> list[dict]:
+    if not mol.atoms[ligand_root].is_carbon:
+        return []
+    terminal_chalcogens = [
+        neighbor
+        for neighbor in mol.get_neighbors(ligand_root)
+        if neighbor in ligand_atoms
+        and mol.atoms[neighbor].symbol in {"O", "S"}
+        and (bond := mol.get_bond(ligand_root, neighbor)) is not None
+        and bond.order == 2
+    ]
+    if len(terminal_chalcogens) != 1:
+        return []
+    branch_roots = [
+        neighbor
+        for neighbor in mol.get_neighbors(ligand_root)
+        if neighbor in ligand_atoms and neighbor not in {heteroatom_center, *terminal_chalcogens}
+    ]
+    if not branch_roots:
+        return []
+    branch_root = branch_roots[0]
+    excluded_atoms = (set(mol.atoms) - ligand_atoms) | {heteroatom_center, ligand_root, *terminal_chalcogens}
+    branch_atoms = _subgraph_component(mol, branch_root, excluded_atoms)
+    if not branch_atoms:
+        return []
+    branch_tree = _recursive_ligand_tree(mol, branch_root, excluded_atoms, upstream_atom=ligand_root)
+    if isinstance(branch_tree, dict):
+        side_node = dict(branch_tree)
+    else:
+        side_node = {
+            "kind": "fragment",
+            "name": "carbonyl side",
+            "atoms": sorted(branch_atoms),
+            "bonds": sorted(_bond_ids_within(mol, branch_atoms)),
+            "substituents": _terminal_ligand_substituent_nodes(mol, branch_atoms),
+        }
+    return [
+        side_node,
+        {
+            "kind": "functional_core",
+            "name": "carbonyl" if mol.atoms[terminal_chalcogens[0]].symbol == "O" else "carbonothioyl",
+            "atoms": sorted({ligand_root, terminal_chalcogens[0]}),
+            "bonds": sorted(_bond_ids_within(mol, {ligand_root, terminal_chalcogens[0]})),
+            "substituents": [],
+        },
+    ]
+
+
+def _terminal_ligand_substituent_nodes(mol: Molecule, ligand_atoms: set[int], ligand_name: str = "") -> list[dict]:
+    nodes = []
+    names = {"N": "amino", "O": "hydroxy", "F": "fluoro", "Cl": "chloro", "Br": "bromo", "I": "iodo"}
+    lower_name = ligand_name.lower()
+    for atom_idx in sorted(ligand_atoms):
+        name = names.get(mol.atoms[atom_idx].symbol)
+        if not name:
+            continue
+        local_bonds = {
+            bond.idx
+            for neighbor in mol.get_neighbors(atom_idx)
+            if neighbor in ligand_atoms and (bond := mol.get_bond(atom_idx, neighbor)) is not None
+        }
+        if len(local_bonds) != 1:
+            continue
+        local_bond = next(
+            bond
+            for neighbor in mol.get_neighbors(atom_idx)
+            if neighbor in ligand_atoms and (bond := mol.get_bond(atom_idx, neighbor)) is not None
+        )
+        if local_bond.order != 1:
+            continue
+        nodes.append(
+            {
+                "kind": "substituent",
+                "name": name,
+                "atoms": [atom_idx],
+                "bonds": sorted(local_bonds),
+                "locants": _visible_ligand_substituent_locants(lower_name, name),
+                "substituents": [],
+            }
+        )
+    return nodes
+
+
+def _visible_ligand_substituent_locants(lower_name: str, child_name: str) -> list[str]:
+    pattern = re.compile(rf"(?<![0-9])([0-9]+(?:,[0-9]+)*)-{re.escape(child_name.lower())}")
+    match = pattern.search(lower_name)
+    if match is None:
+        return []
+    return match.group(1).split(",")
+
+
+def _oxygen_carbonyl_shortcut_children(name: str, component: set[int], mol: Molecule) -> list[dict]:
+    """Return nested tree nodes for O-C(=O)-R shortcut substituents."""
+
+    if "carbonyloxy" not in name.lower() and "carbonothioyloxy" not in name.lower():
+        return []
+    oxygen = next(
+        (
+            atom_idx
+            for atom_idx in component
+            if mol.atoms[atom_idx].symbol == "O"
+            and any(neighbor not in component for neighbor in mol.get_neighbors(atom_idx))
+        ),
+        None,
+    )
+    if oxygen is None:
+        return []
+    carbonyl = next(
+        (
+            neighbor
+            for neighbor in mol.get_neighbors(oxygen)
+            if neighbor in component and mol.atoms[neighbor].is_carbon
+        ),
+        None,
+    )
+    if carbonyl is None:
+        return []
+    terminal = [
+        neighbor
+        for neighbor in mol.get_neighbors(carbonyl)
+        if neighbor in component
+        and neighbor != oxygen
+        and mol.atoms[neighbor].symbol in {"O", "S"}
+        and (bond := mol.get_bond(carbonyl, neighbor)) is not None
+        and bond.order == 2
+    ]
+    ligand_roots = [
+        neighbor for neighbor in mol.get_neighbors(carbonyl) if neighbor in component and neighbor not in {oxygen, *terminal}
+    ]
+    if not ligand_roots:
+        return []
+    ligand_root = ligand_roots[0]
+    ligand_atoms = _subgraph_component(mol, ligand_root, set(mol.atoms) - component | {oxygen, carbonyl, *terminal})
+    bridge_atoms = {ligand_root}
+    branch_root = None
+    for neighbor in mol.get_neighbors(ligand_root):
+        if neighbor not in ligand_atoms:
+            continue
+        bond = mol.get_bond(ligand_root, neighbor)
+        if bond is not None and bond.order == 2:
+            bridge_atoms.add(neighbor)
+            branch_candidates = [n for n in mol.get_neighbors(neighbor) if n in ligand_atoms and n != ligand_root]
+            branch_root = branch_candidates[0] if branch_candidates else None
+            break
+    if branch_root is None:
+        return []
+    branch_atoms = _subgraph_component(mol, branch_root, set(mol.atoms) - component | bridge_atoms | {oxygen, carbonyl, *terminal})
+    hydroxy_children = [
+        {
+            "kind": "substituent",
+            "name": "hydroxy",
+            "atoms": [atom_idx],
+            "bonds": sorted(_bond_ids_within(mol, {atom_idx, *mol.get_neighbors(atom_idx)} & branch_atoms)),
+            "substituents": [],
+        }
+        for atom_idx in sorted(branch_atoms)
+        if mol.atoms[atom_idx].symbol == "O"
+    ]
+    return [
+        {
+            "kind": "fragment",
+            "name": "ethenyl",
+            "atoms": sorted(bridge_atoms),
+            "bonds": sorted(_bond_ids_within(mol, bridge_atoms)),
+            "substituents": [
+                {
+                    "kind": "fragment",
+                    "name": "dihydroxyphenyl",
+                    "atoms": sorted(branch_atoms),
+                    "bonds": sorted(_bond_ids_within(mol, branch_atoms)),
+                    "substituents": hydroxy_children,
+                }
+            ],
+        }
+    ]
 
 
 def name_component(

--- a/src/bluenamer/namer.py
+++ b/src/bluenamer/namer.py
@@ -1617,11 +1617,7 @@ def _oxygen_carbonyl_shortcut_children(name: str, component: set[int], mol: Mole
     if oxygen is None:
         return []
     carbonyl = next(
-        (
-            neighbor
-            for neighbor in mol.get_neighbors(oxygen)
-            if neighbor in component and mol.atoms[neighbor].is_carbon
-        ),
+        (neighbor for neighbor in mol.get_neighbors(oxygen) if neighbor in component and mol.atoms[neighbor].is_carbon),
         None,
     )
     if carbonyl is None:
@@ -1636,7 +1632,9 @@ def _oxygen_carbonyl_shortcut_children(name: str, component: set[int], mol: Mole
         and bond.order == 2
     ]
     ligand_roots = [
-        neighbor for neighbor in mol.get_neighbors(carbonyl) if neighbor in component and neighbor not in {oxygen, *terminal}
+        neighbor
+        for neighbor in mol.get_neighbors(carbonyl)
+        if neighbor in component and neighbor not in {oxygen, *terminal}
     ]
     if not ligand_roots:
         return []
@@ -1655,7 +1653,9 @@ def _oxygen_carbonyl_shortcut_children(name: str, component: set[int], mol: Mole
             break
     if branch_root is None:
         return []
-    branch_atoms = _subgraph_component(mol, branch_root, set(mol.atoms) - component | bridge_atoms | {oxygen, carbonyl, *terminal})
+    branch_atoms = _subgraph_component(
+        mol, branch_root, set(mol.atoms) - component | bridge_atoms | {oxygen, carbonyl, *terminal}
+    )
     hydroxy_children = [
         {
             "kind": "substituent",

--- a/src/bluenamer/special_cases.py
+++ b/src/bluenamer/special_cases.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from .assembly_parts import NameAtomBinding
+from .assembly_parts import NameAtomBinding, NameTokenBinding
 from .charge_pair_roles import charge_pair_roles
 from .formatting import format_counted_prefixes, format_multiplier, oxy_prefix_from_branch, strip_outer_parentheses
 from .molecule import Molecule
@@ -121,8 +121,8 @@ def structural_replacement_parent_result(
         ("oxoacid_parent", lambda: oxoacid_parent_result(mol, component_atoms)),
         ("organophosphinic_acid", lambda: organophosphinic_acid_result(mol, component_atoms)),
         ("sulfoxide_parent", lambda: sulfoxide_parent_result(mol, component_atoms)),
-        ("homonuclear_chain_parent", lambda: homonuclear_chain_parent_name(mol, component_atoms)),
-        ("simple_central_parent_hydride", lambda: simple_central_parent_hydride_name(mol, component_atoms)),
+        ("homonuclear_chain_parent", lambda: homonuclear_chain_parent_result(mol, component_atoms)),
+        ("simple_central_parent_hydride", lambda: simple_central_parent_hydride_result(mol, component_atoms)),
     )
     for role, render in renderers:
         rendered = render()
@@ -162,6 +162,48 @@ def biphenyl_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialC
             return None
         ring_components.append(atoms)
     bindings = (
+        NameAtomBinding(
+            stage="shortcut",
+            role="biphenyl_parent",
+            term="biphenyl",
+            atom_ids=set(component_atoms),
+            bond_ids=_bond_ids_within_atoms(mol, component_atoms),
+            locants=("1", "1'"),
+            emitted_tokens=(
+                NameTokenBinding(
+                    text="1",
+                    token_kind="locant",
+                    source="shortcut_renderer",
+                    grammar_role="biphenyl_attachment",
+                    binding_key="shortcut:biphenyl_attachment:left",
+                    atom_ids={left_root},
+                    bond_ids={bridge_bond},
+                    locants=("1",),
+                    render_order=0,
+                ),
+                NameTokenBinding(
+                    text="1",
+                    token_kind="locant",
+                    source="shortcut_renderer",
+                    grammar_role="biphenyl_attachment",
+                    binding_key="shortcut:biphenyl_attachment:right",
+                    atom_ids={right_root},
+                    bond_ids={bridge_bond},
+                    locants=("1'",),
+                    render_order=1,
+                ),
+                NameTokenBinding(
+                    text="biphenyl",
+                    token_kind="parent",
+                    source="shortcut_renderer",
+                    grammar_role="biphenyl_parent",
+                    binding_key="shortcut:biphenyl_parent",
+                    atom_ids=set(component_atoms),
+                    bond_ids=_bond_ids_within_atoms(mol, component_atoms),
+                    render_order=2,
+                ),
+            ),
+        ),
         NameAtomBinding(
             stage="shortcut",
             role="biphenyl_ring",
@@ -1772,6 +1814,11 @@ def _carbon_degree(mol: Molecule, carbon_atoms: set[int], atom_idx: int) -> int:
 
 
 def homonuclear_chain_parent_name(mol: Molecule, component_atoms: set[int]) -> str:
+    result = homonuclear_chain_parent_result(mol, component_atoms)
+    return result.name if result is not None else ""
+
+
+def homonuclear_chain_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialComponentName | None:
     """Name acyclic same-element parent hydride chains and simple ligands."""
 
     backbone_symbols = {
@@ -1781,35 +1828,66 @@ def homonuclear_chain_parent_name(mol: Molecule, component_atoms: set[int]) -> s
         and mol.atoms[idx].symbol not in {"O", "F", "Cl", "Br", "I"}
     }
     if len(backbone_symbols) != 1:
-        return ""
+        return None
     symbol = next(iter(backbone_symbols))
     backbone = [idx for idx in component_atoms if mol.atoms[idx].symbol == symbol]
     if len(backbone) < 2:
-        return ""
+        return None
     if any(mol.atoms[idx].symbol not in {symbol, "C", "F", "Cl", "Br", "I"} for idx in component_atoms):
-        return ""
+        return None
     chain = _ordered_backbone_chain(mol, backbone)
     if chain is None:
-        return ""
+        return None
     chain_set = set(chain)
+    ligand_bindings = []
     for atom_idx in component_atoms - chain_set:
         backbone_neighbors = [n for n in mol.get_neighbors(atom_idx) if n in chain_set]
         if len(backbone_neighbors) != 1:
-            return ""
+            return None
         bond = mol.get_bond(atom_idx, backbone_neighbors[0])
         if bond is None or bond.order != 1:
-            return ""
-        if not _terminal_ligand_name(mol, atom_idx, backbone_neighbors[0]):
-            return ""
+            return None
+        ligand_name = _terminal_ligand_name(mol, atom_idx, backbone_neighbors[0])
+        if not ligand_name:
+            return None
+        ligand_bindings.append(
+            NameAtomBinding(
+                stage="shortcut",
+                role="homonuclear_chain_ligand",
+                term=ligand_name,
+                atom_ids={atom_idx},
+                bond_ids={bond.idx},
+                locants=(str(chain.index(backbone_neighbors[0]) + 1),),
+            )
+        )
     bond_orders = [mol.get_bond(chain[idx], chain[idx + 1]).order for idx in range(len(chain) - 1)]
     parent = _same_element_parent_name(symbol, len(chain), bond_orders)
     if not parent:
-        return ""
+        return None
     prefixes = _simple_chain_ligand_prefixes(mol, component_atoms, chain)
-    return f"{prefixes}{parent}" if prefixes else parent
+    name = f"{prefixes}{parent}" if prefixes else parent
+    parent_binding = NameAtomBinding(
+        stage="shortcut",
+        role="homonuclear_chain_parent",
+        term=parent,
+        atom_ids=set(chain),
+        bond_ids=_bond_ids_within_atoms(mol, set(chain)),
+    )
+    return _component_name_result(
+        mol,
+        component_atoms,
+        name,
+        "homonuclear_chain_parent",
+        bindings=(parent_binding, *ligand_bindings),
+    )
 
 
 def simple_central_parent_hydride_name(mol: Molecule, component_atoms: set[int]) -> str:
+    result = simple_central_parent_hydride_result(mol, component_atoms)
+    return result.name if result is not None else ""
+
+
+def simple_central_parent_hydride_result(mol: Molecule, component_atoms: set[int]) -> SpecialComponentName | None:
     """Name simple mononuclear parent hydrides with halogen/alkoxy ligands."""
 
     central_candidates = [
@@ -1820,22 +1898,50 @@ def simple_central_parent_hydride_name(mol: Molecule, component_atoms: set[int])
         and mol.degree(idx) >= 2
     ]
     if len(central_candidates) != 1:
-        return ""
+        return None
     central = central_candidates[0]
     central_symbol = mol.atoms[central].symbol
     ligand_names = []
+    ligand_bindings = []
     for neighbor in mol.get_neighbors(central):
         if neighbor not in component_atoms:
             continue
         ligand = _central_ligand_name(mol, component_atoms, central, neighbor)
         if not ligand:
-            return ""
+            return None
         ligand_names.append(ligand)
+        ligand_atoms = _component_atoms_until_blocked(mol, component_atoms, neighbor, {central})
+        ligand_atoms = ligand_atoms or {neighbor}
+        bond = mol.get_bond(central, neighbor)
+        ligand_bindings.append(
+            NameAtomBinding(
+                stage="shortcut",
+                role="central_parent_hydride_ligand",
+                term=ligand,
+                atom_ids=set(ligand_atoms),
+                bond_ids={bond.idx} if bond else set(),
+            )
+        )
     if not ligand_names:
-        return ""
+        return None
     prefix = _grouped_ligand_prefix(ligand_names)
     lambda_text = _lambda_text(mol, central)
-    return f"{prefix}{lambda_text}{RULES.components.mononuclear_parent_hydrides[central_symbol]}"
+    parent = f"{lambda_text}{RULES.components.mononuclear_parent_hydrides[central_symbol]}"
+    name = f"{prefix}{parent}"
+    core_binding = NameAtomBinding(
+        stage="shortcut",
+        role="central_parent_hydride_core",
+        term=parent,
+        atom_ids={central},
+        charge_atom_ids={central} if mol.atoms[central].charge else set(),
+    )
+    return _component_name_result(
+        mol,
+        component_atoms,
+        name,
+        "simple_central_parent_hydride",
+        bindings=(core_binding, *ligand_bindings),
+    )
 
 
 def _ordered_backbone_chain(mol: Molecule, atoms: list[int]) -> list[int] | None:

--- a/src/bluenamer/substituent_tokens.py
+++ b/src/bluenamer/substituent_tokens.py
@@ -163,7 +163,9 @@ def _generic_heteroatom_substituent_tokens(
                 )
 
     charge_atoms = {center} if mol.atoms[center].charge != 0 else set()
-    direct_ligand_atoms = {atom for token_text, atoms in ligand_atoms_by_token for atom in atoms if token_text in {"oxo", "oxido", "imino"}}
+    direct_ligand_atoms = {
+        atom for token_text, atoms in ligand_atoms_by_token for atom in atoms if token_text in {"oxo", "oxido", "imino"}
+    }
     center_atoms = {center, *direct_ligand_atoms}
     center_bonds = bond_ids_within(mol, center_atoms)
     for token_text in center_tokens:
@@ -396,11 +398,7 @@ def _alkenyl_bridge_tokens(
                 left_context="en",
             )
         )
-    stereo_bonds = {
-        bond.idx
-        for bond in mol.bonds.values()
-        if bond.idx in bridge_bonds and bond.stereo in {"E", "Z"}
-    }
+    stereo_bonds = {bond.idx for bond in mol.bonds.values() if bond.idx in bridge_bonds and bond.stereo in {"E", "Z"}}
     if stereo_bonds:
         descriptor = next(bond.stereo for bond in mol.bonds.values() if bond.idx in stereo_bonds and bond.stereo)
         tokens.append(
@@ -439,7 +437,8 @@ def _branch_phrase_tokens(mol: Molecule, branch_atoms: set[int], lower_term: str
     hydroxy_atoms = {
         atom_idx
         for atom_idx in branch_atoms
-        if mol.atoms[atom_idx].symbol == "O" and any(neighbor in branch_atoms for neighbor in mol.get_neighbors(atom_idx))
+        if mol.atoms[atom_idx].symbol == "O"
+        and any(neighbor in branch_atoms for neighbor in mol.get_neighbors(atom_idx))
     }
     if "dihydroxyphenyl" in lower_term:
         tokens.append(

--- a/src/bluenamer/substituent_tokens.py
+++ b/src/bluenamer/substituent_tokens.py
@@ -7,6 +7,7 @@ from .assembly_parts import NameTokenBinding
 from .formatting import strip_outer_parentheses
 from .molecule import Molecule
 from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, RELATIVE_STEREO_DESCRIPTORS
+from .token_grammar import is_locant_token, lexical_token_spans, lexical_tokens
 from .trace_helpers import bond_ids_within
 
 BranchNamer = Callable[..., str]
@@ -150,14 +151,14 @@ def _generic_heteroatom_substituent_tokens(
                 tokens.append(
                     NameTokenBinding(
                         text=token_text,
-                        token_kind="locant" if _is_locant_like_token(token_text) else "prefix",
+                        token_kind="locant" if is_locant_token(token_text, allow_element=False) else "prefix",
                         source="substituent_renderer",
                         grammar_role="heteroatom_organic_ligand",
                         binding_key="prefix:heteroatom_organic_ligand",
                         atom_ids=set(token_atoms),
                         bond_ids=set(token_bonds),
                         charge_atom_ids={idx for idx in token_atoms if mol.atoms[idx].charge != 0},
-                        locants=(token_text,) if _is_locant_like_token(token_text) else (),
+                        locants=(token_text,) if is_locant_token(token_text, allow_element=False) else (),
                     )
                 )
 
@@ -176,6 +177,7 @@ def _generic_heteroatom_substituent_tokens(
                 atom_ids=set(center_atoms),
                 bond_ids=set(center_bonds),
                 charge_atom_ids=set(charge_atoms),
+                match_priority=80,
             )
         )
     return tuple(tokens)
@@ -190,7 +192,7 @@ def _organic_ligand_token_scope(
     """Return the most local graph scope for a token inside an organic ligand."""
 
     token_lower = token_text.lower()
-    if _is_locant_like_token(token_text):
+    if is_locant_token(token_text, allow_element=False):
         locant_atoms = _terminal_substituent_atoms_for_locant_token(mol, ligand_atoms, token_text, lower_term)
         if locant_atoms:
             return locant_atoms, bond_ids_within(mol, locant_atoms | ligand_atoms)
@@ -213,10 +215,10 @@ def _terminal_substituent_atoms_for_locant_token(
         after = lower_term[match.end() :]
         if not after.startswith("-"):
             continue
-        next_token = _TOKEN_RE.search(after, 1)
-        if next_token is None:
+        next_tokens = lexical_token_spans(after, 1)
+        if not next_tokens:
             continue
-        candidates.extend(_terminal_atoms_for_prefix(mol, ligand_atoms, next_token.group(0).lower()))
+        candidates.extend(_terminal_atoms_for_prefix(mol, ligand_atoms, next_tokens[0].text.lower()))
     return set(candidates)
 
 
@@ -303,6 +305,8 @@ def _oxygen_carbonyl_like_tokens(
             binding_key="prefix:heteroatom_center",
             atom_ids={oxygen},
             bond_ids=bond_ids_within(mol, {oxygen, carbonyl}),
+            match_priority=80,
+            left_context="carbonyl",
         ),
     ]
     ligand_roots = [
@@ -361,6 +365,7 @@ def _alkenyl_bridge_tokens(
                 binding_key="prefix:alkenyl_bridge",
                 atom_ids=set(bridge_atoms),
                 bond_ids=set(bridge_bonds),
+                match_priority=60,
             )
         )
     if "en" in lower_term:
@@ -373,6 +378,8 @@ def _alkenyl_bridge_tokens(
                 binding_key="prefix:alkenyl_bridge",
                 atom_ids=set(bridge_atoms),
                 bond_ids=set(bridge_bonds),
+                match_priority=60,
+                right_context="yl",
             )
         )
     if "yl" in lower_term:
@@ -385,6 +392,8 @@ def _alkenyl_bridge_tokens(
                 binding_key="prefix:alkenyl_bridge",
                 atom_ids=set(bridge_atoms),
                 bond_ids=set(bridge_bonds),
+                match_priority=60,
+                left_context="en",
             )
         )
     stereo_bonds = {
@@ -393,6 +402,7 @@ def _alkenyl_bridge_tokens(
         if bond.idx in bridge_bonds and bond.stereo in {"E", "Z"}
     }
     if stereo_bonds:
+        descriptor = next(bond.stereo for bond in mol.bonds.values() if bond.idx in stereo_bonds and bond.stereo)
         tokens.append(
             NameTokenBinding(
                 text="1",
@@ -403,9 +413,10 @@ def _alkenyl_bridge_tokens(
                 atom_ids=set(bridge_atoms),
                 bond_ids=set(stereo_bonds),
                 locants=("1",),
+                match_priority=100,
+                right_context=descriptor,
             )
         )
-        descriptor = next(bond.stereo for bond in mol.bonds.values() if bond.idx in stereo_bonds and bond.stereo)
         tokens.append(
             NameTokenBinding(
                 text=descriptor,
@@ -416,6 +427,7 @@ def _alkenyl_bridge_tokens(
                 atom_ids=set(bridge_atoms),
                 bond_ids=set(stereo_bonds),
                 locants=("1",),
+                match_priority=100,
             )
         )
     return tokens
@@ -617,11 +629,4 @@ def _component_within(mol: Molecule, root: int, allowed_atoms: set[int]) -> set[
 
 
 def _lexical_tokens(text: str) -> tuple[str, ...]:
-    return tuple(match.group(0) for match in _TOKEN_RE.finditer(text))
-
-
-def _is_locant_like_token(text: str) -> bool:
-    return bool(re.fullmatch(r"\d+(?:,\d+)*", text))
-
-
-_TOKEN_RE = re.compile(r"[A-Za-z]+(?:\^[0-9]+)?|\d+(?:,\d+)*(?:'\")?|[0-9]+(?:\([0-9,]+\))?")
+    return lexical_tokens(text)

--- a/src/bluenamer/substituent_tokens.py
+++ b/src/bluenamer/substituent_tokens.py
@@ -112,15 +112,23 @@ def _generic_heteroatom_substituent_tokens(
         return ()
 
     tokens: list[NameTokenBinding] = list(_embedded_absolute_stereo_tokens(mol, center, term_text))
+    carbonyl_like_tokens = _oxygen_carbonyl_like_tokens(mol, center, atom_ids, term_text, upstream_atom)
+    if carbonyl_like_tokens:
+        return tuple([*tokens, *carbonyl_like_tokens])
     ligand_roots = _heteroatom_ligand_roots(mol, center, atom_ids, upstream_atom)
     ligand_atoms_by_token = _direct_ligand_tokens(mol, center, ligand_roots, atom_ids)
     for token_text, ligand_atoms in ligand_atoms_by_token:
         if token_text.lower() in lower_term:
+            ligand_bonds = bond_ids_within(mol, set(ligand_atoms) | {center})
             tokens.append(
                 NameTokenBinding(
                     text=token_text,
+                    token_kind="prefix",
+                    source="substituent_renderer",
+                    grammar_role="heteroatom_direct_ligand",
+                    binding_key="prefix:heteroatom_direct_ligand",
                     atom_ids=set(ligand_atoms),
-                    bond_ids=bond_ids_within(mol, set(ligand_atoms) | {center}),
+                    bond_ids=ligand_bonds,
                     charge_atom_ids={idx for idx in ligand_atoms if mol.atoms[idx].charge != 0},
                 )
             )
@@ -138,25 +146,334 @@ def _generic_heteroatom_substituent_tokens(
             continue
         for token_text in _lexical_tokens(ligand_text):
             if token_text.lower() in lower_term:
+                token_atoms, token_bonds = _organic_ligand_token_scope(mol, token_text, ligand_atoms, lower_term)
                 tokens.append(
                     NameTokenBinding(
                         text=token_text,
-                        atom_ids=set(ligand_atoms),
-                        bond_ids=bond_ids_within(mol, ligand_atoms),
-                        charge_atom_ids={idx for idx in ligand_atoms if mol.atoms[idx].charge != 0},
+                        token_kind="locant" if _is_locant_like_token(token_text) else "prefix",
+                        source="substituent_renderer",
+                        grammar_role="heteroatom_organic_ligand",
+                        binding_key="prefix:heteroatom_organic_ligand",
+                        atom_ids=set(token_atoms),
+                        bond_ids=set(token_bonds),
+                        charge_atom_ids={idx for idx in token_atoms if mol.atoms[idx].charge != 0},
+                        locants=(token_text,) if _is_locant_like_token(token_text) else (),
                     )
                 )
 
     charge_atoms = {center} if mol.atoms[center].charge != 0 else set()
+    direct_ligand_atoms = {atom for token_text, atoms in ligand_atoms_by_token for atom in atoms if token_text in {"oxo", "oxido", "imino"}}
+    center_atoms = {center, *direct_ligand_atoms}
+    center_bonds = bond_ids_within(mol, center_atoms)
     for token_text in center_tokens:
         tokens.append(
             NameTokenBinding(
                 text=token_text,
-                atom_ids={center},
+                token_kind="prefix",
+                source="substituent_renderer",
+                grammar_role="heteroatom_center",
+                binding_key="prefix:heteroatom_center",
+                atom_ids=set(center_atoms),
+                bond_ids=set(center_bonds),
                 charge_atom_ids=set(charge_atoms),
             )
         )
     return tuple(tokens)
+
+
+def _organic_ligand_token_scope(
+    mol: Molecule,
+    token_text: str,
+    ligand_atoms: set[int],
+    lower_term: str,
+) -> tuple[set[int], set[int]]:
+    """Return the most local graph scope for a token inside an organic ligand."""
+
+    token_lower = token_text.lower()
+    if _is_locant_like_token(token_text):
+        locant_atoms = _terminal_substituent_atoms_for_locant_token(mol, ligand_atoms, token_text, lower_term)
+        if locant_atoms:
+            return locant_atoms, bond_ids_within(mol, locant_atoms | ligand_atoms)
+    if token_lower in {"amino", "hydroxy", "fluoro", "chloro", "bromo", "iodo"}:
+        atoms = _terminal_atoms_for_prefix(mol, ligand_atoms, token_lower)
+        if atoms:
+            return atoms, bond_ids_within(mol, atoms | ligand_atoms)
+    return set(ligand_atoms), bond_ids_within(mol, ligand_atoms)
+
+
+def _terminal_substituent_atoms_for_locant_token(
+    mol: Molecule,
+    ligand_atoms: set[int],
+    token_text: str,
+    lower_term: str,
+) -> set[int]:
+    token_lower = token_text.lower()
+    candidates = []
+    for match in re.finditer(re.escape(token_lower), lower_term):
+        after = lower_term[match.end() :]
+        if not after.startswith("-"):
+            continue
+        next_token = _TOKEN_RE.search(after, 1)
+        if next_token is None:
+            continue
+        candidates.extend(_terminal_atoms_for_prefix(mol, ligand_atoms, next_token.group(0).lower()))
+    return set(candidates)
+
+
+def _terminal_atoms_for_prefix(mol: Molecule, ligand_atoms: set[int], token_lower: str) -> set[int]:
+    prefix_symbols = {
+        "amino": {"N"},
+        "hydroxy": {"O"},
+        "fluoro": {"F"},
+        "chloro": {"Cl"},
+        "bromo": {"Br"},
+        "iodo": {"I"},
+    }.get(token_lower)
+    if not prefix_symbols:
+        return set()
+    return {
+        atom_idx
+        for atom_idx in ligand_atoms
+        if mol.atoms[atom_idx].symbol in prefix_symbols
+        and sum(1 for neighbor in mol.get_neighbors(atom_idx) if neighbor in ligand_atoms) == 1
+    }
+
+
+def _oxygen_carbonyl_like_tokens(
+    mol: Molecule,
+    oxygen: int,
+    atom_ids: set[int],
+    term_text: str,
+    upstream_atom: int,
+) -> tuple[NameTokenBinding, ...]:
+    """Return graph scopes for O-C(=O)-R prefixes such as carbonyloxy."""
+
+    if mol.atoms[oxygen].symbol != "O":
+        return ()
+    lower = term_text.lower()
+    if "carbonyloxy" not in lower and "carbonothioyloxy" not in lower:
+        return ()
+    carbonyl = next(
+        (
+            neighbor
+            for neighbor in mol.get_neighbors(oxygen)
+            if neighbor != upstream_atom and neighbor in atom_ids and mol.atoms[neighbor].is_carbon
+        ),
+        None,
+    )
+    if carbonyl is None:
+        return ()
+    terminal_chalcogens = [
+        neighbor
+        for neighbor in mol.get_neighbors(carbonyl)
+        if neighbor in atom_ids
+        and neighbor != oxygen
+        and mol.atoms[neighbor].symbol in {"O", "S"}
+        and (bond := mol.get_bond(carbonyl, neighbor)) is not None
+        and bond.order == 2
+    ]
+    if len(terminal_chalcogens) != 1:
+        return ()
+    carbonyl_atoms = {carbonyl, terminal_chalcogens[0]}
+    carbonyl_bonds = bond_ids_within(mol, carbonyl_atoms | {oxygen})
+    tokens: list[NameTokenBinding] = [
+        NameTokenBinding(
+            text="carbon",
+            token_kind="prefix",
+            source="substituent_renderer",
+            grammar_role="carbonyl_like_core",
+            binding_key="prefix:carbonyl_like_core",
+            atom_ids=set(carbonyl_atoms),
+            bond_ids=set(carbonyl_bonds),
+        ),
+        NameTokenBinding(
+            text="carbonyl",
+            token_kind="prefix",
+            source="substituent_renderer",
+            grammar_role="carbonyl_like_core",
+            binding_key="prefix:carbonyl_like_core",
+            atom_ids=set(carbonyl_atoms),
+            bond_ids=set(carbonyl_bonds),
+        ),
+        NameTokenBinding(
+            text="oxy",
+            token_kind="prefix",
+            source="substituent_renderer",
+            grammar_role="heteroatom_center",
+            binding_key="prefix:heteroatom_center",
+            atom_ids={oxygen},
+            bond_ids=bond_ids_within(mol, {oxygen, carbonyl}),
+        ),
+    ]
+    ligand_roots = [
+        neighbor
+        for neighbor in mol.get_neighbors(carbonyl)
+        if neighbor in atom_ids and neighbor not in {oxygen, terminal_chalcogens[0]}
+    ]
+    if not ligand_roots:
+        return tuple(tokens)
+    ligand_root = ligand_roots[0]
+    ligand_atoms = _component_within(mol, ligand_root, atom_ids - {oxygen, carbonyl, terminal_chalcogens[0]})
+    bridge_atoms, branch_atoms, bridge_bonds = _alkenyl_bridge_scope(mol, ligand_root, ligand_atoms)
+    if bridge_atoms:
+        tokens.extend(_alkenyl_bridge_tokens(mol, bridge_atoms, bridge_bonds, lower))
+    if branch_atoms:
+        tokens.extend(_branch_phrase_tokens(mol, branch_atoms, lower))
+    return tuple(tokens)
+
+
+def _alkenyl_bridge_scope(
+    mol: Molecule,
+    ligand_root: int,
+    ligand_atoms: set[int],
+) -> tuple[set[int], set[int], set[int]]:
+    bridge_atoms = {ligand_root}
+    branch_root = None
+    for neighbor in mol.get_neighbors(ligand_root):
+        if neighbor not in ligand_atoms:
+            continue
+        bond = mol.get_bond(ligand_root, neighbor)
+        if bond is not None and bond.order == 2:
+            bridge_atoms.add(neighbor)
+            branch_candidates = [n for n in mol.get_neighbors(neighbor) if n in ligand_atoms and n != ligand_root]
+            branch_root = branch_candidates[0] if branch_candidates else None
+            break
+    if branch_root is None:
+        return bridge_atoms, ligand_atoms - bridge_atoms, bond_ids_within(mol, bridge_atoms)
+    branch_atoms = _component_within(mol, branch_root, ligand_atoms - bridge_atoms)
+    return bridge_atoms, branch_atoms, bond_ids_within(mol, bridge_atoms)
+
+
+def _alkenyl_bridge_tokens(
+    mol: Molecule,
+    bridge_atoms: set[int],
+    bridge_bonds: set[int],
+    lower_term: str,
+) -> list[NameTokenBinding]:
+    tokens: list[NameTokenBinding] = []
+    if "eth" in lower_term:
+        tokens.append(
+            NameTokenBinding(
+                text="eth",
+                token_kind="prefix",
+                source="substituent_renderer",
+                grammar_role="alkenyl_bridge",
+                binding_key="prefix:alkenyl_bridge",
+                atom_ids=set(bridge_atoms),
+                bond_ids=set(bridge_bonds),
+            )
+        )
+    if "en" in lower_term:
+        tokens.append(
+            NameTokenBinding(
+                text="en",
+                token_kind="unsaturation",
+                source="substituent_renderer",
+                grammar_role="alkenyl_bridge_unsaturation",
+                binding_key="prefix:alkenyl_bridge",
+                atom_ids=set(bridge_atoms),
+                bond_ids=set(bridge_bonds),
+            )
+        )
+    if "yl" in lower_term:
+        tokens.append(
+            NameTokenBinding(
+                text="yl",
+                token_kind="prefix",
+                source="substituent_renderer",
+                grammar_role="alkenyl_bridge_suffix",
+                binding_key="prefix:alkenyl_bridge",
+                atom_ids=set(bridge_atoms),
+                bond_ids=set(bridge_bonds),
+            )
+        )
+    stereo_bonds = {
+        bond.idx
+        for bond in mol.bonds.values()
+        if bond.idx in bridge_bonds and bond.stereo in {"E", "Z"}
+    }
+    if stereo_bonds:
+        tokens.append(
+            NameTokenBinding(
+                text="1",
+                token_kind="locant",
+                source="renderer_stereo",
+                grammar_role="bond_stereo",
+                binding_key="prefix:alkenyl_bridge_stereo",
+                atom_ids=set(bridge_atoms),
+                bond_ids=set(stereo_bonds),
+                locants=("1",),
+            )
+        )
+        descriptor = next(bond.stereo for bond in mol.bonds.values() if bond.idx in stereo_bonds and bond.stereo)
+        tokens.append(
+            NameTokenBinding(
+                text=descriptor,
+                token_kind="stereo",
+                source="renderer_stereo",
+                grammar_role="bond_stereo",
+                binding_key="prefix:alkenyl_bridge_stereo",
+                atom_ids=set(bridge_atoms),
+                bond_ids=set(stereo_bonds),
+                locants=("1",),
+            )
+        )
+    return tokens
+
+
+def _branch_phrase_tokens(mol: Molecule, branch_atoms: set[int], lower_term: str) -> list[NameTokenBinding]:
+    tokens: list[NameTokenBinding] = []
+    branch_bonds = bond_ids_within(mol, branch_atoms)
+    hydroxy_atoms = {
+        atom_idx
+        for atom_idx in branch_atoms
+        if mol.atoms[atom_idx].symbol == "O" and any(neighbor in branch_atoms for neighbor in mol.get_neighbors(atom_idx))
+    }
+    if "dihydroxyphenyl" in lower_term:
+        tokens.append(
+            NameTokenBinding(
+                text="dihydroxyphenyl",
+                token_kind="prefix",
+                source="substituent_renderer",
+                grammar_role="aryl_branch",
+                binding_key="prefix:aryl_branch",
+                atom_ids=set(branch_atoms),
+                bond_ids=set(branch_bonds),
+            )
+        )
+    if "3,4" in lower_term and hydroxy_atoms:
+        hydroxy_bonds = {
+            bond.idx
+            for oxygen in hydroxy_atoms
+            for neighbor in mol.get_neighbors(oxygen)
+            if neighbor in branch_atoms and (bond := mol.get_bond(oxygen, neighbor)) is not None
+        }
+        tokens.append(
+            NameTokenBinding(
+                text="3,4",
+                token_kind="locant",
+                source="substituent_renderer",
+                grammar_role="aryl_branch_substituent_locants",
+                binding_key="prefix:aryl_branch_locants",
+                atom_ids=set(hydroxy_atoms),
+                bond_ids=hydroxy_bonds,
+                locants=("3", "4"),
+            )
+        )
+    if "2-" in lower_term and branch_atoms:
+        tokens.append(
+            NameTokenBinding(
+                text="2",
+                token_kind="locant",
+                source="substituent_renderer",
+                grammar_role="alkenyl_branch_locant",
+                binding_key="prefix:alkenyl_branch_locant",
+                atom_ids=set(branch_atoms),
+                bond_ids=set(branch_bonds),
+                locants=("2",),
+            )
+        )
+    return tokens
 
 
 def _nitrogen_substituent_tokens(
@@ -301,6 +618,10 @@ def _component_within(mol: Molecule, root: int, allowed_atoms: set[int]) -> set[
 
 def _lexical_tokens(text: str) -> tuple[str, ...]:
     return tuple(match.group(0) for match in _TOKEN_RE.finditer(text))
+
+
+def _is_locant_like_token(text: str) -> bool:
+    return bool(re.fullmatch(r"\d+(?:,\d+)*", text))
 
 
 _TOKEN_RE = re.compile(r"[A-Za-z]+(?:\^[0-9]+)?|\d+(?:,\d+)*(?:'\")?|[0-9]+(?:\([0-9,]+\))?")

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -151,18 +151,109 @@ from bluenamer.special_cases import (
     _alkyl_ligand_name,
     organophosphinic_acid_result,
     structural_replacement_parent_name,
+    structural_replacement_parent_result,
     sulfoxide_parent_result,
 )
 from bluenamer.spiro_assembly import SpiroAssembly
 from bluenamer.stereo_audit import audit_stereochemistry
 from bluenamer.substituent_tokens import graph_bound_substituent_tokens
 from bluenamer.suffix_stack import SuffixStack
-from bluenamer.trace_helpers import add_substituent_trace, assembly_trace_segments
+from bluenamer.token_grammar import (
+    binding_term_tokens,
+    is_locant_binding_token,
+    is_locant_token,
+    lexical_token_spans,
+)
+from bluenamer.trace_helpers import add_substituent_trace, assembly_substituent_tree, assembly_trace_segments
 from bluenamer.von_baeyer import _classify_secondary_bridges, find_von_baeyer_candidates
 
 
 def test_name_smiles_stays_plain_fast_api():
     assert name_smiles("CCO") == "ethanol"
+
+
+def test_shared_token_scanner_and_locant_metadata_predicate():
+    assert binding_term_tokens("(propan-2-yl)") == ("propan", "2", "yl")
+    spans = lexical_token_spans("(pyridin-1-ium-1-yl)")
+    assert [(token.text, token.start, token.end) for token in spans] == [
+        ("pyridin", 1, 8),
+        ("1", 9, 10),
+        ("ium", 11, 14),
+        ("1", 15, 16),
+        ("yl", 17, 19),
+    ]
+    assert is_locant_token("2")
+    assert is_locant_token("N")
+    assert is_locant_token("2,4,7")
+    assert not is_locant_token("methyl")
+
+    token = NameTokenBinding(text="N", token_kind="locant")
+    assert is_locant_binding_token(token)
+
+
+def test_ordered_renderer_tokens_place_repeated_text_by_metadata_order():
+    bindings = (
+        NameAtomBinding(
+            stage="shortcut",
+            role="left_attachment",
+            term="1",
+            atom_ids={5},
+            emitted_tokens=(
+                NameTokenBinding(
+                    text="1",
+                    render_order=0,
+                    token_kind="locant",
+                    source="shortcut_renderer",
+                    atom_ids={5},
+                    locants=("1",),
+                ),
+            ),
+        ),
+        NameAtomBinding(
+            stage="shortcut",
+            role="right_attachment",
+            term="1",
+            atom_ids={6},
+            emitted_tokens=(
+                NameTokenBinding(
+                    text="1",
+                    render_order=1,
+                    token_kind="locant",
+                    source="shortcut_renderer",
+                    atom_ids={6},
+                    locants=("1",),
+                ),
+            ),
+        ),
+    )
+
+    tokens = build_name_token_spans("1,1-parent", bindings)
+    locants = [token for token in tokens if token.text == "1"]
+
+    assert [set(token.atom_ids) for token in locants] == [{5}, {6}]
+    assert all(token.source == "shortcut_renderer" for token in locants)
+
+
+def test_substituent_suffix_metadata_is_emitted_by_assembly_parts():
+    parts = AssemblyParts(
+        parent_length=3,
+        is_substituent=True,
+        attachment_locant=2,
+        parent_atom_ids={0, 1, 2},
+        parent_bond_ids={1, 2},
+        parent_atom_ids_by_locant={"1": 0, "2": 1, "3": 2},
+    )
+    assert assemble_name(parts) == "propan-2-yl"
+
+    tree = assembly_substituent_tree(parts, name="propan-2-yl", atom_ids={0, 1, 2}, bond_ids={1, 2})
+
+    assert tree["parent"]["substituent_suffix"] == {
+        "locant": "2",
+        "suffix": "yl",
+        "atom_id": 1,
+        "is_double_attach": False,
+        "is_triple_attach": False,
+    }
 
 
 def test_methane_is_named_without_parent_selection_fallback():
@@ -439,7 +530,7 @@ def test_component_shortcuts_are_final_binding_audited(smiles, decision, role):
     assert data["name_atom_bindings"]
     assert data["name_atom_bindings"][0]["role"] == role
     assert data["name_token_spans"]
-    assert all(token["binding_indices"] for token in data["name_token_spans"])
+    assert all(token["binding_indices"] for token in data["name_token_spans"] if token["token_kind"] != "grammar")
 
     bound_atoms = {atom for binding in data["name_atom_bindings"] for atom in binding["atoms"]}
     token_atoms = {atom for token in data["name_token_spans"] for atom in token["atoms"]}
@@ -478,10 +569,19 @@ def test_biphenyl_is_graph_selected_not_exact_name_rewritten():
     assert steps
     data = steps[-1].data
     assert data["name"] == "1,1'-biphenyl"
-    assert any(binding["role"] == "biphenyl_bridge" for binding in data["name_atom_bindings"])
+    assert any(binding["role"] == "biphenyl_parent" for binding in data["name_atom_bindings"])
     rewrite_names = [operation["name"] for operation in data["name_rewrite_history"]]
     assert "special_component_names" not in rewrite_names
-    assert all(token["binding_indices"] for token in data["name_token_spans"])
+    assert all(token["binding_indices"] for token in data["name_token_spans"] if token["token_kind"] != "grammar")
+    parent_token = next(token for token in data["name_token_spans"] if token["text"] == "biphenyl")
+    assert set(parent_token["atoms"]) == set(range(12))
+    attachment_locants = [
+        token
+        for token in data["name_token_spans"]
+        if token["text"] in {"1", "1'"} and token["source"] == "shortcut_renderer"
+    ]
+    assert len(attachment_locants) == 2
+    assert {tuple(token["atoms"]) for token in attachment_locants} == {(5,), (6,)}
 
 
 def test_oxoacid_shortcut_exposes_central_oxo_ligand_roles():
@@ -1334,9 +1434,9 @@ def test_name_assembly_binds_every_final_token_to_graph_metadata():
     tokens = build_name_token_spans("5-(ammoniomethyl)-oxazolidine-3-ide-2,4-dione", tuple(bindings))
 
     assert tokens
-    assert all(token.binding_indices for token in tokens)
+    assert all(token.binding_indices for token in tokens if token.token_kind != "grammar")
     assert next(token for token in tokens if token.text == "ammoniomethyl").atom_ids == frozenset({0, 1})
-    assert next(token for token in tokens if token.text == "oxazolidine").atom_ids == frozenset({2, 3, 4, 6, 7})
+    assert next(token for token in tokens if token.text == "oxazolidin").atom_ids == frozenset({2, 3, 4, 6, 7})
     assert next(token for token in tokens if token.text == "ide").charge_atom_ids == frozenset({6})
     assert next(token for token in tokens if token.text == "dione").atom_ids == frozenset({4, 5, 7, 8})
 
@@ -1516,6 +1616,29 @@ def test_replacement_parents_are_graph_class_backed():
 
     oxoacid = read_smiles("OP(=O)(O)O")
     assert structural_replacement_parent_name(oxoacid, set(oxoacid.atoms)) == "phosphoric acid"
+
+
+def test_special_replacement_parent_results_have_role_bindings_not_full_fallbacks():
+    cases = {
+        "C[Si]#[Si]C": {"homonuclear_chain_parent", "homonuclear_chain_ligand"},
+        "CCOSCl": {"central_parent_hydride_core", "central_parent_hydride_ligand"},
+        "CC[S@@](=O)CC(C)C": {"sulfoxide_core", "sulfoxide_ligand"},
+    }
+
+    for smiles, expected_roles in cases.items():
+        mol = read_smiles(smiles)
+        result = structural_replacement_parent_result(mol, set(mol.atoms))
+
+        assert result is not None
+        roles = {binding.role for binding in result.bindings}
+        assert expected_roles <= roles
+        assert len(result.bindings) > 1
+        assert not (
+            len(result.bindings) == 1
+            and result.bindings[0].role == result.role
+            and result.bindings[0].atom_ids == set(mol.atoms)
+        )
+        assert all(binding.atom_ids for binding in result.bindings)
 
 
 def test_halogen_oxoacid_replacement_parents_are_data_backed():

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -538,7 +538,60 @@ def test_non_n_heteroatom_substituent_tokens_bind_center_and_ligands():
     methyl = next(token for token in result.token_spans if token.text == "methyl")
     sulfonyl = next(token for token in result.token_spans if token.text == "sulfonyl")
     assert methyl.atom_ids == frozenset({2})
-    assert sulfonyl.atom_ids == frozenset({1})
+    assert sulfonyl.atom_ids == frozenset({1, 3, 4})
+    assert sulfonyl.bond_ids == frozenset({3, 4})
+
+
+def test_heteroatom_shortcut_leaf_tokens_and_tree_are_graph_local():
+    analysis = analyze_smiles("O=S(=O)(Nc1nc(cc(n1)C)C)c2ccc(N)cc2")
+    assembly = next(step for step in analysis.decisions if step.decision == "assembled component name")
+    tokens = {(token["text"], token["start"]): token for token in assembly.data["name_token_spans"]}
+    name = analysis.name
+
+    assert analysis.name == "N-(4-aminophenylsulfonyl)-4,6-dimethylpyrimidin-2-amine"
+    assert tokens[("N", name.index("N-("))]["atoms"] == [3]
+    assert tokens[("N", name.index("N-("))]["source"] == "n_substituent_locant"
+    assert tokens[("4", name.index("4-aminophenyl"))]["atoms"] == [16]
+    assert tokens[("aminophenyl", name.index("aminophenyl"))]["atoms"] == [12, 13, 14, 15, 16, 17, 18]
+    assert tokens[("sulfonyl", name.index("sulfonyl"))]["atoms"] == [0, 1, 2]
+    assert tokens[("sulfonyl", name.index("sulfonyl"))]["bonds"] == [1, 2]
+
+    component = analysis.substituent_tree[0]
+    sulfonyl_branch = next(item for item in component["substituents"] if item["name"] == "(4-aminophenylsulfonyl)")
+    ligand = sulfonyl_branch["substituents"][0]
+    assert ligand["name"] == "4-aminophenyl"
+    assert ligand["substituents"][0]["name"] == "amino"
+    assert ligand["substituents"][0]["locants"] == ["4"]
+
+
+def test_carbonylamino_heteroatom_shortcut_tree_does_not_invent_hydroxy_children():
+    analysis = analyze_smiles("CC(C)C[C@@H](C(=O)N[C@@H](CC(C)C)C(=O)N[C@@H](CC(C)C)C(=O)O)N")
+    component = analysis.substituent_tree[0]
+    peptide_branch = next(
+        item
+        for item in component["substituents"]
+        if item["name"]
+        == "(1S)-1-((1S)-1-amino-3-methylbutylcarbonylamino)-3-methylbutylcarbonylamino"
+    )
+    branch_children = peptide_branch["substituents"][0]["substituents"]
+    child_names = [child["name"] for child in branch_children]
+
+    assert "hydroxy" not in child_names
+    assert "carbonyl" in child_names
+    carbonyl = next(child for child in branch_children if child["name"] == "carbonyl")
+    assert carbonyl["atoms"] == [13, 14]
+    assert carbonyl["bonds"] == [14]
+    side = next(child for child in branch_children if child["name"].endswith("methylbutyl)"))
+    assert side["parent"]["parent_length"] == 4
+    assert any(child["name"] == "methyl" for child in side["substituents"])
+    carbonylamino = next(child for child in side["substituents"] if child["name"].endswith("carbonylamino"))
+    assert carbonylamino["atoms"] == [0, 1, 2, 3, 4, 5, 6, 7, 24]
+    inner_carbonyl = carbonylamino["substituents"][0]
+    inner_side = next(child for child in inner_carbonyl["substituents"] if child["name"].endswith("methylbutyl)"))
+    amino = next(child for child in inner_side["substituents"] if child["name"] == "amino")
+    assert amino["locants"] == ["1"]
+    core = next(child for child in inner_carbonyl["substituents"] if child["name"] == "carbonyl")
+    assert core["atoms"] == [5, 6]
 
 
 def test_postprocessing_rewrites_keep_token_metadata_auditable():
@@ -822,11 +875,27 @@ def test_n_substituent_locant_survives_retained_suffix_postprocessing():
     n_locant = next(token for token in assembly.data["name_token_spans"] if token["text"] == "N")
 
     assert analysis.name == "N-methylacetamide"
-    assert n_locant["source"] in {"default_binding", "typed_rewrite"}
+    assert n_locant["source"] == "n_substituent_locant"
     assert n_locant["confidence"] in {"exact", "derived"}
     assert n_locant["ownership"] == "exact"
     assert n_locant["token_kind"] == "locant"
-    assert n_locant["binding_key"] == "prefix:substituent"
+    assert n_locant["binding_key"] == "prefix:n_substituent_locant"
+
+
+def test_n_substituent_and_parent_suffix_morphology_tokens_have_local_scope():
+    analysis = analyze_smiles("CC(=O)Nc1ccccc1")
+    assembly = next(step for step in analysis.decisions if step.decision == "assembled component name")
+    tokens = {token["text"]: token for token in assembly.data["name_token_spans"]}
+
+    assert analysis.name == "N-phenylacetamide"
+    assert tokens["N"]["atoms"] == [3]
+    assert tokens["N"]["bonds"] == [4]
+    assert tokens["N"]["source"] == "n_substituent_locant"
+    assert tokens["phenyl"]["atoms"] == [4, 5, 6, 7, 8, 9]
+    assert tokens["acet"]["atoms"] == [0, 1, 2, 3]
+    assert tokens["acet"]["bonds"] == [1, 2, 3]
+    assert tokens["acet"]["source"] == "parent_suffix_gap"
+    assert tokens["amide"]["atoms"] == [1, 2, 3]
 
 
 def test_mixed_numeric_and_element_locants_are_bound_individually():
@@ -837,10 +906,11 @@ def test_mixed_numeric_and_element_locants_are_bound_individually():
     assert analysis.name == "2,N-dimethylpropanamide"
     for key in [("2", 0), ("N", 2)]:
         token = tokens[key]
-        assert token["source"] == "typed_rewrite"
+        expected_source = "typed_rewrite" if key[0] == "2" else "n_substituent_locant"
+        assert token["source"] == expected_source
         assert token["confidence"] == "derived"
         assert token["ownership"] == "exact"
-        assert token["binding_key"] == "prefix:substituent"
+        assert token["binding_key"] in {"prefix:substituent", "prefix:n_substituent_locant"}
 
 
 def test_multiplier_token_is_grammar_scoped_not_broad_fallback():
@@ -866,6 +936,221 @@ def test_retained_dihydro_and_indicated_h_tokens_avoid_broad_fallback():
     assert tokens["H"]["source"] == "indicated_hydrogen_fallback"
     assert tokens["H"]["token_kind"] == "hydro"
     assert tokens["H"]["ownership"] == "locanted_hydro"
+
+
+def test_recursive_substituent_tree_tokens_keep_nested_scopes_local():
+    parts = AssemblyParts(parent_length=1, parent_atom_ids={0})
+    parts.substituents.append(
+        SubstituentItem(
+            name="(2-(4-fluorophenyl)-3-phenyl-4-(phenylcarbamoyl)-5-(propan-2-yl)-1H-pyrrol-1-yl)",
+            locants=["7"],
+            atom_ids=set(range(11, 41)),
+            bond_ids=set(range(11, 45)),
+            substituent_tree={
+                "name": "(2-(4-fluorophenyl)-3-phenyl-4-(phenylcarbamoyl)-5-(propan-2-yl)-1H-pyrrol-1-yl)",
+                "atoms": list(range(11, 41)),
+                "bonds": list(range(11, 45)),
+                "parent": {
+                    "retained_name": "pyrrole",
+                    "atoms": [11, 12, 13, 14, 15],
+                    "bonds": [12, 13, 14, 15, 42],
+                },
+                "trace_segments": [
+                    {
+                        "label": "parent skeleton",
+                        "atoms": [11, 12, 13, 14, 15],
+                        "bonds": [12, 13, 14, 15, 42],
+                        "name_terms": ["pyrrole", "pyrrol"],
+                    }
+                ],
+                "hydro_operations": [{"locants": ["1"], "atom_ids": [11]}],
+                "substituents": [
+                    {
+                        "name": "(4-fluorophenyl)",
+                        "locants": ["2"],
+                        "atoms": [16, 17, 18, 19, 20, 21, 22],
+                        "bonds": [17, 18, 19, 20, 21, 22, 41],
+                        "substituents": [
+                            {
+                                "name": "fluoro",
+                                "locants": ["4"],
+                                "atoms": [20],
+                                "bonds": [20],
+                                "substituents": [],
+                            }
+                        ],
+                    },
+                    {
+                        "name": "phenyl",
+                        "locants": ["3"],
+                        "atoms": [23, 24, 25, 26, 27, 28],
+                        "bonds": [24, 25, 26, 27, 28, 43],
+                        "substituents": [],
+                    },
+                    {
+                        "name": "(phenylcarbamoyl)",
+                        "locants": ["4"],
+                        "atoms": [29, 30, 31, 32, 33, 34, 35, 36, 37],
+                        "bonds": [30, 31, 32, 33, 34, 35, 36, 37, 44],
+                        "substituents": [
+                            {
+                                "name": "phenyl",
+                                "atoms": [32, 33, 34, 35, 36, 37],
+                                "bonds": [33, 34, 35, 36, 37, 44],
+                                "substituents": [],
+                            }
+                        ],
+                    },
+                    {
+                        "name": "(propan-2-yl)",
+                        "locants": ["5"],
+                        "atoms": [38, 39, 40],
+                        "bonds": [39, 40],
+                        "parent": {
+                            "atoms": [38, 39, 40],
+                            "bonds": [39, 40],
+                            "atom_ids_by_locant": {"1": 39, "2": 38, "3": 40},
+                        },
+                        "substituents": [],
+                    },
+                ],
+            },
+        )
+    )
+
+    bindings = tuple(refresh_name_atom_bindings(parts))
+    text = "7-(2-(4-fluorophenyl)-3-phenyl-4-(phenylcarbamoyl)-5-(propan-2-yl)-1H-pyrrol-1-yl)"
+    tokens = build_name_token_spans(text, bindings)
+    by_text = {(token.text, token.start): token for token in tokens}
+
+    assert by_text[("fluorophenyl", text.index("fluorophenyl"))].atom_ids == frozenset(
+        {16, 17, 18, 19, 20, 21, 22}
+    )
+    assert by_text[("4", text.index("4-fluorophenyl"))].atom_ids == frozenset({20})
+    assert by_text[("phenyl", text.index("-3-phenyl") + 3)].atom_ids == frozenset({23, 24, 25, 26, 27, 28})
+    assert by_text[("4", text.index("4-(phenylcarbamoyl"))].atom_ids == frozenset(
+        {29, 30, 31, 32, 33, 34, 35, 36, 37}
+    )
+    assert by_text[("phenylcarbamoyl", text.index("phenylcarbamoyl"))].atom_ids == frozenset(
+        {29, 30, 31, 32, 33, 34, 35, 36, 37}
+    )
+    assert by_text[("2", text.index("propan-2-yl") + len("propan-"))].atom_ids == frozenset({38})
+
+
+def test_repeated_grouped_locants_use_following_structural_scope():
+    parts = AssemblyParts(
+        parent_length=9,
+        is_ring=True,
+        is_bicycle=True,
+        bicycle_xyz=(4, 3, 0),
+        parent_atom_ids={1, 2, 3, 4, 5, 6, 8, 9, 11},
+        parent_bond_ids={2, 3, 4, 5, 6, 8, 9, 11, 14, 15},
+    )
+    parts.a_prefixes.extend(
+        [
+            SubstituentItem(name="aza", locants=["2"], atom_ids={11}),
+            SubstituentItem(name="aza", locants=["4"], atom_ids={8}),
+            SubstituentItem(name="aza", locants=["7"], atom_ids={1}),
+            SubstituentItem(name="aza", locants=["9"], atom_ids={3}),
+        ]
+    )
+    parts.substituents.append(
+        SubstituentItem(
+            name="methyl",
+            locants=["2", "4", "7"],
+            atom_ids={0, 12, 13},
+            bond_ids={1, 12, 13},
+            emitted_tokens=(
+                NameTokenBinding(text="methyl", atom_ids={12}, source="substituent_renderer"),
+                NameTokenBinding(text="methyl", atom_ids={13}, source="substituent_renderer"),
+                NameTokenBinding(text="methyl", atom_ids={0}, source="substituent_renderer"),
+            ),
+        )
+    )
+    bindings = tuple(refresh_name_atom_bindings(parts))
+    text = "2,4,7-trimethyl-2,4,7,9-tetraazabicyclo[4.3.0]nona"
+    tokens = build_name_token_spans(text, bindings)
+    by_start = {(token.text, token.start): token for token in tokens}
+
+    assert by_start[("2,4,7", 0)].atom_ids == frozenset({0, 12, 13})
+    assert by_start[("methyl", text.index("methyl"))].atom_ids == frozenset({0, 12, 13})
+    assert by_start[("2", text.index("2,4,7,9"))].atom_ids == frozenset({11})
+    assert by_start[("4", text.index("2,4,7,9") + 2)].atom_ids == frozenset({8})
+    assert by_start[("7", text.index("2,4,7,9") + 4)].atom_ids == frozenset({1})
+    assert by_start[("9", text.index("2,4,7,9") + 6)].atom_ids == frozenset({3})
+    assert by_start[(",", text.index("2,4,7,9") + 1)].atom_ids == frozenset()
+    assert by_start[("tetra", text.index("tetra"))].atom_ids == frozenset({1, 3, 8, 11})
+    assert by_start[("aza", text.index("aza"))].atom_ids == frozenset({1, 3, 8, 11})
+
+
+def test_parenthesized_unsaturation_locants_bind_to_double_bond_endpoints():
+    analysis = analyze_smiles("CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
+    assembly = next(step for step in analysis.decisions if step.decision == "assembled component name")
+    tokens = {(token["text"], token["start"]): token for token in assembly.data["name_token_spans"]}
+    name = analysis.name
+
+    assert analysis.name == "2,4,7-trimethyl-2,4,7,9-tetraazabicyclo[4.3.0]nona-1(6),8-diene-3,5-dione"
+    assert tokens[("1", name.index("1(6)"))]["atoms"] == [4]
+    assert tokens[("1", name.index("1(6)"))]["bonds"] == [5]
+    assert tokens[("6", name.index("6),8"))]["atoms"] == [5]
+    assert tokens[("6", name.index("6),8"))]["bonds"] == [5]
+    assert tokens[("8", name.index("8-diene"))]["atoms"] == [2]
+    assert tokens[("8", name.index("8-diene"))]["bonds"] == [3]
+
+
+def test_nested_hydroxyphenyl_propan_yl_tokens_keep_local_scopes():
+    analysis = analyze_smiles("CC(C)(C1=CC=C(C=C1)O)C2=CC=C(C=C2)O")
+    assembly = next(step for step in analysis.decisions if step.decision == "assembled component name")
+    tokens = {(token["text"], token["start"]): token for token in assembly.data["name_token_spans"]}
+    name = analysis.name
+
+    assert analysis.name == "4-(2-(4-hydroxyphenyl)propan-2-yl)benzen-1-ol"
+    assert tokens[("2", name.index("2-(4-hydroxyphenyl"))]["atoms"] == [1]
+    assert tokens[("4", name.index("4-hydroxyphenyl"))]["atoms"] == [16]
+    assert tokens[("hydroxyphenyl", name.index("hydroxyphenyl"))]["atoms"] == [10, 11, 12, 13, 14, 15, 16]
+    assert tokens[("prop", name.index("propan"))]["atoms"] == [0, 1, 2]
+    assert tokens[("2", name.index("2-yl"))]["atoms"] == [1]
+    assert tokens[("yl", name.index("yl)benzen"))]["atoms"] == [1]
+    assert tokens[("benzen", name.index("benzen"))]["atoms"] == [3, 4, 5, 6, 7, 8]
+
+
+def test_oxygen_carbonyl_alkenyl_aryl_substituent_tokens_keep_local_scopes():
+    analysis = analyze_smiles("C1[C@H]([C@@H]([C@@H](C=C1C(=O)O)OC(=O)/C=C/C2=CC(=C(C=C2)O)O)O)O")
+    assembly = next(step for step in analysis.decisions if step.decision == "assembled component name")
+    tokens = {(token["text"], token["start"]): token for token in assembly.data["name_token_spans"]}
+    name = analysis.name
+
+    assert (
+        analysis.name
+        == "(3R,4S,5R)-3-((1E)-2-(3,4-dihydroxyphenyl)ethenylcarbonyloxy)-4,5-dihydroxycyclohex-1-ene-1-carboxylic acid"
+    )
+    assert tokens[("1", name.index("1E"))]["atoms"] == [12, 13]
+    assert tokens[("1", name.index("1E"))]["bonds"] == [13]
+    assert tokens[("E", name.index("E)-2"))]["atoms"] == [12, 13]
+    assert tokens[("2", name.index("2-(3,4-dihydroxyphenyl"))]["atoms"] == [14, 15, 16, 17, 18, 19, 20, 21]
+    assert tokens[("3,4", name.index("3,4-dihydroxyphenyl"))]["atoms"] == [20, 21]
+    assert tokens[("3,4", name.index("3,4-dihydroxyphenyl"))]["bonds"] == [20, 21]
+    assert tokens[("dihydroxyphenyl", name.index("dihydroxyphenyl"))]["atoms"] == [
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+    ]
+    assert tokens[("eth", name.index("ethenyl"))]["atoms"] == [12, 13]
+    ethenyl_start = name.index("ethenyl")
+    assert tokens[("en", name.index("enyl", ethenyl_start))]["bonds"] == [13]
+    assert tokens[("yl", name.index("ylcarbonyloxy", ethenyl_start))]["atoms"] == [12, 13]
+    assert tokens[("carbonyl", name.index("carbonyloxy"))]["atoms"] == [10, 11]
+    assert tokens[("oxy", name.index("oxy)-4,5"))]["atoms"] == [9]
+    assert tokens[("4,5", name.index("4,5-dihydroxycyclohex"))]["atoms"] == [22, 23]
+    assert tokens[("dihydr", name.index("dihydroxycyclohex"))]["atoms"] == [22, 23]
+    assert tokens[("oxy", name.index("oxycyclohex"))]["atoms"] == [22, 23]
+    assert tokens[("1", name.index("1-ene"))]["atoms"] == [5]
+    assert tokens[("en", name.index("ene-1-carboxylic"))]["atoms"] == [4, 5]
 
 
 def test_contextual_postprocessing_updates_absorbed_binding_terms():

--- a/src/bluenamer/tests/test_analysis.py
+++ b/src/bluenamer/tests/test_analysis.py
@@ -670,8 +670,7 @@ def test_carbonylamino_heteroatom_shortcut_tree_does_not_invent_hydroxy_children
     peptide_branch = next(
         item
         for item in component["substituents"]
-        if item["name"]
-        == "(1S)-1-((1S)-1-amino-3-methylbutylcarbonylamino)-3-methylbutylcarbonylamino"
+        if item["name"] == "(1S)-1-((1S)-1-amino-3-methylbutylcarbonylamino)-3-methylbutylcarbonylamino"
     )
     branch_children = peptide_branch["substituents"][0]["substituents"]
     child_names = [child["name"] for child in branch_children]
@@ -1123,14 +1122,10 @@ def test_recursive_substituent_tree_tokens_keep_nested_scopes_local():
     tokens = build_name_token_spans(text, bindings)
     by_text = {(token.text, token.start): token for token in tokens}
 
-    assert by_text[("fluorophenyl", text.index("fluorophenyl"))].atom_ids == frozenset(
-        {16, 17, 18, 19, 20, 21, 22}
-    )
+    assert by_text[("fluorophenyl", text.index("fluorophenyl"))].atom_ids == frozenset({16, 17, 18, 19, 20, 21, 22})
     assert by_text[("4", text.index("4-fluorophenyl"))].atom_ids == frozenset({20})
     assert by_text[("phenyl", text.index("-3-phenyl") + 3)].atom_ids == frozenset({23, 24, 25, 26, 27, 28})
-    assert by_text[("4", text.index("4-(phenylcarbamoyl"))].atom_ids == frozenset(
-        {29, 30, 31, 32, 33, 34, 35, 36, 37}
-    )
+    assert by_text[("4", text.index("4-(phenylcarbamoyl"))].atom_ids == frozenset({29, 30, 31, 32, 33, 34, 35, 36, 37})
     assert by_text[("phenylcarbamoyl", text.index("phenylcarbamoyl"))].atom_ids == frozenset(
         {29, 30, 31, 32, 33, 34, 35, 36, 37}
     )

--- a/src/bluenamer/tests_roundtrip/roundtrip_helpers.py
+++ b/src/bluenamer/tests_roundtrip/roundtrip_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import shutil
 import subprocess
+import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -119,7 +120,9 @@ def roundtrip_smiles(smiles: str) -> None:
     name = name_smiles(original)
     assert name
 
-    result = py2opsin.py2opsin([name])
+    with tempfile.NamedTemporaryFile(prefix="bluenamer_opsin_", suffix=".txt", delete=True) as handle:
+        tmp_fpath = handle.name
+    result = py2opsin.py2opsin([name], tmp_fpath=tmp_fpath)
     assert result and result[0]
 
     back = standardize_and_canonicalize_tautomer(result[0])

--- a/src/bluenamer/token_grammar.py
+++ b/src/bluenamer/token_grammar.py
@@ -1,0 +1,88 @@
+"""Shared lexical token grammar for rendered nomenclature text.
+
+This module intentionally stays small and dependency-light. Renderers should
+emit graph ownership metadata directly; this scanner only splits already
+rendered terms into stable visible tokens and provides shared locant
+predicates for final metadata placement.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Protocol
+
+ELEMENT_LOCANTS = frozenset({"N", "O", "P", "S"})
+
+_LEXICAL_TOKEN_RE = re.compile(
+    r"""
+    [A-Za-z]+(?:\^[0-9]+)?
+    |
+    \d+(?:,\d+)*(?:\([0-9,]+\))?
+    """,
+    re.VERBOSE,
+)
+_LOCANT_RE = re.compile(r"(?:\d+|[NOPS])(?:,(?:\d+|[NOPS]))*(?:\([0-9,]+\))?")
+
+
+class TokenBindingLike(Protocol):
+    """Minimal structural protocol for token bindings."""
+
+    text: str
+    token_kind: str
+    locants: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LexicalToken:
+    """One visible token span in a rendered name."""
+
+    text: str
+    start: int
+    end: int
+
+
+def lexical_token_spans(text: str, offset: int = 0) -> tuple[LexicalToken, ...]:
+    """Return lexical token spans for visible nomenclature text."""
+
+    return tuple(
+        LexicalToken(match.group(0), offset + match.start(), offset + match.end())
+        for match in _LEXICAL_TOKEN_RE.finditer(text)
+    )
+
+
+def lexical_tokens(text: str) -> tuple[str, ...]:
+    """Return visible lexical token strings from ``text``."""
+
+    return tuple(token.text for token in lexical_token_spans(text))
+
+
+def binding_term_tokens(text: str) -> tuple[str, ...]:
+    """Return visible token strings for a rendered binding term."""
+
+    return lexical_tokens(text)
+
+
+def locant_tokens_in_text(text: str) -> tuple[str, ...]:
+    """Return locant-like tokens visible in ``text``."""
+
+    return tuple(token for token in lexical_tokens(text) if is_locant_token(token))
+
+
+def is_locant_token(token: str, *, allow_element: bool = True) -> bool:
+    """Return whether ``token`` is a numeric or element locant token."""
+
+    token = token.strip().strip("'").strip('"')
+    if not token:
+        return False
+    if token in ELEMENT_LOCANTS:
+        return allow_element
+    return bool(_LOCANT_RE.fullmatch(token))
+
+
+def is_locant_binding_token(token_binding: TokenBindingLike) -> bool:
+    """Return whether an emitted token binding represents a locant."""
+
+    if token_binding.token_kind == "locant":
+        return True
+    return bool(token_binding.locants) and is_locant_token(token_binding.text)

--- a/src/bluenamer/trace_helpers.py
+++ b/src/bluenamer/trace_helpers.py
@@ -390,7 +390,7 @@ def _merge_substituent_tree_instances(existing: dict | None, new: dict, name: st
 
 
 def _parent_tree_node(parts: AssemblyParts) -> dict:
-    return {
+    node = {
         "kind": "parent",
         "retained_name": parts.retained_name,
         "parent_length": parts.parent_length,
@@ -406,6 +406,27 @@ def _parent_tree_node(parts: AssemblyParts) -> dict:
         "atom_ids_by_locant": dict(parts.parent_atom_ids_by_locant),
         "atom_symbols_by_locant": dict(parts.parent_atom_symbols_by_locant),
         "atom_charges_by_locant": dict(parts.parent_atom_charges_by_locant),
+    }
+    suffix_data = _substituent_suffix_tree_node(parts)
+    if suffix_data:
+        node["substituent_suffix"] = suffix_data
+    return node
+
+
+def _substituent_suffix_tree_node(parts: AssemblyParts) -> dict | None:
+    if not parts.is_substituent:
+        return None
+    locant = str(parts.attachment_locant)
+    atom_id = parts.parent_atom_ids_by_locant.get(locant)
+    if atom_id is None:
+        return None
+    suffix = "ylidyne" if parts.is_triple_attach else "ylidene" if parts.is_double_attach else "yl"
+    return {
+        "locant": locant,
+        "suffix": suffix,
+        "atom_id": atom_id,
+        "is_double_attach": bool(parts.is_double_attach),
+        "is_triple_attach": bool(parts.is_triple_attach),
     }
 
 

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -93,10 +93,21 @@ def test_cli_describe_json():
     assert payload["paragraphs"]
     assert isinstance(payload["components"], list)
     assert any(c["phase"] == "parent_selection" for c in payload["components"])
+    assert "token_summary" not in payload
+    assert "token_spans" not in payload
 
 
-def test_describe_exposes_token_binding_summary():
+def test_describe_hides_token_binding_summary_by_default():
     d = describe("CCO")
+    payload = d.to_dict()
+
+    assert "token_summary" not in payload
+    assert "token_spans" not in payload
+    assert "Name-token graph bindings" not in str(d)
+
+
+def test_describe_exposes_token_binding_summary_in_debug_mode():
+    d = describe("CCO", debugging_tokens=True)
     payload = d.to_dict()
 
     assert payload["token_summary"]["total"] >= 1
@@ -104,6 +115,19 @@ def test_describe_exposes_token_binding_summary():
     assert payload["token_spans"]
     assert any(token["atoms"] for token in payload["token_spans"])
     assert "Name-token graph bindings" in str(d)
+
+
+def test_cli_describe_json_exposes_token_binding_summary_in_debug_mode():
+    result = subprocess.run(
+        [sys.executable, "-m", "bluenamer.cli", "describe", "CCO", "--json", "--debug-tokens"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["token_summary"]["total"] >= 1
+    assert payload["token_spans"]
 
 
 def test_describe_renders_nested_substituent_tree_from_metadata():

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -160,9 +160,7 @@ def test_describe_explains_parenthesized_unsaturation_locants():
 
 
 def test_describe_renders_oxygen_carbonyl_shortcut_substituent_tree():
-    text = str(
-        describe("C1[C@H]([C@@H]([C@@H](C=C1C(=O)O)OC(=O)/C=C/C2=CC(=C(C=C2)O)O)O)O")
-    )
+    text = str(describe("C1[C@H]([C@@H]([C@@H](C=C1C(=O)O)OC(=O)/C=C/C2=CC(=C(C=C2)O)O)O)O"))
 
     assert "Substituent at 3: ((1E)-2-(3,4-dihydroxyphenyl)ethenylcarbonyloxy)" in text
     assert "Substituent: ethenyl covers 2 atoms and 1 bond" in text

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -93,3 +93,72 @@ def test_cli_describe_json():
     assert payload["paragraphs"]
     assert isinstance(payload["components"], list)
     assert any(c["phase"] == "parent_selection" for c in payload["components"])
+
+
+def test_describe_exposes_token_binding_summary():
+    d = describe("CCO")
+    payload = d.to_dict()
+
+    assert payload["token_summary"]["total"] >= 1
+    assert payload["token_summary"]["fallback_tokens"] == []
+    assert payload["token_spans"]
+    assert any(token["atoms"] for token in payload["token_spans"])
+    assert "Name-token graph bindings" in str(d)
+
+
+def test_describe_renders_nested_substituent_tree_from_metadata():
+    d = describe("CC(=O)Nc1ccccc1")
+    text = str(d)
+
+    assert d.substituent_tree
+    assert "Component and substituent structure" in text
+    assert "Substituent" in text
+    assert "phenyl" in text
+    assert "retained as benzene" in text
+
+
+def test_describe_orders_main_parent_trace_before_nested_substituent_trace():
+    text = str(describe("CC(=O)Nc1ccccc1"))
+
+    assert "The final assembled name is **N-phenylacetamide**." not in text
+    assert "Component assembled as **N-phenylacetamide**" not in text
+    eth_index = text.index('contributes "eth"')
+    amide_index = text.index('contributes "amide"')
+    benzene_index = text.index('contributes "benzene"')
+    assert eth_index < amide_index < benzene_index
+
+
+def test_describe_explains_parenthesized_unsaturation_locants():
+    text = str(describe("CN1C=NC2=C1C(=O)N(C(=O)N2C)C"))
+
+    assert "Unsaturation: double at 1(6),8" in text
+    assert "1(6) means a multiple bond between locants 1 and 6" in text
+
+
+def test_describe_renders_oxygen_carbonyl_shortcut_substituent_tree():
+    text = str(
+        describe("C1[C@H]([C@@H]([C@@H](C=C1C(=O)O)OC(=O)/C=C/C2=CC(=C(C=C2)O)O)O)O")
+    )
+
+    assert "Substituent at 3: ((1E)-2-(3,4-dihydroxyphenyl)ethenylcarbonyloxy)" in text
+    assert "Substituent: ethenyl covers 2 atoms and 1 bond" in text
+    assert "Substituent: dihydroxyphenyl covers 8 atoms and 8 bonds" in text
+    assert text.count("Substituent: hydroxy covers 1 atom and 1 bond") >= 2
+
+
+def test_describe_renders_heteroatom_shortcut_ligand_tree():
+    text = str(describe("O=S(=O)(Nc1nc(cc(n1)C)C)c2ccc(N)cc2"))
+
+    assert "Substituent at N: (4-aminophenylsulfonyl)" in text
+    assert "Substituent: 4-aminophenyl covers 7 atoms and 7 bonds" in text
+    assert "Parent: ring parent with 6 atoms retained as benzene" in text
+    assert "Substituent at 4: amino covers 1 atom" in text
+
+
+def test_describe_carbonylamino_shortcut_does_not_render_carbonyl_oxygen_as_hydroxy():
+    text = str(describe("CC(C)C[C@@H](C(=O)N[C@@H](CC(C)C)C(=O)N[C@@H](CC(C)C)C(=O)O)N"))
+
+    assert "Substituent: carbonyl covers 2 atoms and 1 bond" in text
+    assert "Substituent at 1: (1S)-1-amino-3-methylbutylcarbonylamino covers 9 atoms and 8 bonds" in text
+    assert "Substituent: (1S)-1-amino-3-methylbutylcarbonyl covers 8 atoms and 7 bonds" in text
+    assert "Substituent: hydroxy covers 1 atom and 1 bond" not in text

--- a/tests/integration/test_human_descriptor.py
+++ b/tests/integration/test_human_descriptor.py
@@ -11,13 +11,27 @@ def test_human_descriptor_uses_parent_metadata_without_token_spans():
     assert isinstance(d, HumanDescription)
     text = str(d)
     assert "9-membered bicyclic [4.3.0] heteroskeleton" in text
-    assert "nitrogen at positions 2, 4, 7, and 9" in text
-    assert "double bond between positions 1 and 6" in text
-    assert "double bond between positions 8 and 9" in text
-    assert "oxo groups at positions 3 and 5" in text
-    assert "methyl groups at positions 2, 4, and 7" in text
+    assert "nitrogen at positions 2 (atom id" in text
+    assert "4 (atom id" in text
+    assert "7 (atom id" in text
+    assert "9 (atom id" in text
+    assert "double bond between position 1 (atom id" in text
+    assert "and position 6 (atom id" in text
+    assert "double bond between position 8 (atom id" in text
+    assert "and position 9 (atom id" in text
+    assert "oxo groups at positions 3 (atom id" in text
+    assert "5 (atom id" in text
+    assert "methyl groups at positions 2 (atom id" in text
     assert "token" not in text.lower()
     assert "span" not in text.lower()
+
+
+def test_human_descriptor_starts_with_processed_smiles_atom_ids():
+    d = describe_human("C[C@@H](Cl)C(=O)c1ccccc1")
+
+    first = d.paragraphs[0]
+    assert first.startswith("Processed SMILES: C[C@@H](Cl)C(=O)c1ccccc1\n")
+    assert "C{0}[C@@H]{1}(Cl{2})C{3}(=O{4})c{5}1c{6}c{7}c{8}c{9}c{10}1" in first
 
 
 def test_human_descriptor_recurses_into_substituent_parents():
@@ -25,9 +39,23 @@ def test_human_descriptor_recurses_into_substituent_parents():
 
     text = str(d)
     assert "N-phenylacetamide" in text
-    assert "an amide group at position 1" in text
+    assert "an amide group at position 1 (atom id" in text
     assert "a phenyl group at position N" in text
     assert "phenyl substituent at position N is built around the retained benzene parent" in text
+    assert "\nThe principal characteristic feature is an amide group" in text
+
+
+def test_human_descriptor_uses_local_substituent_names_and_atom_ids():
+    d = describe_human("CC(=O)c1cccc(Nc2ccccc2CC)c1")
+
+    text = str(d)
+    assert "1-(3-((2-ethylphenyl)amino)phenyl)ethan-1-one" in text
+    assert "a phenyl group at position 1 (atom id" in text
+    assert "3-((2-ethylphenyl)amino)phenyl group" not in text
+    assert "an amino group at position 3 (atom id" in text
+    assert "a phenyl group." in text
+    assert "a ethyl group" not in text
+    assert "an ethyl group" in text
 
 
 def test_human_descriptor_handles_nested_substituent_trees_generically():

--- a/tests/integration/test_human_descriptor.py
+++ b/tests/integration/test_human_descriptor.py
@@ -1,0 +1,41 @@
+"""Tests for the human-oriented metadata descriptor."""
+
+from __future__ import annotations
+
+from bluenamer import HumanDescription, describe_human
+
+
+def test_human_descriptor_uses_parent_metadata_without_token_spans():
+    d = describe_human("CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
+
+    assert isinstance(d, HumanDescription)
+    text = str(d)
+    assert "9-membered bicyclic [4.3.0] heteroskeleton" in text
+    assert "nitrogen at positions 2, 4, 7, and 9" in text
+    assert "double bond between positions 1 and 6" in text
+    assert "double bond between positions 8 and 9" in text
+    assert "oxo groups at positions 3 and 5" in text
+    assert "methyl groups at positions 2, 4, and 7" in text
+    assert "token" not in text.lower()
+    assert "span" not in text.lower()
+
+
+def test_human_descriptor_recurses_into_substituent_parents():
+    d = describe_human("CC(=O)Nc1ccccc1")
+
+    text = str(d)
+    assert "N-phenylacetamide" in text
+    assert "an amide group at position 1" in text
+    assert "a phenyl group at position N" in text
+    assert "phenyl substituent at position N is built around the retained benzene parent" in text
+
+
+def test_human_descriptor_handles_nested_substituent_trees_generically():
+    d = describe_human("O=S(=O)(Nc1nc(cc(n1)C)C)c2ccc(N)cc2")
+
+    text = str(d)
+    assert "N-(4-aminophenylsulfonyl)-4,6-dimethylpyrimidin-2-amine" in text
+    assert "4-aminophenylsulfonyl" in text
+    assert "4-aminophenyl" in text
+    assert "retained benzene parent" in text
+    assert "amino group" in text


### PR DESCRIPTION
## Summary

This PR improves BluNamer’s molecule description and name-token metadata layers. It adds richer, metadata-backed descriptions, introduces a new human-oriented descriptor API, and tightens graph-local token bindings for complex substituents, N-substituent locants, unsaturations, and heteroatom shortcut names.

## What changed

* Added `DescriptionTokenSummary` to summarize final-name token binding metadata by kind, ownership, confidence, and source.
* Expanded `describe()` output with:

  * token summaries
  * token spans
  * substituent tree rendering
  * ordered trace segment explanations
  * clearer parent, unsaturation, substituent, and rule descriptions
* Added new public `describe_human()` API and `HumanDescription` model for compact, chemistry-facing descriptions that avoid token-span/debug terminology.
* Exported the new descriptor types and functions from `bluenamer.__init__`.
* Added explicit graph-local handling for N-substituent locants so tokens like `N` bind to the relevant nitrogen atom instead of broad substituent scope.
* Improved token span alignment for:

  * parenthesized unsaturation locants such as `1(6)`
  * repeated grouped locants
  * recursive substituent trees
  * heteroatom-centered shortcut substituents
  * oxygen-carbonyl shortcut substituents such as `carbonyloxy`
  * parent/suffix morphology gaps
  * alkenyl bridge stereo and unsaturation tokens
* Added nested substituent-tree metadata for heteroatom and oxygen-carbonyl shortcut branches.
* Improved substituent renderer token metadata so complex fragments preserve local atom and bond ownership instead of falling back to broad scopes.

## Why

The previous describer was useful for high-level naming explanations, but it did not expose enough structured metadata for auditing token-to-graph alignment or for explaining nested substituents clearly. Complex names with recursive substituents, heteroatom shortcut prefixes, and repeated locants could also assign overly broad graph scopes to individual name tokens.

This PR makes the description layer more transparent and makes token bindings more local and auditable.

## Testing

Added and updated tests covering:

* token binding summaries in `describe()`
* nested substituent tree rendering
* ordered trace segment output
* parenthesized unsaturation locants
* heteroatom shortcut ligand trees
* oxygen-carbonyl shortcut substituent trees
* human-oriented descriptions from `describe_human()`
* N-substituent locant binding
* local parent/suffix morphology scope
* recursive substituent tree token scopes
* repeated grouped locant disambiguation
* local token scopes for hydroxyphenyl, alkenyl, aryl, carbonyl, and oxy fragments
* regression coverage for carbonylamino shortcut trees avoiding incorrect hydroxy children

## Summary by Sourcery

Improve name-token to graph binding metadata, add human-readable describer, and refine handling of complex substituents and locants.

New Features:
- Introduce a human-oriented description API and model that explains names from substituent-tree metadata without exposing token-span internals.
- Expose detailed token binding summaries, spans, and substituent trees from the core describer and CLI in an opt-in debug mode.
- Add structured nested substituent trees for heteroatom and oxygen–carbonyl shortcut branches, including ligand and carbonyl core nodes.

Bug Fixes:
- Tighten token binding for N-substituent locants so N tokens bind to their specific nitrogen and local bonds instead of broad substituent scopes.
- Fix binding of parenthesized unsaturation locants and repeated grouped locants so locant tokens map to the correct double-bond endpoints and ligand atoms.
- Prevent shortcut trees such as carbonylamino from inventing spurious hydroxy children in the substituent tree.

Enhancements:
- Refine tokenization and context-aware placement of renderer tokens, including ordered emission, match priorities, and context guards for locants and stereo tokens.
- Improve recursive substituent token metadata so complex fragments reuse tree-local scopes rather than broad substituent-level bindings.
- Extend shortcut parent naming logic to return structured binding roles for homonuclear chains, central parent hydrides, and biphenyl parents to support better auditing.
- Enhance the describer output with substituent-tree rendering, ordered trace segment explanations, and clearer parent, unsaturation, substituent, and rule narratives.

Documentation:
- Update README to document the new human-like description API and demonstrate its usage.

Tests:
- Add extensive tests covering token grammar utilities, ordered renderer token placement, N-substituent locants, unsaturation locants, recursive substituent scopes, and shortcut parent bindings.
- Add integration tests for the new human-oriented descriptor and for debug token summaries in CLI and library describe flows.