### PR TITLE
feat: atom-ids in SMILES for debugging purposes

### DIFF
--- a/src/bluenamer/describer.py
+++ b/src/bluenamer/describer.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .engine import DEFAULT_NAMING_ENGINE, NamingRequest, NamingResult, _extract_rules_hit
+from .human_descriptor import _processed_smiles_sentence
 from .molecule import TracePhase, TraceStep
 
 
@@ -110,6 +111,9 @@ def describe(
 
     components = tuple(_decision_components(result))
     paragraphs: list[str] = [summary]
+    smiles_sentence = _processed_smiles_sentence(smiles)
+    if smiles_sentence:
+        paragraphs.append(smiles_sentence)
     if components:
         paragraphs.append("\n".join(c.text for c in components))
 

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -25,6 +25,16 @@ def test_describe_returns_structured_description():
     assert any(c.phase == "parent_selection" for c in d.components)
 
 
+def test_describe_includes_processed_smiles_atom_ids():
+    d = describe("C[C@@H](Cl)C(=O)c1ccccc1")
+    text = str(d)
+
+    assert d.summary.startswith("The molecule C[C@@H](Cl)C(=O)c1ccccc1 is named")
+    assert "Processed SMILES: C[C@@H](Cl)C(=O)c1ccccc1" in text
+    assert "Atom ids in that SMILES:" in text
+    assert "C{0}[C@@H]{1}(Cl{2})C{3}(=O{4})c{5}1c{6}c{7}c{8}c{9}c{10}1" in text
+
+
 def test_describe_explains_functional_group_selection():
     d = describe("CC(=O)Nc1ccccc1")
     text = str(d)


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add an integration test to verify that the description includes processed SMILES and corresponding atom IDs.