### PR TITLE
 normalization roundtrip fix + retianed names support for phenazine, phenanthrolines, acridine, carbazole, purine, indazole, xanthenes and their derivates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,12 @@ print(d.text)
 Processed SMILES: Cn1cnc2c1c(=O)n(C)c(=O)n2C
 Atom ids in that SMILES: C{0}n{1}1c{2}n{3}c{4}2c{5}1c{6}(=O{7})n{8}(C{13})c{9}(=O{10})n{11}2C{12}
 
-The molecule is named 2,4,7-trimethyl-2,4,7,9-tetraazabicyclo[4.3.0]nona-1(6),8-diene-3,5-dione.
+The molecule is named 1,3,7-trimethylpurine-2,6-dione.
 
-The molecule is built around a 9-membered bicyclic [4.3.0] heteroskeleton.
-Within that parent framework, there is nitrogen at positions 2 (atom id 11), 4 (atom id 8), 7 (atom id 1), and 9 (atom id 3).
-Within that parent framework, there is a double bond between position 1 (atom id 4) and position 6 (atom id 5) and a double bond between position 8 (atom id 2) and position 9 (atom id 3).
-The principal characteristic feature is oxo groups at positions 3 (atom id 9) and 5 (atom id 6).
-Attached to this framework are methyl groups at positions 2 (atom id 11), 4 (atom id 8), and 7 (atom id 1). """
+The molecule is built around the retained purine parent, 9-membered bicyclic [4.3.0] heteroskeleton.
+Within that parent framework, there is nitrogen at positions 1 (atom id 8), 3 (atom id 11), 7 (atom id 1), and 9 (atom id 3).
+The principal characteristic feature is oxo groups at positions 2 (atom id 9) and 6 (atom id 6).
+Attached to this framework are methyl groups at positions 1 (atom id 8), 3 (atom id 11), and 7 (atom id 1). """
 
 ```
 
@@ -225,6 +224,11 @@ curl -X POST localhost:8000/describe -H 'content-type: application/json' \
 ```
 
 OpenAPI docs are served at `http://localhost:8000/docs`.
+
+An interactive, recording-ready visualization of the naming pipeline is
+available at `http://localhost:8000/showcase`. It accepts arbitrary SMILES,
+animates the real naming trace, and includes autoplay, looping, speed,
+fullscreen, and a distraction-free record mode.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -225,16 +225,41 @@ curl -X POST localhost:8000/describe -H 'content-type: application/json' \
 
 OpenAPI docs are served at `http://localhost:8000/docs`.
 
-An interactive, recording-ready visualization of the naming pipeline is
-available at `http://localhost:8000/showcase`. It accepts arbitrary SMILES,
-animates the real naming trace, and includes autoplay, looping, speed,
-fullscreen, and a distraction-free record mode.
-
 
 ## License
 
 MIT. See `LICENSE`.
 
-## How to cite 
-Adrian Mirza, Kevin Maik Jablonka, Rostislav Fedorov. Openclatura–an Open-Source Nomenclature Framework for Rule-Based Molecule Naming. ChemRxiv. 15 July 2026.
-DOI: https://doi.org/10.26434/chemrxiv.15006114/v1
+## How to cite
+
+If you use Openclatura in your research, please cite the Openclatura preprint:
+
+```bibtex
+@article{openclatura2026,
+  author  = {Mirza, Adrian and Jablonka, Kevin Maik and Fedorov, Rostislav},
+  title   = {Openclatura--An Open-Source Nomenclature Framework for Rule-Based Molecule Naming},
+  journal = {ChemRxiv},
+  year    = {2026},
+  month   = jul,
+  day     = {15},
+  doi     = {10.26434/chemrxiv.15006114/v1},
+  url     = {https://doi.org/10.26434/chemrxiv.15006114/v1},
+  note    = {Preprint}
+}
+```
+
+If you are using OPSIN for verification, please cite the original OPSIN publication:
+
+```bibtex
+@article{lowe2011opsin,
+  author  = {Lowe, Daniel M. and Corbett, Peter T. and Murray-Rust, Peter and Glen, Robert C.},
+  title   = {Chemical Name to Structure: {OPSIN}, an Open Source Solution},
+  journal = {Journal of Chemical Information and Modeling},
+  year    = {2011},
+  volume  = {51},
+  number  = {3},
+  pages   = {739--753},
+  doi     = {10.1021/ci100384d},
+  url     = {https://doi.org/10.1021/ci100384d}
+}
+```

--- a/evaluations/check_regression.py
+++ b/evaluations/check_regression.py
@@ -119,6 +119,7 @@ def check_regression(
     chunksize: int,
     opsin_chunk_size: int,
     limit: int = 0,
+    normalize_generation_input: bool = False,
 ) -> dict[str, Any]:
     """Run the delta-aware regression check and return a JSON-ready report."""
 
@@ -130,8 +131,9 @@ def check_regression(
     # Keep generation baseline-compatible: the paper names were produced from
     # the stored SMILES. Standardization belongs only to the structural
     # comparison on both sides of the OPSIN round trip.
-    generation_smiles = [row["smiles"] for row in rows]
-    standardized_smiles = [standardize_mol(smiles) or "" for smiles in generation_smiles]
+    stored_smiles = [row["smiles"] for row in rows]
+    standardized_smiles = [standardize_mol(smiles) or "" for smiles in stored_smiles]
+    generation_smiles = standardized_smiles if normalize_generation_input else stored_smiles
     results = name_many(
         generation_smiles,
         processes=processes,
@@ -172,7 +174,7 @@ def check_regression(
 
     return {
         "baseline_file": str(baseline_path),
-        "generation_input": "stored_smiles",
+        "generation_input": "standardized_smiles" if normalize_generation_input else "stored_smiles",
         "comparison_method": "standardize_mol(original) == standardize_mol(OPSIN(name))",
         "rows": len(rows),
         "baseline_matches": baseline_matches,
@@ -206,6 +208,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--chunksize", type=int, default=64, help="naming multiprocessing chunk size")
     parser.add_argument("--opsin-chunk-size", type=int, default=1000, help="changed names per OPSIN invocation")
     parser.add_argument("--limit", type=int, default=0, help="check only the first N rows (development only)")
+    parser.add_argument(
+        "--normalize-generation-input",
+        action="store_true",
+        help="diagnostic: name standardize_mol(smiles) instead of the stored SMILES",
+    )
     parser.add_argument("--report", type=Path, help="write the full JSON report to this path")
     return parser.parse_args(argv)
 
@@ -218,6 +225,7 @@ def main(argv: list[str] | None = None) -> int:
         chunksize=args.chunksize,
         opsin_chunk_size=args.opsin_chunk_size,
         limit=args.limit,
+        normalize_generation_input=args.normalize_generation_input,
     )
     if args.report:
         args.report.parent.mkdir(parents=True, exist_ok=True)

--- a/src/openclatura/additive.py
+++ b/src/openclatura/additive.py
@@ -1,7 +1,6 @@
 """Explicit additive/replacement feature collection for selected parents."""
 
 from .assembly_parts import AssemblyParts, SubstituentItem
-from .grammar_snapshot_data import retained_fused_token
 from .molecule import Molecule
 from .name_operations import HydroOperation
 from .namer_config import INDICATED_H_RETAINED_NAMES
@@ -15,8 +14,10 @@ def add_indicated_hydrogens(mol: Molecule, parts: AssemblyParts, numbered_path: 
     if parts.retained_name == "tetrazole" and any(mol.atoms[idx].charge for idx in numbered_path):
         return
     oxo_derivative = parts.principal_group is not None and parts.principal_group.key == "ketone"
-    retained_token = retained_fused_token(parts.retained_name)
-    default_indicated_h = set(retained_token.default_indicated_h) if retained_token is not None else set()
+    metadata = parts.retained_parent_metadata
+    default_indicated_h = set(metadata.default_indicated_h) if metadata is not None else set()
+    fusion_locants = set(metadata.fusion_locants) if metadata is not None else set()
+    candidates: list[tuple[str, int]] = []
     for idx in numbered_path:
         atom = mol.atoms[idx]
         locant = str(get_loc(idx))
@@ -24,7 +25,7 @@ def add_indicated_hydrogens(mol: Molecule, parts: AssemblyParts, numbered_path: 
         # derivatives, not additional indicated-H sites.  Carbon-bound H is
         # emitted only where the retained parent plan declares it (9H-xanthene,
         # indene, fluorene, and similar parent hydrides).
-        if retained_token is not None and default_indicated_h and atom.is_carbon and locant not in default_indicated_h:
+        if metadata is not None and default_indicated_h and atom.is_carbon and locant not in default_indicated_h:
             continue
         if oxo_derivative:
             if atom.explicit_h_count + atom.total_h_count <= 0:
@@ -45,24 +46,45 @@ def add_indicated_hydrogens(mol: Molecule, parts: AssemblyParts, numbered_path: 
         if atom.symbol in ["N", "C"]:
             ring_bonds = [mol.get_bond(idx, n) for n in mol.get_neighbors(idx) if n in numbered_path]
             fusion_carbon_h = (
-                retained_token is not None
+                metadata is not None
                 and not default_indicated_h
                 and atom.is_carbon
+                and locant in fusion_locants
                 and len(ring_bonds) == 3
                 and atom.explicit_h_count + atom.total_h_count > 0
             )
             if sum(b.order for b in ring_bonds) == 2 or fusion_carbon_h:
-                locant = str(get_loc(idx))
-                parts.indicated_hydrogens.append(locant)
-                parts.hydro_operations.append(
-                    HydroOperation(
-                        key="indicated_hydrogen",
-                        reason="Retained unsaturated parent requires indicated-hydrogen locant.",
-                        locants=(locant,),
-                        atom_ids=(idx,),
-                        operation_kind="indicated_hydrogen",
-                    )
-                )
+                candidates.append((locant, idx))
+
+    # A hydrogenated fusion carbon changes the retained-parent hydride state.
+    # It is expressed together with the other affected locants as one additive
+    # hydro operation (for example 1,4-dihydropurine), not as indicated H.
+    additive_hydrogen = any(
+        mol.atoms[atom_idx].is_carbon and locant in fusion_locants for locant, atom_idx in candidates
+    )
+    if additive_hydrogen and len(candidates) > 1:
+        parts.hydro_operations.append(
+            HydroOperation(
+                key="additive_hydrogen",
+                reason="Retained parent requires an additive hydrogen prefix.",
+                locants=tuple(locant for locant, _ in candidates),
+                atom_ids=tuple(atom_idx for _, atom_idx in candidates),
+                operation_kind="additive_hydrogen",
+            )
+        )
+        return
+
+    for locant, atom_idx in candidates:
+        parts.indicated_hydrogens.append(locant)
+        parts.hydro_operations.append(
+            HydroOperation(
+                key="indicated_hydrogen",
+                reason="Retained unsaturated parent requires indicated-hydrogen locant.",
+                locants=(locant,),
+                atom_ids=(atom_idx,),
+                operation_kind="indicated_hydrogen",
+            )
+        )
 
 
 def add_replacement_prefixes(mol: Molecule, parts: AssemblyParts, numbered_path: list[int], get_loc) -> None:

--- a/src/openclatura/additive.py
+++ b/src/openclatura/additive.py
@@ -1,6 +1,7 @@
 """Explicit additive/replacement feature collection for selected parents."""
 
 from .assembly_parts import AssemblyParts, SubstituentItem
+from .grammar_snapshot_data import retained_fused_token
 from .molecule import Molecule
 from .name_operations import HydroOperation
 from .namer_config import INDICATED_H_RETAINED_NAMES
@@ -13,11 +14,44 @@ def add_indicated_hydrogens(mol: Molecule, parts: AssemblyParts, numbered_path: 
         return
     if parts.retained_name == "tetrazole" and any(mol.atoms[idx].charge for idx in numbered_path):
         return
+    oxo_derivative = parts.principal_group is not None and parts.principal_group.key == "ketone"
+    retained_token = retained_fused_token(parts.retained_name)
+    default_indicated_h = set(retained_token.default_indicated_h) if retained_token is not None else set()
     for idx in numbered_path:
         atom = mol.atoms[idx]
+        locant = str(get_loc(idx))
+        # Saturated carbon atoms elsewhere in a fused ring system are hydro
+        # derivatives, not additional indicated-H sites.  Carbon-bound H is
+        # emitted only where the retained parent plan declares it (9H-xanthene,
+        # indene, fluorene, and similar parent hydrides).
+        if retained_token is not None and default_indicated_h and atom.is_carbon and locant not in default_indicated_h:
+            continue
+        if oxo_derivative:
+            if atom.explicit_h_count + atom.total_h_count <= 0:
+                continue
+            # Hydrogen introduced next to =O is implied by ``-one``/``-dione``
+            # and must not become a new indicated-H locant.  Carbon is allowed
+            # only when the retained parent itself declares that H locant, as
+            # in 9H-xanthene; this excludes the spurious 2H in carbazol-1-one.
+            ring_neighbor_count = sum(neighbor in numbered_path for neighbor in mol.get_neighbors(idx))
+            if (
+                atom.is_carbon
+                and locant not in default_indicated_h
+                and not (not default_indicated_h and ring_neighbor_count == 3)
+            ):
+                continue
+            if default_indicated_h and locant not in default_indicated_h:
+                continue
         if atom.symbol in ["N", "C"]:
             ring_bonds = [mol.get_bond(idx, n) for n in mol.get_neighbors(idx) if n in numbered_path]
-            if sum(b.order for b in ring_bonds) == 2:
+            fusion_carbon_h = (
+                retained_token is not None
+                and not default_indicated_h
+                and atom.is_carbon
+                and len(ring_bonds) == 3
+                and atom.explicit_h_count + atom.total_h_count > 0
+            )
+            if sum(b.order for b in ring_bonds) == 2 or fusion_carbon_h:
                 locant = str(get_loc(idx))
                 parts.indicated_hydrogens.append(locant)
                 parts.hydro_operations.append(

--- a/src/openclatura/assembler.py
+++ b/src/openclatura/assembler.py
@@ -280,7 +280,11 @@ def _add_indicated_hydrogen_prefix(parts: AssemblyParts, core_name: str) -> str:
         return core_name
     if positive_parent_n_charges(parts):
         return core_name
-    ih_str = ",".join(sorted(indicated_hydrogens, key=parse_locant)) + "H-"
+    indicated_hydrogens = sorted(set(indicated_hydrogens), key=parse_locant)
+    has_carbon_h = any(parts.parent_atom_symbols_by_locant.get(locant) == "C" for locant in indicated_hydrogens)
+    if has_carbon_h and len(indicated_hydrogens) > 1:
+        return f"{','.join(indicated_hydrogens)}-{format_multiplier('hydro', len(indicated_hydrogens))}{core_name}"
+    ih_str = ",".join(indicated_hydrogens) + "H-"
     return ih_str + core_name
 
 

--- a/src/openclatura/assembler.py
+++ b/src/openclatura/assembler.py
@@ -270,22 +270,29 @@ def _post_process_name(name: str) -> str:
 
 
 def _add_indicated_hydrogen_prefix(parts: AssemblyParts, core_name: str) -> str:
+    additive_hydrogens = [
+        locant
+        for operation in parts.hydro_operations
+        if operation.operation_kind == "additive_hydrogen"
+        for locant in operation.locants
+    ]
     indicated_hydrogens = [
         locant
         for operation in parts.hydro_operations
         if operation.operation_kind == "indicated_hydrogen"
         for locant in operation.locants
     ] or parts.indicated_hydrogens
-    if not indicated_hydrogens:
+    if not indicated_hydrogens and not additive_hydrogens:
         return core_name
     if positive_parent_n_charges(parts):
         return core_name
-    indicated_hydrogens = sorted(set(indicated_hydrogens), key=parse_locant)
-    has_carbon_h = any(parts.parent_atom_symbols_by_locant.get(locant) == "C" for locant in indicated_hydrogens)
-    if has_carbon_h and len(indicated_hydrogens) > 1:
-        return f"{','.join(indicated_hydrogens)}-{format_multiplier('hydro', len(indicated_hydrogens))}{core_name}"
-    ih_str = ",".join(indicated_hydrogens) + "H-"
-    return ih_str + core_name
+    if indicated_hydrogens:
+        indicated_hydrogens = sorted(set(indicated_hydrogens), key=parse_locant)
+        core_name = ",".join(indicated_hydrogens) + "H-" + core_name
+    if additive_hydrogens:
+        additive_hydrogens = sorted(set(additive_hydrogens), key=parse_locant)
+        core_name = f"{','.join(additive_hydrogens)}-{format_multiplier('hydro', len(additive_hydrogens))}{core_name}"
+    return core_name
 
 
 def _add_stereo_prefix(parts: AssemblyParts, final_word: str) -> str:

--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -80,6 +80,15 @@ class NameAtomBinding:
     emitted_tokens: tuple[NameTokenBinding, ...] = ()
 
 
+@dataclass(frozen=True)
+class RetainedParentMetadata:
+    """Naming metadata carried from a matched retained-parent template."""
+
+    default_indicated_h: tuple[str, ...] = ()
+    fusion_locants: tuple[str, ...] = ()
+    derivative_stem: str | None = None
+
+
 @dataclass
 class AssemblyParts:
     parent_length: int
@@ -96,6 +105,7 @@ class AssemblyParts:
     is_triple_attach: bool = False
     attachment_locant: int | str = 1
     retained_name: str | None = None
+    retained_parent_metadata: RetainedParentMetadata | None = None
     front_modifiers: list[str] = field(default_factory=list)
     front_modifier_atom_ids: set[int] = field(default_factory=set)
     front_modifier_charge_atom_ids: set[int] = field(default_factory=set)

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -572,7 +572,6 @@ def name_component(
     )
     parts = parent_plan.parts
     emit_bond_stereo(mol, parts, numbered_path, get_loc, state.base_exclude)
-    add_indicated_hydrogens(mol, parts, numbered_path, get_loc)
     add_component_front_modifiers(
         mol, parts, state.perceived_groups, state.principal_key, state.sub_exclude, name_subgraph
     )
@@ -604,6 +603,7 @@ def name_component(
         numbered_path,
         get_loc,
     )
+    add_indicated_hydrogens(mol, parts, numbered_path, get_loc)
     add_component_substituents(parts, subst_mapping, numbered_path, get_loc)
 
     refresh_name_atom_bindings(parts)

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -537,7 +537,9 @@ def name_component(
         subst_mapping,
     )
     if retained_fused is not None:
-        state.retained_name, state.locant_maps = retained_fused
+        state.retained_name = retained_fused.name
+        state.locant_maps = retained_fused.locant_maps
+        state.retained_parent_metadata = retained_fused.metadata
     if (
         state.retained_name
         and state.locant_maps is None
@@ -553,6 +555,7 @@ def name_component(
         subst_mapping,
         state.locant_maps,
         state.retained_name,
+        state.retained_parent_metadata,
     )
     numbered_path = parent_plan.numbered_path
     locant_map = parent_plan.locant_map

--- a/src/openclatura/data/namer_rules.json
+++ b/src/openclatura/data/namer_rules.json
@@ -71,7 +71,9 @@
       "isoindole",
       "indazole",
       "benzimidazole",
+      "carbazole",
       "purine",
+      "xanthene",
       "indene",
       "fluorene"
     ]

--- a/src/openclatura/data/parser_grammar_snapshot.json
+++ b/src/openclatura/data/parser_grammar_snapshot.json
@@ -35,7 +35,25 @@
       "quinazoline",
       "quinoxaline",
       "cinnoline",
-      "phthalazine"
+      "phthalazine",
+      "phenazine",
+      "1,4-phenanthroline",
+      "1,5-phenanthroline",
+      "1,6-phenanthroline",
+      "1,7-phenanthroline",
+      "1,8-phenanthroline",
+      "1,9-phenanthroline",
+      "1,10-phenanthroline",
+      "2,7-phenanthroline",
+      "2,8-phenanthroline",
+      "3,5-phenanthroline",
+      "3,6-phenanthroline",
+      "4,5-phenanthroline",
+      "acridine",
+      "carbazole",
+      "purine",
+      "indazole",
+      "xanthene"
     ],
     "audit_only_parent_names": [
       "azulene",
@@ -55,7 +73,8 @@
       "ring_nitrile",
       "ring_aldehyde",
       "ring_amide",
-      "ring_carboxylic_acid"
+      "ring_carboxylic_acid",
+      "ketone"
     ],
     "allowed_group_keys": [
       "alcohol",
@@ -64,6 +83,7 @@
       "ring_aldehyde",
       "ring_amide",
       "ring_carboxylic_acid",
+      "ketone",
       "ether",
       "fluoro",
       "chloro",
@@ -241,6 +261,117 @@
         "phthalazino"
       ],
       "derivative_status": "production_safe"
+    },
+    "phenazine": {
+      "parent_stems": ["phenazin"],
+      "substituent_stems": ["phenazin"],
+      "fusion_stems": ["phenazino"],
+      "derivative_status": "production_safe"
+    },
+    "1,4-phenanthroline": {
+      "parent_stems": ["1,4-phenanthrolin"],
+      "substituent_stems": ["1,4-phenanthrolin"],
+      "fusion_stems": ["1,4-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "1,5-phenanthroline": {
+      "parent_stems": ["1,5-phenanthrolin"],
+      "substituent_stems": ["1,5-phenanthrolin"],
+      "fusion_stems": ["1,5-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "1,6-phenanthroline": {
+      "parent_stems": ["1,6-phenanthrolin"],
+      "substituent_stems": ["1,6-phenanthrolin"],
+      "fusion_stems": ["1,6-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "1,7-phenanthroline": {
+      "parent_stems": ["1,7-phenanthrolin"],
+      "substituent_stems": ["1,7-phenanthrolin"],
+      "fusion_stems": ["1,7-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "1,8-phenanthroline": {
+      "parent_stems": ["1,8-phenanthrolin"],
+      "substituent_stems": ["1,8-phenanthrolin"],
+      "fusion_stems": ["1,8-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "1,9-phenanthroline": {
+      "parent_stems": ["1,9-phenanthrolin"],
+      "substituent_stems": ["1,9-phenanthrolin"],
+      "fusion_stems": ["1,9-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "1,10-phenanthroline": {
+      "parent_stems": ["1,10-phenanthrolin"],
+      "substituent_stems": ["1,10-phenanthrolin"],
+      "fusion_stems": ["1,10-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "2,7-phenanthroline": {
+      "parent_stems": ["2,7-phenanthrolin"],
+      "substituent_stems": ["2,7-phenanthrolin"],
+      "fusion_stems": ["2,7-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "2,8-phenanthroline": {
+      "parent_stems": ["2,8-phenanthrolin"],
+      "substituent_stems": ["2,8-phenanthrolin"],
+      "fusion_stems": ["2,8-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "3,5-phenanthroline": {
+      "parent_stems": ["3,5-phenanthrolin"],
+      "substituent_stems": ["3,5-phenanthrolin"],
+      "fusion_stems": ["3,5-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "3,6-phenanthroline": {
+      "parent_stems": ["3,6-phenanthrolin"],
+      "substituent_stems": ["3,6-phenanthrolin"],
+      "fusion_stems": ["3,6-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "4,5-phenanthroline": {
+      "parent_stems": ["4,5-phenanthrolin"],
+      "substituent_stems": ["4,5-phenanthrolin"],
+      "fusion_stems": ["4,5-phenanthrolino"],
+      "derivative_status": "production_safe"
+    },
+    "acridine": {
+      "parent_stems": ["acridin"],
+      "substituent_stems": ["acridin"],
+      "fusion_stems": ["acridino"],
+      "derivative_status": "production_safe"
+    },
+    "carbazole": {
+      "parent_stems": ["carbazol"],
+      "substituent_stems": ["carbazol"],
+      "fusion_stems": ["carbazolo"],
+      "derivative_status": "production_safe",
+      "default_indicated_h": ["9"]
+    },
+    "purine": {
+      "parent_stems": ["purin"],
+      "substituent_stems": ["purin"],
+      "fusion_stems": ["purino"],
+      "derivative_status": "production_safe"
+    },
+    "indazole": {
+      "parent_stems": ["indazol"],
+      "substituent_stems": ["indazol"],
+      "fusion_stems": ["indazolo"],
+      "derivative_status": "production_safe",
+      "default_indicated_h": ["1"]
+    },
+    "xanthene": {
+      "parent_stems": ["xanthen"],
+      "substituent_stems": ["xanthen"],
+      "fusion_stems": ["xantheno"],
+      "derivative_status": "production_safe",
+      "default_indicated_h": ["9"]
     },
     "azulene": {
       "parent_stems": [

--- a/src/openclatura/data/retained_fused_graph_templates.json
+++ b/src/openclatura/data/retained_fused_graph_templates.json
@@ -551,6 +551,269 @@
       }
     },
     {
+      "name": "phenazine",
+      "pin": true,
+      "priority": 4,
+      "aliases": [],
+      "derivative_stem": "phenazin",
+      "attached_prefix": "phenazino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "linear_tricyclic_14",
+        "heteroatoms": [
+          {"locant": "5", "symbol": "N"},
+          {"locant": "10", "symbol": "N"}
+        ]
+      }
+    },
+    {
+      "name": "1,4-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "1,4-phenanthrolin",
+      "attached_prefix": "1,4-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "4", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "1,5-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "1,5-phenanthrolin",
+      "attached_prefix": "1,5-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "5", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "1,6-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "1,6-phenanthrolin",
+      "attached_prefix": "1,6-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "6", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "1,7-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "1,7-phenanthrolin",
+      "attached_prefix": "1,7-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "7", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "1,8-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "1,8-phenanthrolin",
+      "attached_prefix": "1,8-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "8", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "1,9-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "1,9-phenanthrolin",
+      "attached_prefix": "1,9-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "9", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "1,10-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "1,10-phenanthrolin",
+      "attached_prefix": "1,10-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "10", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "2,7-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "2,7-phenanthrolin",
+      "attached_prefix": "2,7-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "2", "symbol": "N"}, {"locant": "7", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "2,8-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "2,8-phenanthrolin",
+      "attached_prefix": "2,8-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "2", "symbol": "N"}, {"locant": "8", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "3,5-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "3,5-phenanthrolin",
+      "attached_prefix": "3,5-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "3", "symbol": "N"}, {"locant": "5", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "3,6-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "3,6-phenanthrolin",
+      "attached_prefix": "3,6-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "3", "symbol": "N"}, {"locant": "6", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "4,5-phenanthroline",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "4,5-phenanthrolin",
+      "attached_prefix": "4,5-phenanthrolino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "phenanthrenoid_14",
+        "heteroatoms": [{"locant": "4", "symbol": "N"}, {"locant": "5", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "acridine",
+      "pin": true,
+      "priority": 6,
+      "aliases": [],
+      "derivative_stem": "acridin",
+      "attached_prefix": "acridino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "acridinoid_14",
+        "heteroatoms": [{"locant": "10", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "carbazole",
+      "pin": true,
+      "priority": 17,
+      "aliases": ["9H-carbazole"],
+      "default_indicated_h": ["9"],
+      "derivative_stem": "carbazol",
+      "attached_prefix": "carbazolo",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "carbazoloid_13",
+        "heteroatoms": [{"locant": "9", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "purine",
+      "pin": true,
+      "priority": 16,
+      "aliases": ["7H-purine", "9H-purine"],
+      "derivative_stem": "purin",
+      "attached_prefix": "purino",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "purinoid_9",
+        "heteroatoms": [
+          {"locant": "1", "symbol": "N"}, {"locant": "3", "symbol": "N"},
+          {"locant": "7", "symbol": "N"}, {"locant": "9", "symbol": "N"}
+        ]
+      }
+    },
+    {
+      "name": "indazole",
+      "pin": true,
+      "priority": 17,
+      "aliases": ["1H-indazole", "2H-indazole"],
+      "default_indicated_h": ["1"],
+      "derivative_stem": "indazol",
+      "attached_prefix": "indazolo",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "indazoloid_9",
+        "heteroatoms": [{"locant": "1", "symbol": "N"}, {"locant": "2", "symbol": "N"}]
+      }
+    },
+    {
+      "name": "xanthene",
+      "pin": true,
+      "priority": 17,
+      "aliases": ["9H-xanthene"],
+      "default_indicated_h": ["9"],
+      "derivative_stem": "xanthen",
+      "attached_prefix": "xantheno",
+      "template": {
+        "enabled": false,
+        "derivative_production_enabled": true,
+        "base_template": "acridinoid_14",
+        "mancude_double_bonds": 6,
+        "heteroatoms": [{"locant": "10", "symbol": "O"}],
+        "atom_overrides": [{"locant": "9", "aromatic": false}, {"locant": "10", "aromatic": false}]
+      }
+    },
+    {
       "name": "1H-indole",
       "pin": true,
       "priority": 18,

--- a/src/openclatura/data/retained_fused_graph_templates.json
+++ b/src/openclatura/data/retained_fused_graph_templates.json
@@ -1,5 +1,103 @@
 {
   "bluebook_rule": "P-25 retained fused parent templates. Rows are locant-keyed graph templates, not SMILES/SMARTS keys.",
+  "base_templates": {
+    "naphthalenoid_10": {
+      "locants": ["1", "2", "3", "4", "4a", "5", "6", "7", "8", "8a"],
+      "bonds": [
+        {"locants": ["1", "2"]}, {"locants": ["2", "3"]},
+        {"locants": ["3", "4"]}, {"locants": ["4", "4a"]},
+        {"locants": ["4a", "8a"], "bond_class": "fusion"}, {"locants": ["8a", "1"]},
+        {"locants": ["4a", "5"]}, {"locants": ["5", "6"]},
+        {"locants": ["6", "7"]}, {"locants": ["7", "8"]}, {"locants": ["8", "8a"]}
+      ],
+      "rings": [["1", "2", "3", "4", "4a", "8a"], ["4a", "5", "6", "7", "8", "8a"]],
+      "fusion_atoms": ["4a", "8a"],
+      "peripheral_atoms": ["1", "2", "3", "4", "4a", "5", "6", "7", "8", "8a"]
+    },
+    "linear_tricyclic_14": {
+      "locants": ["1", "2", "3", "4", "4a", "5", "5a", "6", "7", "8", "9", "9a", "10", "10a"],
+      "bonds": [
+        {"locants": ["1", "2"]}, {"locants": ["2", "3"]}, {"locants": ["3", "4"]},
+        {"locants": ["4", "4a"]}, {"locants": ["4a", "5"]}, {"locants": ["5", "5a"]},
+        {"locants": ["5a", "6"]}, {"locants": ["6", "7"]}, {"locants": ["7", "8"]},
+        {"locants": ["8", "9"]}, {"locants": ["9", "9a"]},
+        {"locants": ["5a", "9a"], "bond_class": "fusion"}, {"locants": ["9a", "10"]},
+        {"locants": ["10", "10a"]}, {"locants": ["10a", "1"]},
+        {"locants": ["4a", "10a"], "bond_class": "fusion"}
+      ],
+      "fusion_atoms": ["4a", "5a", "9a", "10a"],
+      "peripheral_atoms": ["1", "2", "3", "4", "4a", "5", "5a", "6", "7", "8", "9", "9a", "10", "10a"],
+      "mancude_double_bonds": 7
+    },
+    "phenanthrenoid_14": {
+      "locants": ["1", "2", "3", "4", "4a", "5", "6", "6a", "7", "8", "9", "10", "10a", "10b"],
+      "bonds": [
+        {"locants": ["1", "2"]}, {"locants": ["2", "3"]}, {"locants": ["3", "4"]},
+        {"locants": ["4", "4a"]}, {"locants": ["4a", "5"]}, {"locants": ["5", "6"]},
+        {"locants": ["6", "6a"]}, {"locants": ["6a", "7"]}, {"locants": ["7", "8"]},
+        {"locants": ["8", "9"]}, {"locants": ["9", "10"]}, {"locants": ["10", "10a"]},
+        {"locants": ["6a", "10a"], "bond_class": "fusion"}, {"locants": ["10a", "10b"]},
+        {"locants": ["10b", "1"]}, {"locants": ["4a", "10b"], "bond_class": "fusion"}
+      ],
+      "fusion_atoms": ["4a", "6a", "10a", "10b"],
+      "peripheral_atoms": ["1", "2", "3", "4", "4a", "5", "6", "6a", "7", "8", "9", "10", "10a", "10b"],
+      "mancude_double_bonds": 7
+    },
+    "acridinoid_14": {
+      "locants": ["1", "2", "3", "4", "4a", "10", "10a", "5", "6", "7", "8", "8a", "9", "9a"],
+      "bonds": [
+        {"locants": ["1", "2"]}, {"locants": ["2", "3"]}, {"locants": ["3", "4"]},
+        {"locants": ["4", "4a"]}, {"locants": ["4a", "10"]}, {"locants": ["10", "10a"]},
+        {"locants": ["10a", "5"]}, {"locants": ["5", "6"]}, {"locants": ["6", "7"]},
+        {"locants": ["7", "8"]}, {"locants": ["8", "8a"]},
+        {"locants": ["10a", "8a"], "bond_class": "fusion"}, {"locants": ["8a", "9"]},
+        {"locants": ["9", "9a"]}, {"locants": ["9a", "1"]},
+        {"locants": ["4a", "9a"], "bond_class": "fusion"}
+      ],
+      "fusion_atoms": ["4a", "10a", "8a", "9a"],
+      "peripheral_atoms": ["1", "2", "3", "4", "4a", "10", "10a", "5", "6", "7", "8", "8a", "9", "9a"],
+      "mancude_double_bonds": 7
+    },
+    "carbazoloid_13": {
+      "locants": ["1", "2", "3", "4", "4a", "4b", "5", "6", "7", "8", "8a", "9", "9a"],
+      "bonds": [
+        {"locants": ["1", "2"]}, {"locants": ["2", "3"]}, {"locants": ["3", "4"]},
+        {"locants": ["4", "4a"]}, {"locants": ["4a", "4b"], "bond_class": "fusion"},
+        {"locants": ["4b", "5"]}, {"locants": ["5", "6"]}, {"locants": ["6", "7"]},
+        {"locants": ["7", "8"]}, {"locants": ["8", "8a"]},
+        {"locants": ["4b", "8a"], "bond_class": "fusion"}, {"locants": ["8a", "9"]},
+        {"locants": ["9", "9a"]}, {"locants": ["9a", "1"]},
+        {"locants": ["4a", "9a"], "bond_class": "fusion"}
+      ],
+      "fusion_atoms": ["4a", "4b", "8a", "9a"],
+      "peripheral_atoms": ["1", "2", "3", "4", "4a", "4b", "5", "6", "7", "8", "8a", "9", "9a"],
+      "mancude_double_bonds": 6
+    },
+    "purinoid_9": {
+      "locants": ["1", "2", "3", "4", "9", "8", "7", "5", "6"],
+      "bonds": [
+        {"locants": ["1", "2"]}, {"locants": ["2", "3"]}, {"locants": ["3", "4"]},
+        {"locants": ["4", "9"]}, {"locants": ["9", "8"]}, {"locants": ["8", "7"]},
+        {"locants": ["7", "5"]}, {"locants": ["5", "4"], "bond_class": "fusion"},
+        {"locants": ["5", "6"]}, {"locants": ["6", "1"]}
+      ],
+      "fusion_atoms": ["4", "5"],
+      "peripheral_atoms": ["1", "2", "3", "4", "9", "8", "7", "5", "6"],
+      "mancude_double_bonds": 4
+    },
+    "indazoloid_9": {
+      "locants": ["1", "2", "3", "3a", "4", "5", "6", "7", "7a"],
+      "bonds": [
+        {"locants": ["1", "2"]}, {"locants": ["2", "3"]}, {"locants": ["3", "3a"]},
+        {"locants": ["3a", "4"]}, {"locants": ["4", "5"]}, {"locants": ["5", "6"]},
+        {"locants": ["6", "7"]}, {"locants": ["7", "7a"]}, {"locants": ["7a", "1"]},
+        {"locants": ["3a", "7a"], "bond_class": "fusion"}
+      ],
+      "fusion_atoms": ["3a", "7a"],
+      "peripheral_atoms": ["1", "2", "3", "3a", "4", "5", "6", "7", "7a"],
+      "mancude_double_bonds": 4
+    }
+  },
   "pending_parents": [
     {"name": "pleiadene", "pin": false, "priority": 100, "attached_prefix": "pleiadeno"},
     {"name": "phenanthridine", "pin": true, "priority": 5},

--- a/src/openclatura/name_bindings.py
+++ b/src/openclatura/name_bindings.py
@@ -4,6 +4,7 @@ import re
 
 from .assembly_parent import parent_stem_and_terminal
 from .assembly_parts import AssemblyParts, NameAtomBinding, NameTokenBinding
+from .formatting import format_multiplier
 from .nomenclature import RULES
 from .principal_suffixes import render_principal_suffix
 from .rules import bonds, stems
@@ -36,13 +37,13 @@ def refresh_name_atom_bindings(parts: AssemblyParts) -> list[NameAtomBinding]:
             )
         )
     for operation in parts.hydro_operations:
-        if operation.operation_kind != "indicated_hydrogen":
+        if operation.operation_kind not in {"indicated_hydrogen", "additive_hydrogen"}:
             continue
         bindings.append(
             NameAtomBinding(
                 stage="hydro",
                 role=operation.operation_kind,
-                term="indicated hydrogen",
+                term="indicated hydrogen" if operation.operation_kind == "indicated_hydrogen" else "hydro",
                 atom_ids=set(operation.atom_ids),
                 locants=tuple(str(locant) for locant in operation.locants),
                 emitted_tokens=_hydro_operation_tokens(operation),
@@ -479,9 +480,10 @@ def _hydro_operation_tokens(operation) -> tuple[NameTokenBinding, ...]:
                 locants=locants,
             )
         )
+    hydro_text = "H" if operation.operation_kind == "indicated_hydrogen" else format_multiplier("hydro", len(locants))
     tokens.append(
         NameTokenBinding(
-            text="H",
+            text=hydro_text,
             token_kind="hydro",
             source="default_binding",
             grammar_role=operation.operation_kind,

--- a/src/openclatura/naming_context.py
+++ b/src/openclatura/naming_context.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 
+from .assembly_parts import RetainedParentMetadata
 from .molecule import DecisionTrace, Molecule
 from .parent_selection import ParentSelection
 from .perception import PerceivedGroup
@@ -98,6 +99,7 @@ class ParentPlan:
     selection: ParentSelection
     retained_name: str | None = None
     locant_maps: list[dict[int, str]] | None = None
+    retained_parent_metadata: RetainedParentMetadata | None = None
     principal: PrincipalGroupSelection | None = None
 
 
@@ -149,6 +151,7 @@ class ComponentNamingState:
     parent_selection: ParentSelection | None = None
     retained_name: str | None = None
     locant_maps: list[dict[int, str]] | None = None
+    retained_parent_metadata: RetainedParentMetadata | None = None
     principal_involved_atoms: set[int] = field(default_factory=set)
     base_exclude: set[int] = field(default_factory=set)
     sub_exclude: set[int] = field(default_factory=set)

--- a/src/openclatura/parent_pipeline.py
+++ b/src/openclatura/parent_pipeline.py
@@ -1,12 +1,13 @@
 """Shared parent planning steps for component and subgraph naming."""
 
-from .assembly_parts import AssemblyParts, NameAtomBinding, ParentChargeItem
+from .assembly_parts import AssemblyParts, NameAtomBinding, ParentChargeItem, RetainedParentMetadata
 from .molecule import Molecule
 from .name_bindings import ensure_name_atom_binding_tokens
 from .namer_config import RETAINED_RING_ELEMENTS
 from .naming_context import NamingIntent, ParentAssemblyPlan
 from .numbering import choose_parent_numbering
 from .parent_selection import ParentSelection
+from .retained_fused_templates import retained_parent_metadata as graph_retained_parent_metadata
 from .ring_renderer import is_von_baeyer_descriptor
 from .rules import retained
 from .small_ring_stereo import scoped_small_ring_stereo_features
@@ -39,6 +40,7 @@ def build_parent_assembly_plan(
     substituent_mapping: dict[int, list],
     locant_maps,
     retained_name: str | None,
+    retained_parent_metadata: RetainedParentMetadata | None = None,
 ) -> ParentAssemblyPlan:
     """Number a selected parent and create base assembly parts."""
 
@@ -73,6 +75,7 @@ def build_parent_assembly_plan(
         retained_name,
         selection,
         intent,
+        retained_parent_metadata,
     )
     return ParentAssemblyPlan(numbered_path=numbered_path, locant_map=locant_map, get_loc=get_loc, parts=parts)
 
@@ -88,9 +91,12 @@ def build_parent_parts(
     retained_name: str | None,
     selection: ParentSelection,
     intent: NamingIntent,
+    retained_parent_metadata: RetainedParentMetadata | None = None,
 ) -> AssemblyParts:
     """Create shared parent assembly parts for a naming intent."""
 
+    if retained_parent_metadata is None and retained_name is not None:
+        retained_parent_metadata = graph_retained_parent_metadata(retained_name)
     assembly_overrides = {}
     if intent.is_substituent:
         if intent.root_atom is None:
@@ -115,6 +121,7 @@ def build_parent_parts(
         spiro_xy=(selection.xyz[0], selection.xyz[1]) if selection.is_spiro else (0, 0),
         polycycle_descriptor=selection.polycycle_descriptor,
         retained_name=retained_name,
+        retained_parent_metadata=retained_parent_metadata,
         parent_atom_ids=set(numbered_path),
         parent_bond_ids=bond_ids_within(mol, set(numbered_path)),
         **assembly_overrides,

--- a/src/openclatura/retained_fused_production.py
+++ b/src/openclatura/retained_fused_production.py
@@ -9,7 +9,9 @@ OPSIN-verified grammar classes.
 
 from __future__ import annotations
 
-from .assembly_parts import SubstituentItem
+from dataclasses import dataclass
+
+from .assembly_parts import RetainedParentMetadata, SubstituentItem
 from .grammar_snapshot_data import retained_fused_derivative_gate
 from .molecule import Molecule
 from .perception import PerceivedGroup
@@ -22,6 +24,15 @@ ALLOWED_GROUP_KEYS = _DERIVATIVE_GATE.allowed_group_keys
 ALLOWED_SUBSTITUENT_NAMES = _DERIVATIVE_GATE.allowed_substituent_names
 
 
+@dataclass(frozen=True)
+class ProductionRetainedFusedParent:
+    """A matched retained parent and the template metadata needed downstream."""
+
+    name: str
+    locant_maps: list[dict[int, str]]
+    metadata: RetainedParentMetadata
+
+
 def production_retained_fused_parent(
     mol: Molecule,
     parent_path: list[int],
@@ -29,7 +40,7 @@ def production_retained_fused_parent(
     perceived_groups: list[PerceivedGroup],
     principal_key: str | None,
     substituent_mapping: dict[int, list[SubstituentItem]],
-) -> tuple[str, list[dict[int, str]]] | None:
+) -> ProductionRetainedFusedParent | None:
     """Return retained fused parent data only for verified derivative classes."""
 
     parent_atoms = set(parent_path)
@@ -73,7 +84,16 @@ def production_retained_fused_parent(
     ]
     if not maps:
         return None
-    return parent_name, maps
+    template = matches[0].template
+    return ProductionRetainedFusedParent(
+        name=parent_name,
+        locant_maps=maps,
+        metadata=RetainedParentMetadata(
+            default_indicated_h=template.default_indicated_h,
+            fusion_locants=template.fusion_atoms,
+            derivative_stem=template.derivative_stem,
+        ),
+    )
 
 
 def _neutral_component(mol: Molecule, atoms: set[int]) -> bool:

--- a/src/openclatura/retained_fused_production.py
+++ b/src/openclatura/retained_fused_production.py
@@ -13,7 +13,7 @@ from .assembly_parts import SubstituentItem
 from .grammar_snapshot_data import retained_fused_derivative_gate
 from .molecule import Molecule
 from .perception import PerceivedGroup
-from .retained_fused_templates import match_retained_fused_templates
+from .retained_fused_templates import RetainedFusedTemplateMatch, match_retained_fused_templates
 
 _DERIVATIVE_GATE = retained_fused_derivative_gate()
 PRODUCTION_RETAINED_FUSED_PARENTS = _DERIVATIVE_GATE.production_parent_names
@@ -51,8 +51,15 @@ def production_retained_fused_parent(
 
     matches = [
         match
-        for match in match_retained_fused_templates(mol, parent_atoms, include_disabled=True)
-        if match.template.name in PRODUCTION_RETAINED_FUSED_PARENTS and match.template.derivative_production_enabled
+        for match in match_retained_fused_templates(
+            mol,
+            parent_atoms,
+            include_disabled=True,
+            allow_nonaromatic=principal_key == "ketone",
+        )
+        if match.template.name in PRODUCTION_RETAINED_FUSED_PARENTS
+        and match.template.derivative_production_enabled
+        and (principal_key != "ketone" or _has_mancude_unsaturation(mol, parent_atoms, match))
     ]
     if not matches:
         return None
@@ -71,6 +78,33 @@ def production_retained_fused_parent(
 
 def _neutral_component(mol: Molecule, atoms: set[int]) -> bool:
     return all(mol.atoms[atom].charge == 0 for atom in atoms)
+
+
+def _has_mancude_unsaturation(
+    mol: Molecule,
+    parent_atoms: set[int],
+    match: RetainedFusedTemplateMatch,
+) -> bool:
+    """Reject hydro derivatives that merely share an oxo-parent topology."""
+
+    expected_double_bonds = match.template.mancude_double_bonds
+    if expected_double_bonds is None:
+        return False
+    nonaromatic_parent_carbonyls = sum(
+        atom_template.symbol == "C"
+        and not atom_template.aromatic
+        and any(
+            neighbor not in parent_atoms
+            and mol.atoms[neighbor].symbol == "O"
+            and mol.get_bond(match.locant_to_atom[atom_template.locant], neighbor).order == 2
+            for neighbor in mol.get_neighbors(match.locant_to_atom[atom_template.locant])
+        )
+        for atom_template in match.template.atoms
+    )
+    actual_double_bonds = sum(
+        bond.order == 2 and (bond.u in parent_atoms or bond.v in parent_atoms) for bond in mol.bonds.values()
+    )
+    return actual_double_bonds >= expected_double_bonds + nonaromatic_parent_carbonyls
 
 
 def _neutral_retained_parent(mol: Molecule, atoms: set[int]) -> bool:

--- a/src/openclatura/retained_fused_production.py
+++ b/src/openclatura/retained_fused_production.py
@@ -116,7 +116,8 @@ def _has_mancude_unsaturation(
         and any(
             neighbor not in parent_atoms
             and mol.atoms[neighbor].symbol == "O"
-            and mol.get_bond(match.locant_to_atom[atom_template.locant], neighbor).order == 2
+            and (bond := mol.get_bond(match.locant_to_atom[atom_template.locant], neighbor)) is not None
+            and bond.order == 2
             for neighbor in mol.get_neighbors(match.locant_to_atom[atom_template.locant])
         )
         for atom_template in match.template.atoms

--- a/src/openclatura/retained_fused_templates.py
+++ b/src/openclatura/retained_fused_templates.py
@@ -40,6 +40,169 @@ NAPHTHALENOID_10_TEMPLATE = {
 }
 
 
+def _shared_graph_template(
+    locants: list[str],
+    bonds: list[tuple[str, str]],
+    fusion_atoms: list[str],
+    mancude_double_bonds: int,
+) -> dict:
+    return {
+        "locants": locants,
+        "bonds": [
+            {
+                "locants": [left, right],
+                **({"bond_class": "fusion"} if left in fusion_atoms and right in fusion_atoms else {}),
+            }
+            for left, right in bonds
+        ],
+        "fusion_atoms": fusion_atoms,
+        "peripheral_atoms": locants,
+        "mancude_double_bonds": mancude_double_bonds,
+    }
+
+
+LINEAR_TRICYCLIC_14_TEMPLATE = _shared_graph_template(
+    ["1", "2", "3", "4", "4a", "5", "5a", "6", "7", "8", "9", "9a", "10", "10a"],
+    [
+        ("1", "2"),
+        ("2", "3"),
+        ("3", "4"),
+        ("4", "4a"),
+        ("4a", "5"),
+        ("5", "5a"),
+        ("5a", "6"),
+        ("6", "7"),
+        ("7", "8"),
+        ("8", "9"),
+        ("9", "9a"),
+        ("5a", "9a"),
+        ("9a", "10"),
+        ("10", "10a"),
+        ("10a", "1"),
+        ("4a", "10a"),
+    ],
+    ["4a", "5a", "9a", "10a"],
+    7,
+)
+
+PHENANTHRENOID_14_TEMPLATE = _shared_graph_template(
+    ["1", "2", "3", "4", "4a", "5", "6", "6a", "7", "8", "9", "10", "10a", "10b"],
+    [
+        ("1", "2"),
+        ("2", "3"),
+        ("3", "4"),
+        ("4", "4a"),
+        ("4a", "5"),
+        ("5", "6"),
+        ("6", "6a"),
+        ("6a", "7"),
+        ("7", "8"),
+        ("8", "9"),
+        ("9", "10"),
+        ("10", "10a"),
+        ("6a", "10a"),
+        ("10a", "10b"),
+        ("10b", "1"),
+        ("4a", "10b"),
+    ],
+    ["4a", "6a", "10a", "10b"],
+    7,
+)
+
+ACRIDINOID_14_TEMPLATE = _shared_graph_template(
+    ["1", "2", "3", "4", "4a", "10", "10a", "5", "6", "7", "8", "8a", "9", "9a"],
+    [
+        ("1", "2"),
+        ("2", "3"),
+        ("3", "4"),
+        ("4", "4a"),
+        ("4a", "10"),
+        ("10", "10a"),
+        ("10a", "5"),
+        ("5", "6"),
+        ("6", "7"),
+        ("7", "8"),
+        ("8", "8a"),
+        ("10a", "8a"),
+        ("8a", "9"),
+        ("9", "9a"),
+        ("9a", "1"),
+        ("4a", "9a"),
+    ],
+    ["4a", "10a", "8a", "9a"],
+    7,
+)
+
+CARBAZOLOID_13_TEMPLATE = _shared_graph_template(
+    ["1", "2", "3", "4", "4a", "4b", "5", "6", "7", "8", "8a", "9", "9a"],
+    [
+        ("1", "2"),
+        ("2", "3"),
+        ("3", "4"),
+        ("4", "4a"),
+        ("4a", "4b"),
+        ("4b", "5"),
+        ("5", "6"),
+        ("6", "7"),
+        ("7", "8"),
+        ("8", "8a"),
+        ("4b", "8a"),
+        ("8a", "9"),
+        ("9", "9a"),
+        ("9a", "1"),
+        ("4a", "9a"),
+    ],
+    ["4a", "4b", "8a", "9a"],
+    6,
+)
+
+PURINOID_9_TEMPLATE = _shared_graph_template(
+    ["1", "2", "3", "4", "9", "8", "7", "5", "6"],
+    [
+        ("1", "2"),
+        ("2", "3"),
+        ("3", "4"),
+        ("4", "9"),
+        ("9", "8"),
+        ("8", "7"),
+        ("7", "5"),
+        ("5", "4"),
+        ("5", "6"),
+        ("6", "1"),
+    ],
+    ["4", "5"],
+    4,
+)
+
+INDAZOLOID_9_TEMPLATE = _shared_graph_template(
+    ["1", "2", "3", "3a", "4", "5", "6", "7", "7a"],
+    [
+        ("1", "2"),
+        ("2", "3"),
+        ("3", "3a"),
+        ("3a", "4"),
+        ("4", "5"),
+        ("5", "6"),
+        ("6", "7"),
+        ("7", "7a"),
+        ("7a", "1"),
+        ("3a", "7a"),
+    ],
+    ["3a", "7a"],
+    4,
+)
+
+RETAINED_FUSED_BASE_TEMPLATES = {
+    "naphthalenoid_10": NAPHTHALENOID_10_TEMPLATE,
+    "linear_tricyclic_14": LINEAR_TRICYCLIC_14_TEMPLATE,
+    "phenanthrenoid_14": PHENANTHRENOID_14_TEMPLATE,
+    "acridinoid_14": ACRIDINOID_14_TEMPLATE,
+    "carbazoloid_13": CARBAZOLOID_13_TEMPLATE,
+    "purinoid_9": PURINOID_9_TEMPLATE,
+    "indazoloid_9": INDAZOLOID_9_TEMPLATE,
+}
+
+
 @dataclass(frozen=True)
 class RetainedFusedAtomTemplate:
     locant: str
@@ -77,6 +240,7 @@ class RetainedFusedGraphTemplate:
     aromatic_equivalence_policy: str = "neutral_kekule_equivalent"
     enabled: bool = False
     derivative_production_enabled: bool = False
+    mancude_double_bonds: int | None = None
 
     @property
     def atom_by_locant(self) -> dict[str, RetainedFusedAtomTemplate]:
@@ -127,6 +291,8 @@ def match_retained_fused_template(
     mol: Molecule,
     atom_indices: set[int] | list[int] | tuple[int, ...],
     template: RetainedFusedGraphTemplate,
+    *,
+    allow_nonaromatic: bool = False,
 ) -> RetainedFusedTemplateMatch | None:
     """Match one retained fused graph template to a molecule atom set.
 
@@ -160,7 +326,7 @@ def match_retained_fused_template(
         locant: [
             atom_idx
             for atom_idx in atom_set
-            if _atom_matches_template(mol, atom_idx, atom_by_locant[locant])
+            if _atom_matches_template(mol, atom_idx, atom_by_locant[locant], allow_nonaromatic=allow_nonaromatic)
             and molecule_degrees[atom_idx] == template_degrees[locant]
         ]
         for locant in template.locants
@@ -185,6 +351,8 @@ def _match_all_retained_fused_template(
     mol: Molecule,
     atom_indices: set[int] | list[int] | tuple[int, ...],
     template: RetainedFusedGraphTemplate,
+    *,
+    allow_nonaromatic: bool = False,
 ) -> list[RetainedFusedTemplateMatch]:
     validate_retained_fused_template(template)
     atom_set = set(atom_indices)
@@ -209,7 +377,7 @@ def _match_all_retained_fused_template(
         locant: [
             atom_idx
             for atom_idx in atom_set
-            if _atom_matches_template(mol, atom_idx, atom_by_locant[locant])
+            if _atom_matches_template(mol, atom_idx, atom_by_locant[locant], allow_nonaromatic=allow_nonaromatic)
             and molecule_degrees[atom_idx] == template_degrees[locant]
         ]
         for locant in template.locants
@@ -243,13 +411,19 @@ def match_retained_fused_templates(
     atom_indices: set[int] | list[int] | tuple[int, ...],
     *,
     include_disabled: bool = False,
+    allow_nonaromatic: bool = False,
 ) -> list[RetainedFusedTemplateMatch]:
     """Return retained fused template matches ranked by retained priority."""
 
     matches = [
         match
         for template in retained_fused_graph_templates(include_disabled=include_disabled)
-        for match in _match_all_retained_fused_template(mol, atom_indices, template)
+        for match in _match_all_retained_fused_template(
+            mol,
+            atom_indices,
+            template,
+            allow_nonaromatic=allow_nonaromatic,
+        )
     ]
     return sorted(
         matches,
@@ -324,6 +498,11 @@ def retained_fused_template_from_data(row: dict[str, Any]) -> RetainedFusedGraph
         aromatic_equivalence_policy=str(template_data.get("aromatic_equivalence_policy", "neutral_kekule_equivalent")),
         enabled=bool(template_data.get("enabled", row.get("template_enabled", False))),
         derivative_production_enabled=bool(template_data.get("derivative_production_enabled", False)),
+        mancude_double_bonds=(
+            int(template_data["mancude_double_bonds"])
+            if template_data.get("mancude_double_bonds") is not None
+            else None
+        ),
     )
     validate_retained_fused_template(template)
     return template
@@ -334,10 +513,11 @@ def _expand_template_data(template_data: dict[str, Any]) -> dict[str, Any]:
     if base_name is None:
         expanded = dict(template_data)
         return _expand_locant_atom_shorthand(expanded)
-    if base_name != "naphthalenoid_10":
+    base_template = RETAINED_FUSED_BASE_TEMPLATES.get(str(base_name))
+    if base_template is None:
         raise ValueError(f"Unknown retained fused base template {base_name!r}.")
 
-    expanded = {**NAPHTHALENOID_10_TEMPLATE, **template_data}
+    expanded = {**base_template, **template_data}
     return _expand_locant_atom_shorthand(expanded)
 
 
@@ -461,17 +641,39 @@ def _template_neighbors(template: RetainedFusedGraphTemplate) -> dict[str, set[s
     return neighbors
 
 
-def _atom_matches_template(mol: Molecule, atom_idx: int, atom_template: RetainedFusedAtomTemplate) -> bool:
+def _atom_matches_template(
+    mol: Molecule,
+    atom_idx: int,
+    atom_template: RetainedFusedAtomTemplate,
+    *,
+    allow_nonaromatic: bool = False,
+) -> bool:
     atom = mol.atoms[atom_idx]
     if atom.symbol != atom_template.symbol:
         return False
     if atom.charge != atom_template.charge:
         return False
-    if atom_template.aromatic and not atom.is_aromatic:
+    if (
+        atom_template.aromatic
+        and not atom.is_aromatic
+        and not allow_nonaromatic
+        and not _is_retained_oxo_site(mol, atom_idx)
+    ):
         return False
     if atom_template.default_h and atom.explicit_h_count + atom.total_h_count <= 0:
         return False
     return True
+
+
+def _is_retained_oxo_site(mol: Molecule, atom_idx: int) -> bool:
+    """Return whether aromaticity was lost only because this carbon bears =O."""
+
+    if mol.atoms[atom_idx].symbol != "C":
+        return False
+    return any(
+        mol.atoms[neighbor].symbol == "O" and (bond := mol.get_bond(atom_idx, neighbor)) is not None and bond.order == 2
+        for neighbor in mol.get_neighbors(atom_idx)
+    )
 
 
 def _match_locants_backtracking(

--- a/src/openclatura/retained_fused_templates.py
+++ b/src/openclatura/retained_fused_templates.py
@@ -8,199 +8,30 @@ keyed by locants and graph structure, not by SMILES or SMARTS strings.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cache, lru_cache
 from typing import Any
 
+from .assembly_parts import RetainedParentMetadata
 from .molecule import Molecule
 from .naming_data import load_json_table
 from .nomenclature import RULES
 
 ALLOWED_BOND_CLASSES = {"single", "double", "aromatic", "mancude", "fusion"}
 
-NAPHTHALENOID_10_TEMPLATE = {
-    "locants": ["1", "2", "3", "4", "4a", "5", "6", "7", "8", "8a"],
-    "bonds": [
-        {"locants": ["1", "2"]},
-        {"locants": ["2", "3"]},
-        {"locants": ["3", "4"]},
-        {"locants": ["4", "4a"]},
-        {"locants": ["4a", "8a"], "bond_class": "fusion"},
-        {"locants": ["8a", "1"]},
-        {"locants": ["4a", "5"]},
-        {"locants": ["5", "6"]},
-        {"locants": ["6", "7"]},
-        {"locants": ["7", "8"]},
-        {"locants": ["8", "8a"]},
-    ],
-    "rings": [
-        ["1", "2", "3", "4", "4a", "8a"],
-        ["4a", "5", "6", "7", "8", "8a"],
-    ],
-    "fusion_atoms": ["4a", "8a"],
-    "peripheral_atoms": ["1", "2", "3", "4", "4a", "5", "6", "7", "8", "8a"],
-}
 
+@lru_cache(maxsize=1)
+def retained_fused_base_templates() -> dict[str, dict[str, Any]]:
+    """Return the shared retained-fused skeletons owned by the template table."""
 
-def _shared_graph_template(
-    locants: list[str],
-    bonds: list[tuple[str, str]],
-    fusion_atoms: list[str],
-    mancude_double_bonds: int,
-) -> dict:
-    return {
-        "locants": locants,
-        "bonds": [
-            {
-                "locants": [left, right],
-                **({"bond_class": "fusion"} if left in fusion_atoms and right in fusion_atoms else {}),
-            }
-            for left, right in bonds
-        ],
-        "fusion_atoms": fusion_atoms,
-        "peripheral_atoms": locants,
-        "mancude_double_bonds": mancude_double_bonds,
-    }
-
-
-LINEAR_TRICYCLIC_14_TEMPLATE = _shared_graph_template(
-    ["1", "2", "3", "4", "4a", "5", "5a", "6", "7", "8", "9", "9a", "10", "10a"],
-    [
-        ("1", "2"),
-        ("2", "3"),
-        ("3", "4"),
-        ("4", "4a"),
-        ("4a", "5"),
-        ("5", "5a"),
-        ("5a", "6"),
-        ("6", "7"),
-        ("7", "8"),
-        ("8", "9"),
-        ("9", "9a"),
-        ("5a", "9a"),
-        ("9a", "10"),
-        ("10", "10a"),
-        ("10a", "1"),
-        ("4a", "10a"),
-    ],
-    ["4a", "5a", "9a", "10a"],
-    7,
-)
-
-PHENANTHRENOID_14_TEMPLATE = _shared_graph_template(
-    ["1", "2", "3", "4", "4a", "5", "6", "6a", "7", "8", "9", "10", "10a", "10b"],
-    [
-        ("1", "2"),
-        ("2", "3"),
-        ("3", "4"),
-        ("4", "4a"),
-        ("4a", "5"),
-        ("5", "6"),
-        ("6", "6a"),
-        ("6a", "7"),
-        ("7", "8"),
-        ("8", "9"),
-        ("9", "10"),
-        ("10", "10a"),
-        ("6a", "10a"),
-        ("10a", "10b"),
-        ("10b", "1"),
-        ("4a", "10b"),
-    ],
-    ["4a", "6a", "10a", "10b"],
-    7,
-)
-
-ACRIDINOID_14_TEMPLATE = _shared_graph_template(
-    ["1", "2", "3", "4", "4a", "10", "10a", "5", "6", "7", "8", "8a", "9", "9a"],
-    [
-        ("1", "2"),
-        ("2", "3"),
-        ("3", "4"),
-        ("4", "4a"),
-        ("4a", "10"),
-        ("10", "10a"),
-        ("10a", "5"),
-        ("5", "6"),
-        ("6", "7"),
-        ("7", "8"),
-        ("8", "8a"),
-        ("10a", "8a"),
-        ("8a", "9"),
-        ("9", "9a"),
-        ("9a", "1"),
-        ("4a", "9a"),
-    ],
-    ["4a", "10a", "8a", "9a"],
-    7,
-)
-
-CARBAZOLOID_13_TEMPLATE = _shared_graph_template(
-    ["1", "2", "3", "4", "4a", "4b", "5", "6", "7", "8", "8a", "9", "9a"],
-    [
-        ("1", "2"),
-        ("2", "3"),
-        ("3", "4"),
-        ("4", "4a"),
-        ("4a", "4b"),
-        ("4b", "5"),
-        ("5", "6"),
-        ("6", "7"),
-        ("7", "8"),
-        ("8", "8a"),
-        ("4b", "8a"),
-        ("8a", "9"),
-        ("9", "9a"),
-        ("9a", "1"),
-        ("4a", "9a"),
-    ],
-    ["4a", "4b", "8a", "9a"],
-    6,
-)
-
-PURINOID_9_TEMPLATE = _shared_graph_template(
-    ["1", "2", "3", "4", "9", "8", "7", "5", "6"],
-    [
-        ("1", "2"),
-        ("2", "3"),
-        ("3", "4"),
-        ("4", "9"),
-        ("9", "8"),
-        ("8", "7"),
-        ("7", "5"),
-        ("5", "4"),
-        ("5", "6"),
-        ("6", "1"),
-    ],
-    ["4", "5"],
-    4,
-)
-
-INDAZOLOID_9_TEMPLATE = _shared_graph_template(
-    ["1", "2", "3", "3a", "4", "5", "6", "7", "7a"],
-    [
-        ("1", "2"),
-        ("2", "3"),
-        ("3", "3a"),
-        ("3a", "4"),
-        ("4", "5"),
-        ("5", "6"),
-        ("6", "7"),
-        ("7", "7a"),
-        ("7a", "1"),
-        ("3a", "7a"),
-    ],
-    ["3a", "7a"],
-    4,
-)
-
-RETAINED_FUSED_BASE_TEMPLATES = {
-    "naphthalenoid_10": NAPHTHALENOID_10_TEMPLATE,
-    "linear_tricyclic_14": LINEAR_TRICYCLIC_14_TEMPLATE,
-    "phenanthrenoid_14": PHENANTHRENOID_14_TEMPLATE,
-    "acridinoid_14": ACRIDINOID_14_TEMPLATE,
-    "carbazoloid_13": CARBAZOLOID_13_TEMPLATE,
-    "purinoid_9": PURINOID_9_TEMPLATE,
-    "indazoloid_9": INDAZOLOID_9_TEMPLATE,
-}
+    raw_templates = load_json_table("retained_fused_graph_templates.json").get("base_templates", {})
+    if not isinstance(raw_templates, dict):
+        raise ValueError("retained fused base_templates must be a mapping")
+    templates: dict[str, dict[str, Any]] = {}
+    for name, template in raw_templates.items():
+        if not isinstance(template, dict):
+            raise ValueError(f"Retained fused base template {name!r} must be a mapping.")
+        templates[str(name)] = dict(template)
+    return templates
 
 
 @dataclass(frozen=True)
@@ -257,6 +88,7 @@ class RetainedFusedTemplateMatch:
     trace: tuple[str, ...] = ()
 
 
+@lru_cache(maxsize=2)
 def retained_fused_graph_templates(*, include_disabled: bool = False) -> tuple[RetainedFusedGraphTemplate, ...]:
     """Return graph-template retained fused parent rows from the rule registry."""
 
@@ -273,6 +105,26 @@ def retained_fused_graph_templates(*, include_disabled: bool = False) -> tuple[R
         if include_disabled or template.enabled:
             templates.append(template)
     return tuple(templates)
+
+
+@cache
+def retained_parent_metadata(parent_name: str) -> RetainedParentMetadata | None:
+    """Return graph-template metadata for a retained parent spelling."""
+
+    for template in retained_fused_graph_templates(include_disabled=True):
+        spellings = {template.name, *template.aliases}
+        spellings.update(
+            f"{locant}H-{template.name}"
+            for locant in template.default_indicated_h
+            if not template.name.startswith(f"{locant}H-")
+        )
+        if parent_name in spellings:
+            return RetainedParentMetadata(
+                default_indicated_h=template.default_indicated_h,
+                fusion_locants=template.fusion_atoms,
+                derivative_stem=template.derivative_stem,
+            )
+    return None
 
 
 def pending_retained_fused_parent_names() -> tuple[str, ...]:
@@ -513,7 +365,7 @@ def _expand_template_data(template_data: dict[str, Any]) -> dict[str, Any]:
     if base_name is None:
         expanded = dict(template_data)
         return _expand_locant_atom_shorthand(expanded)
-    base_template = RETAINED_FUSED_BASE_TEMPLATES.get(str(base_name))
+    base_template = retained_fused_base_templates().get(str(base_name))
     if base_template is None:
         raise ValueError(f"Unknown retained fused base template {base_name!r}.")
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -139,6 +139,7 @@ from openclatura.retained_fused_templates import (
     match_retained_fused_template,
     match_retained_fused_templates,
     pending_retained_fused_parent_names,
+    retained_fused_base_templates,
     retained_fused_graph_templates,
     retained_fused_template_from_data,
     template_molecule,
@@ -979,6 +980,17 @@ def test_indicated_hydrogen_prefix_uses_hydro_operation_binding():
         assert tokens[text]["confidence"] == "derived"
         assert tokens[text]["ownership"] == "exact"
         assert tokens[text]["binding_key"] == "hydro:indicated_hydrogen"
+
+
+def test_retained_fusion_hydride_is_a_typed_additive_hydrogen_operation():
+    analysis = analyze_smiles("NC1=NC2N=C(N)NC(=O)C2=N1")
+    assembly = next(step for step in analysis.decisions if step.decision == "assembled component name")
+    hydro_binding = next(binding for binding in assembly.data["name_atom_bindings"] if binding["stage"] == "hydro")
+
+    assert analysis.name == "2,8-diamino-1,4-dihydropurin-6-one"
+    assert hydro_binding["role"] == "additive_hydrogen"
+    assert hydro_binding["term"] == "hydro"
+    assert hydro_binding["locants"] == ["1", "4"]
 
 
 def test_n_substituent_locant_survives_retained_suffix_postprocessing():
@@ -2946,6 +2958,14 @@ def _naphthalene_graph_template_row() -> dict:
             "numbering_policy": "retained_template",
         },
     }
+
+
+def test_retained_fused_base_skeletons_are_loaded_from_the_graph_template_table():
+    base_templates = retained_fused_base_templates()
+
+    assert {"naphthalenoid_10", "linear_tricyclic_14", "purinoid_9", "indazoloid_9"} <= set(base_templates)
+    assert base_templates["purinoid_9"]["fusion_atoms"] == ["4", "5"]
+    assert base_templates["purinoid_9"]["mancude_double_bonds"] == 4
 
 
 def test_retained_fused_graph_template_schema_validates_locant_graphs():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -1191,19 +1191,16 @@ def test_repeated_grouped_locants_use_following_structural_scope():
     assert by_start[("aza", text.index("aza"))].atom_ids == frozenset({1, 3, 8, 11})
 
 
-def test_parenthesized_unsaturation_locants_bind_to_double_bond_endpoints():
+def test_caffeine_uses_the_retained_purine_dione_parent():
     analysis = analyze_smiles("CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
-    assembly = next(step for step in analysis.decisions if step.decision == "assembled component name")
-    tokens = {(token["text"], token["start"]): token for token in assembly.data["name_token_spans"]}
-    name = analysis.name
 
-    assert analysis.name == "2,4,7-trimethyl-2,4,7,9-tetraazabicyclo[4.3.0]nona-1(6),8-diene-3,5-dione"
-    assert tokens[("1", name.index("1(6)"))]["atoms"] == [4]
-    assert tokens[("1", name.index("1(6)"))]["bonds"] == [5]
-    assert tokens[("6", name.index("6),8"))]["atoms"] == [5]
-    assert tokens[("6", name.index("6),8"))]["bonds"] == [5]
-    assert tokens[("8", name.index("8-diene"))]["atoms"] == [2]
-    assert tokens[("8", name.index("8-diene"))]["bonds"] == [3]
+    assert analysis.name == "1,3,7-trimethylpurine-2,6-dione"
+
+
+def test_purinone_fusion_carbon_hydrogen_uses_a_dihydro_prefix():
+    generated = name_smiles("NC1=NC2N=C(N)NC(=O)C2=N1")
+
+    assert generated == "2,8-diamino-1,4-dihydropurin-6-one"
 
 
 def test_nested_hydroxyphenyl_propan_yl_tokens_keep_local_scopes():
@@ -3013,6 +3010,24 @@ def test_retained_fused_graph_template_data_file_validates_guarded_core_entries(
         "2H-isoindole",
         "indolizine",
         "1H-indole",
+        "phenazine",
+        "1,4-phenanthroline",
+        "1,5-phenanthroline",
+        "1,6-phenanthroline",
+        "1,7-phenanthroline",
+        "1,8-phenanthroline",
+        "1,9-phenanthroline",
+        "1,10-phenanthroline",
+        "2,7-phenanthroline",
+        "2,8-phenanthroline",
+        "3,5-phenanthroline",
+        "3,6-phenanthroline",
+        "4,5-phenanthroline",
+        "acridine",
+        "carbazole",
+        "purine",
+        "indazole",
+        "xanthene",
     } <= set(by_name)
     enabled_names = {template.name for template in retained_fused_graph_templates()}
     assert not (
@@ -3057,6 +3072,24 @@ def test_retained_fused_graph_template_data_file_validates_guarded_core_entries(
         "quinoxaline",
         "cinnoline",
         "phthalazine",
+        "phenazine",
+        "1,4-phenanthroline",
+        "1,5-phenanthroline",
+        "1,6-phenanthroline",
+        "1,7-phenanthroline",
+        "1,8-phenanthroline",
+        "1,9-phenanthroline",
+        "1,10-phenanthroline",
+        "2,7-phenanthroline",
+        "2,8-phenanthroline",
+        "3,5-phenanthroline",
+        "3,6-phenanthroline",
+        "4,5-phenanthroline",
+        "acridine",
+        "carbazole",
+        "purine",
+        "indazole",
+        "xanthene",
     }
     assert by_name["1H-indole"].default_indicated_h == ("1",)
     assert by_name["quinoline"].atom_by_locant["1"].symbol == "N"

--- a/src/openclatura/tests/test_utils.py
+++ b/src/openclatura/tests/test_utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+from rdkit import Chem
+
+from openclatura.utils import standardize_mol
+
+
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "N=C1NC(=O)CO1",
+        "N=C1OC(=O)CNC1=O",
+        "[NH2+]=C1O[CH-]C(=O)C=C1",
+        "NC1=[NH+]C(=N)C=C([O-])N1",
+        "O=C1O[C-]2CC[NH2+]C2=C1",
+    ],
+)
+def test_standardize_mol_is_parseable_and_idempotent(smiles: str):
+    standardized = standardize_mol(smiles)
+
+    assert standardized is not None
+    assert Chem.MolFromSmiles(standardized) is not None
+    assert standardize_mol(standardized) == standardized
+
+
+@pytest.mark.parametrize(
+    ("tautomer_a", "tautomer_b"),
+    [
+        ("N=c1[nH]c(O)co1", "Nc1nc(O)co1"),
+        ("N=c1oc(O)c[nH]c1=O", "Nc1oc(=O)cnc1O"),
+    ],
+)
+def test_standardize_mol_converges_equivalent_heterocyclic_tautomers(tautomer_a: str, tautomer_b: str):
+    assert standardize_mol(tautomer_a) == standardize_mol(tautomer_b)

--- a/src/openclatura/tests_roundtrip/test_retained_fused_production.py
+++ b/src/openclatura/tests_roundtrip/test_retained_fused_production.py
@@ -114,7 +114,18 @@ def _cml_plan(cml: str) -> tuple[dict[str, str], set[frozenset[str]], set[str]]:
 
 
 def _normalized_pairs_match(left: list[str], right: list[str]) -> bool:
-    return all(standardize_mol(a) == standardize_mol(b) is not None for a, b in zip(left, right, strict=True))
+    for left_smiles, right_smiles in zip(left, right, strict=True):
+        standardized_left = standardize_mol(left_smiles)
+        standardized_right = standardize_mol(right_smiles)
+        if standardized_left is None or standardized_right is None or standardized_left != standardized_right:
+            return False
+    return True
+
+
+def test_normalized_pairs_match_requires_parseable_equivalent_structures():
+    assert _normalized_pairs_match(["C(C)O"], ["CCO"])
+    assert not _normalized_pairs_match(["CCO"], ["CC"])
+    assert not _normalized_pairs_match(["not-a-smiles"], ["CCO"])
 
 
 @pytest.fixture(scope="module")

--- a/src/openclatura/tests_roundtrip/test_retained_fused_production.py
+++ b/src/openclatura/tests_roundtrip/test_retained_fused_production.py
@@ -1,0 +1,340 @@
+"""OPSIN-audited production tests for retained fused parent plans."""
+
+from __future__ import annotations
+
+import shutil
+import warnings
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from itertools import combinations
+from random import Random
+
+import pytest
+
+from openclatura import name_many
+from openclatura.retained_fused_templates import retained_fused_graph_templates
+from openclatura.utils import standardize_mol
+
+try:
+    import py2opsin
+except Exception:  # pragma: no cover - optional test dependency
+    py2opsin = None
+
+
+PARENT_CASES = (
+    ("phenazine", "phenazine"),
+    ("1,4-phenanthroline", "1,4-phenanthroline"),
+    ("1,5-phenanthroline", "1,5-phenanthroline"),
+    ("1,6-phenanthroline", "1,6-phenanthroline"),
+    ("1,7-phenanthroline", "1,7-phenanthroline"),
+    ("1,8-phenanthroline", "1,8-phenanthroline"),
+    ("1,9-phenanthroline", "1,9-phenanthroline"),
+    ("1,10-phenanthroline", "1,10-phenanthroline"),
+    ("2,7-phenanthroline", "2,7-phenanthroline"),
+    ("2,8-phenanthroline", "2,8-phenanthroline"),
+    ("3,5-phenanthroline", "3,5-phenanthroline"),
+    ("3,6-phenanthroline", "3,6-phenanthroline"),
+    ("4,5-phenanthroline", "4,5-phenanthroline"),
+    ("acridine", "acridine"),
+    ("9H-carbazole", "9H-carbazole"),
+    ("purine", "7H-purine"),
+    ("1H-indazole", "1H-indazole"),
+    ("9H-xanthene", "9H-xanthene"),
+)
+
+OXO_CASES = (
+    ("phenazin-1-one", "phenazin-1-one"),
+    ("phenazine-1,6-dione", "phenazine-1,6-dione"),
+    ("1,10-phenanthrolin-5-one", "1,10-phenanthrolin-5-one"),
+    ("1,10-phenanthroline-5,6-dione", "1,10-phenanthroline-5,6-dione"),
+    ("acridin-9-one", "acridin-9-one"),
+    ("9H-carbazol-1-one", "9H-carbazol-1-one"),
+    ("purine-2,6-dione", "1H-purine-2,6-dione"),
+    ("2,8-diamino-1,4-dihydropurin-6-one", "2,8-diamino-1,4-dihydropurin-6-one"),
+    ("1,3,7-trimethylpurine-2,6-dione", "1,3,7-trimethylpurine-2,6-dione"),
+    ("1H-indazol-3-one", "1H-indazol-3-one"),
+    ("xanthen-9-one", "xanthen-9-one"),
+)
+
+OXO_STEMS = {
+    "phenazine": "phenazin",
+    "acridine": "acridin",
+    "9H-carbazole": "9H-carbazol",
+    "purine": "purin",
+    "1H-indazole": "1H-indazol",
+    "9H-xanthene": "xanthen",
+}
+
+_CML_NS = {"cml": "http://www.xml-cml.org/schema"}
+_COMBINATION_SAMPLE_SIZE = 100
+_COMBINATION_SAMPLE_SEED = 42
+
+
+@dataclass(frozen=True)
+class OxoProbe:
+    parent: str
+    name: str
+    root: str
+    occupied_locants: tuple[str, ...]
+    carbon_locants: tuple[str, ...]
+    smiles: str
+
+
+def _require_opsin() -> None:
+    if py2opsin is None:
+        pytest.skip("py2opsin is not available")
+    if shutil.which("java") is None:
+        pytest.skip("Java runtime not found (OPSIN requires Java)")
+
+
+def _opsin(names: list[str], output_format: str = "SMILES") -> list[str]:
+    _require_opsin()
+    # py2opsin 2.9 splits batched CML at newlines instead of at molecules.
+    # Single-name calls preserve each XML document intact.
+    if output_format == "CML":
+        return [py2opsin.py2opsin(name, output_format=output_format) for name in names]
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=r".*OPSIN raised the following error.*", category=RuntimeWarning)
+        return list(py2opsin.py2opsin(names, output_format=output_format))
+
+
+def _cml_plan(cml: str) -> tuple[dict[str, str], set[frozenset[str]], set[str]]:
+    root = ET.fromstring(cml)
+    atom_rows: dict[str, tuple[str, str | None]] = {}
+    for atom in root.findall(".//cml:atom", _CML_NS):
+        labels = atom.findall("cml:label", _CML_NS)
+        locant = next((label.get("value") for label in labels if label.get("value", "")[0].isdigit()), None)
+        atom_rows[atom.get("id", "")] = (atom.get("elementType", ""), locant)
+
+    elements = {locant: element for element, locant in atom_rows.values() if locant is not None}
+    edges: set[frozenset[str]] = set()
+    hydrogenated: set[str] = set()
+    for bond in root.findall(".//cml:bond", _CML_NS):
+        left_id, right_id = bond.get("atomRefs2", "").split()
+        left_element, left_locant = atom_rows[left_id]
+        right_element, right_locant = atom_rows[right_id]
+        if left_locant is not None and right_locant is not None:
+            edges.add(frozenset((left_locant, right_locant)))
+        elif left_element == "H" and right_locant is not None:
+            hydrogenated.add(right_locant)
+        elif right_element == "H" and left_locant is not None:
+            hydrogenated.add(left_locant)
+    return elements, edges, hydrogenated
+
+
+def _normalized_pairs_match(left: list[str], right: list[str]) -> bool:
+    return all(standardize_mol(a) == standardize_mol(b) is not None for a, b in zip(left, right, strict=True))
+
+
+@pytest.fixture(scope="module")
+def parent_cml_rows() -> list[str]:
+    return _opsin([name for name, _ in PARENT_CASES], output_format="CML")
+
+
+@pytest.fixture(scope="module")
+def valid_oxo_rows(parent_cml_rows) -> list[OxoProbe]:
+    candidates: list[OxoProbe] = []
+    for (parent, _), cml in zip(PARENT_CASES, parent_cml_rows, strict=True):
+        elements, _, hydrogenated = _cml_plan(cml)
+        carbon_locants = tuple(
+            sorted(
+                (loc for loc in hydrogenated if elements[loc] == "C"),
+                key=lambda value: int(value),
+            )
+        )
+        stem = OXO_STEMS.get(parent, parent.replace("phenanthroline", "phenanthrolin"))
+        root = "phenanthrol" if "phenanthroline" in parent else stem.removeprefix("1H-").removeprefix("9H-")
+        candidates.extend(
+            OxoProbe(parent, f"{stem}-{locant}-one", root, (locant,), carbon_locants, "") for locant in carbon_locants
+        )
+        candidates.extend(
+            OxoProbe(
+                parent,
+                f"{parent}-{left},{right}-dione",
+                root,
+                (left, right),
+                carbon_locants,
+                "",
+            )
+            for left, right in combinations(carbon_locants, 2)
+        )
+
+    candidate_smiles = _opsin([probe.name for probe in candidates])
+    return [
+        OxoProbe(
+            probe.parent,
+            probe.name,
+            probe.root,
+            probe.occupied_locants,
+            probe.carbon_locants,
+            smiles,
+        )
+        for probe, smiles in zip(candidates, candidate_smiles, strict=True)
+        if smiles
+    ]
+
+
+def _substituted_derivative_name(base_name: str, substituents: tuple[tuple[str, str], ...]) -> str:
+    grouped: dict[str, list[str]] = {}
+    for locant, substituent in substituents:
+        grouped.setdefault(substituent, []).append(locant)
+    prefix_parts = []
+    for substituent in sorted(grouped):
+        locants = sorted(grouped[substituent], key=int)
+        multiplier = {1: "", 2: "di"}[len(locants)]
+        prefix_parts.append(f"{','.join(locants)}-{multiplier}{substituent}")
+    separator = "-" if base_name[0].isdigit() else ""
+    return f"{'-'.join(prefix_parts)}{separator}{base_name}"
+
+
+@pytest.mark.opsin
+def test_opsin_cml_locants_and_graphs_are_the_source_of_truth_for_production_plans(parent_cml_rows):
+    """Every template atom, element, edge, and locant must equal OPSIN CML."""
+
+    templates = {template.name: template for template in retained_fused_graph_templates(include_disabled=True)}
+
+    for (opsin_name, expected_name), cml in zip(PARENT_CASES, parent_cml_rows, strict=True):
+        template_name = expected_name.removeprefix("7H-").removeprefix("9H-").removeprefix("1H-")
+        template = templates[template_name]
+        elements, edges, _ = _cml_plan(cml)
+        template_edges = {frozenset(bond.locants) for bond in template.bonds}
+
+        assert set(elements) == set(template.locants), opsin_name
+        assert elements == {locant: atom.symbol for locant, atom in template.atom_by_locant.items()}, opsin_name
+        assert edges == template_edges, opsin_name
+
+
+@pytest.mark.opsin
+def test_opsin_generated_parent_smiles_use_the_audited_retained_names():
+    opsin_smiles = _opsin([name for name, _ in PARENT_CASES])
+    generated = [result.name for result in name_many(opsin_smiles, processes=1)]
+
+    assert generated == [expected for _, expected in PARENT_CASES]
+
+
+@pytest.mark.opsin
+def test_every_opsin_hydrogen_bearing_carbon_locant_survives_methyl_substitution(parent_cml_rows):
+    """Probe every substitutable carbon locant, including symmetry-equivalent sites."""
+
+    opsin_names = [name for name, _ in PARENT_CASES]
+    probes: list[str] = []
+    for parent, cml in zip(opsin_names, parent_cml_rows, strict=True):
+        elements, _, hydrogenated = _cml_plan(cml)
+        for locant in sorted((loc for loc in hydrogenated if elements[loc] == "C"), key=lambda value: int(value)):
+            separator = "-" if parent[0].isdigit() else ""
+            probes.append(f"{locant}-methyl{separator}{parent}")
+
+    substituted_smiles = _opsin(probes)
+    assert len(probes) >= 130
+    assert substituted_smiles and all(substituted_smiles)
+    generated_names = [result.name for result in name_many(substituted_smiles, processes=1)]
+    regenerated_smiles = _opsin(generated_names)
+
+    assert all(generated_names)
+    assert all("methyl" in name for name in generated_names)
+    assert _normalized_pairs_match(substituted_smiles, regenerated_smiles)
+
+
+@pytest.mark.opsin
+def test_all_opsin_valid_oxo_and_dione_positions_keep_the_retained_parent(valid_oxo_rows):
+    """Exercise every carbonyl position and pair accepted by OPSIN."""
+
+    assert len(valid_oxo_rows) >= 400
+
+    generated_names = [result.name for result in name_many([row.smiles for row in valid_oxo_rows], processes=1)]
+    regenerated_smiles = _opsin(generated_names)
+
+    assert all(
+        row.root.lower() in generated.lower() for row, generated in zip(valid_oxo_rows, generated_names, strict=True)
+    )
+    failures = [
+        (row.name, generated, standardize_mol(row.smiles), standardize_mol(regenerated))
+        for row, generated, regenerated in zip(valid_oxo_rows, generated_names, regenerated_smiles, strict=True)
+        if standardize_mol(row.smiles) != standardize_mol(regenerated)
+    ]
+    assert not failures, failures[:20]
+
+
+@pytest.mark.opsin
+def test_oxo_dione_amino_methyl_combinations_preserve_hydride_state(valid_oxo_rows):
+    """Cross principal groups with substituents that can move indicated H."""
+
+    representative_rows: list[OxoProbe] = []
+    for parent, _ in PARENT_CASES:
+        parent_rows = [probe for probe in valid_oxo_rows if probe.parent == parent]
+        mono_rows = [probe for probe in parent_rows if len(probe.occupied_locants) == 1]
+        dione_rows = [probe for probe in parent_rows if len(probe.occupied_locants) == 2]
+        # One mono-oxo and one dione per retained plan exercise every family
+        # without repeating symmetry-equivalent cross products. Purine keeps
+        # the complete positional matrix because fusion-carbon hydride shifts
+        # were observed there in the PubChem regression corpus.
+        representative_rows.extend(parent_rows if parent == "purine" else [mono_rows[0], dione_rows[0]])
+
+    candidate_names: list[tuple[str, str]] = []
+    for probe in representative_rows:
+        free_locants = tuple(locant for locant in probe.carbon_locants if locant not in probe.occupied_locants)
+        for locant in free_locants:
+            candidate_names.append((_substituted_derivative_name(probe.name, ((locant, "amino"),)), probe.root))
+            candidate_names.append((_substituted_derivative_name(probe.name, ((locant, "methyl"),)), probe.root))
+
+        # Pair substitutions are the important hydride-state stressor. Apply
+        # every pair to mono-oxo representatives; diones retain complete
+        # single-substitution coverage without a second quadratic expansion.
+        if len(probe.occupied_locants) == 1:
+            for left, right in combinations(free_locants, 2):
+                candidate_names.append(
+                    (_substituted_derivative_name(probe.name, ((left, "amino"), (right, "amino"))), probe.root)
+                )
+                candidate_names.append(
+                    (_substituted_derivative_name(probe.name, ((left, "amino"), (right, "methyl"))), probe.root)
+                )
+                candidate_names.append(
+                    (_substituted_derivative_name(probe.name, ((left, "methyl"), (right, "amino"))), probe.root)
+                )
+
+    candidate_names = Random(_COMBINATION_SAMPLE_SEED).sample(candidate_names, k=_COMBINATION_SAMPLE_SIZE)
+    candidate_smiles = _opsin([name for name, _ in candidate_names])
+    valid_rows = [
+        (name, root, smiles) for (name, root), smiles in zip(candidate_names, candidate_smiles, strict=True) if smiles
+    ]
+    assert len(valid_rows) == _COMBINATION_SAMPLE_SIZE
+
+    generated_names = [result.name for result in name_many([smiles for _, _, smiles in valid_rows], processes=1)]
+    regenerated_smiles = _opsin(generated_names)
+    failures = [
+        (source_name, generated, standardize_mol(source), standardize_mol(regenerated))
+        for (source_name, _, source), generated, regenerated in zip(
+            valid_rows, generated_names, regenerated_smiles, strict=True
+        )
+        if not generated or standardize_mol(source) != standardize_mol(regenerated)
+    ]
+
+    assert all(root.lower() in generated.lower() for (_, root, _), generated in zip(valid_rows, generated_names))
+    assert not failures, failures[:20]
+
+
+@pytest.mark.opsin
+def test_oxo_and_dione_derivative_classes_are_opsin_exact_and_roundtrip():
+    opsin_smiles = _opsin([opsin_name for opsin_name, _ in OXO_CASES])
+    generated_names = [result.name for result in name_many(opsin_smiles, processes=1)]
+    regenerated_smiles = _opsin(generated_names)
+
+    assert generated_names == [expected for _, expected in OXO_CASES]
+    assert _normalized_pairs_match(opsin_smiles, regenerated_smiles)
+
+
+@pytest.mark.opsin
+def test_hydro_oxo_analogs_do_not_false_match_mancude_production_plans():
+    opsin_names = [
+        "3,4-dihydrophenazin-1-one",
+        "3,4-dihydroacridin-9-one",
+        "1,2-dihydroxanthen-9-one",
+    ]
+    opsin_smiles = _opsin(opsin_names)
+    generated_names = [result.name for result in name_many(opsin_smiles, processes=1)]
+    regenerated_smiles = _opsin(generated_names)
+
+    assert "phenazin" not in generated_names[0]
+    assert "acridin" not in generated_names[1]
+    assert "xanthen" not in generated_names[2]
+    assert _normalized_pairs_match(opsin_smiles, regenerated_smiles)

--- a/src/openclatura/tests_roundtrip/test_retained_fused_production.py
+++ b/src/openclatura/tests_roundtrip/test_retained_fused_production.py
@@ -56,15 +56,6 @@ OXO_CASES = (
     ("xanthen-9-one", "xanthen-9-one"),
 )
 
-OXO_STEMS = {
-    "phenazine": "phenazin",
-    "acridine": "acridin",
-    "9H-carbazole": "9H-carbazol",
-    "purine": "purin",
-    "1H-indazole": "1H-indazol",
-    "9H-xanthene": "xanthen",
-}
-
 _CML_NS = {"cml": "http://www.xml-cml.org/schema"}
 _COMBINATION_SAMPLE_SIZE = 100
 _COMBINATION_SAMPLE_SEED = 42
@@ -134,6 +125,7 @@ def parent_cml_rows() -> list[str]:
 @pytest.fixture(scope="module")
 def valid_oxo_rows(parent_cml_rows) -> list[OxoProbe]:
     candidates: list[OxoProbe] = []
+    templates = {template.name: template for template in retained_fused_graph_templates(include_disabled=True)}
     for (parent, _), cml in zip(PARENT_CASES, parent_cml_rows, strict=True):
         elements, _, hydrogenated = _cml_plan(cml)
         carbon_locants = tuple(
@@ -142,7 +134,9 @@ def valid_oxo_rows(parent_cml_rows) -> list[OxoProbe]:
                 key=lambda value: int(value),
             )
         )
-        stem = OXO_STEMS.get(parent, parent.replace("phenanthroline", "phenanthrolin"))
+        template_name = parent.removeprefix("1H-").removeprefix("7H-").removeprefix("9H-")
+        stem = templates[template_name].derivative_stem
+        assert stem is not None
         root = "phenanthrol" if "phenanthroline" in parent else stem.removeprefix("1H-").removeprefix("9H-")
         candidates.extend(
             OxoProbe(parent, f"{stem}-{locant}-one", root, (locant,), carbon_locants, "") for locant in carbon_locants
@@ -185,6 +179,27 @@ def _substituted_derivative_name(base_name: str, substituents: tuple[tuple[str, 
         prefix_parts.append(f"{','.join(locants)}-{multiplier}{substituent}")
     separator = "-" if base_name[0].isdigit() else ""
     return f"{'-'.join(prefix_parts)}{separator}{base_name}"
+
+
+def _stratified_combination_sample(
+    candidates: list[tuple[str, str, str, str]],
+) -> list[tuple[str, str, str, str]]:
+    """Select a seeded sample covering every retained parent and probe class."""
+
+    rng = Random(_COMBINATION_SAMPLE_SEED)
+    shuffled = list(dict.fromkeys(candidates))
+    rng.shuffle(shuffled)
+    selected: list[tuple[str, str, str, str]] = []
+
+    for parent in sorted({row[2] for row in candidates}):
+        selected.append(next(row for row in shuffled if row[2] == parent))
+    for probe_class in sorted({row[3] for row in candidates}):
+        if not any(row[3] == probe_class for row in selected):
+            selected.append(next(row for row in shuffled if row[3] == probe_class))
+
+    selected_set = set(selected)
+    selected.extend(row for row in shuffled if row not in selected_set)
+    return selected[:_COMBINATION_SAMPLE_SIZE]
 
 
 @pytest.mark.opsin
@@ -270,12 +285,27 @@ def test_oxo_dione_amino_methyl_combinations_preserve_hydride_state(valid_oxo_ro
         # were observed there in the PubChem regression corpus.
         representative_rows.extend(parent_rows if parent == "purine" else [mono_rows[0], dione_rows[0]])
 
-    candidate_names: list[tuple[str, str]] = []
+    candidate_names: list[tuple[str, str, str, str]] = []
     for probe in representative_rows:
+        derivative_class = "mono" if len(probe.occupied_locants) == 1 else "dione"
         free_locants = tuple(locant for locant in probe.carbon_locants if locant not in probe.occupied_locants)
         for locant in free_locants:
-            candidate_names.append((_substituted_derivative_name(probe.name, ((locant, "amino"),)), probe.root))
-            candidate_names.append((_substituted_derivative_name(probe.name, ((locant, "methyl"),)), probe.root))
+            candidate_names.append(
+                (
+                    _substituted_derivative_name(probe.name, ((locant, "amino"),)),
+                    probe.root,
+                    probe.parent,
+                    f"{derivative_class}:amino",
+                )
+            )
+            candidate_names.append(
+                (
+                    _substituted_derivative_name(probe.name, ((locant, "methyl"),)),
+                    probe.root,
+                    probe.parent,
+                    f"{derivative_class}:methyl",
+                )
+            )
 
         # Pair substitutions are the important hydride-state stressor. Apply
         # every pair to mono-oxo representatives; diones retain complete
@@ -283,19 +313,45 @@ def test_oxo_dione_amino_methyl_combinations_preserve_hydride_state(valid_oxo_ro
         if len(probe.occupied_locants) == 1:
             for left, right in combinations(free_locants, 2):
                 candidate_names.append(
-                    (_substituted_derivative_name(probe.name, ((left, "amino"), (right, "amino"))), probe.root)
+                    (
+                        _substituted_derivative_name(probe.name, ((left, "amino"), (right, "amino"))),
+                        probe.root,
+                        probe.parent,
+                        "mono:diamino",
+                    )
                 )
                 candidate_names.append(
-                    (_substituted_derivative_name(probe.name, ((left, "amino"), (right, "methyl"))), probe.root)
+                    (
+                        _substituted_derivative_name(probe.name, ((left, "amino"), (right, "methyl"))),
+                        probe.root,
+                        probe.parent,
+                        "mono:amino_methyl",
+                    )
                 )
                 candidate_names.append(
-                    (_substituted_derivative_name(probe.name, ((left, "methyl"), (right, "amino"))), probe.root)
+                    (
+                        _substituted_derivative_name(probe.name, ((left, "methyl"), (right, "amino"))),
+                        probe.root,
+                        probe.parent,
+                        "mono:amino_methyl",
+                    )
                 )
 
-    candidate_names = Random(_COMBINATION_SAMPLE_SEED).sample(candidate_names, k=_COMBINATION_SAMPLE_SIZE)
-    candidate_smiles = _opsin([name for name, _ in candidate_names])
+    candidate_names = _stratified_combination_sample(candidate_names)
+    assert {row[2] for row in candidate_names} == {parent for parent, _ in PARENT_CASES}
+    assert {row[3] for row in candidate_names} == {
+        "mono:amino",
+        "mono:methyl",
+        "mono:diamino",
+        "mono:amino_methyl",
+        "dione:amino",
+        "dione:methyl",
+    }
+    candidate_smiles = _opsin([name for name, _, _, _ in candidate_names])
     valid_rows = [
-        (name, root, smiles) for (name, root), smiles in zip(candidate_names, candidate_smiles, strict=True) if smiles
+        (name, root, smiles)
+        for (name, root, _, _), smiles in zip(candidate_names, candidate_smiles, strict=True)
+        if smiles
     ]
     assert len(valid_rows) == _COMBINATION_SAMPLE_SIZE
 

--- a/src/openclatura/utils.py
+++ b/src/openclatura/utils.py
@@ -33,8 +33,38 @@ uncharger = rdMolStandardize.Uncharger()
 fragment_chooser = rdMolStandardize.LargestFragmentChooser()
 tautomer_enum = rdMolStandardize.TautomerEnumerator()
 
+# Bounds repeated parse/canonicalize/serialize passes while seeking a stable
+# representation. This is independent of RDKit's internal tautomer limit.
+_MAX_STANDARDIZATION_PASSES = 10
 
-def standardize_mol(smi):
+
+def _roundtrip_safe_smiles(mol: Chem.Mol) -> str | None:
+    """Serialize ``mol`` to canonical SMILES that RDKit can parse again.
+
+    RDKit can retain aromatic flags after neutralization that produce an
+    aromatic SMILES with no valid Kekule form.  A Kekule serialization clears
+    that inconsistent intermediate while preserving the molecular graph.
+    """
+
+    for kekule in (False, True):
+        try:
+            smiles = Chem.MolToSmiles(mol, canonical=True, kekuleSmiles=kekule)
+        except Exception:
+            continue
+        if Chem.MolFromSmiles(smiles) is not None:
+            return smiles
+    return None
+
+
+def standardize_mol(smi: str) -> str | None:
+    """Return a parseable, idempotent standardized tautomeric SMILES.
+
+    Serialization/reparse between charge normalization and tautomer
+    canonicalization refreshes RDKit's aromaticity and valence state.  The
+    short fixed-point loop is needed because some heterocyclic tautomer sets
+    choose a different canonical member after their first serialization.
+    """
+
     mol = Chem.MolFromSmiles(smi)
     if mol is None:
         return None
@@ -43,6 +73,27 @@ def standardize_mol(smi):
     mol = normalizer.normalize(mol)
     mol = reionizer.reionize(mol)
     mol = uncharger.uncharge(mol)
-    mol = tautomer_enum.Canonicalize(mol)
 
-    return Chem.MolToSmiles(mol, canonical=True)
+    current = _roundtrip_safe_smiles(mol)
+    if current is None:
+        return None
+
+    seen: set[str] = set()
+    for _ in range(_MAX_STANDARDIZATION_PASSES):
+        if current in seen:
+            # A deterministic representative makes a rare cycle idempotent.
+            return min(seen)
+        seen.add(current)
+
+        reparsed = Chem.MolFromSmiles(current)
+        if reparsed is None:  # defensive; _roundtrip_safe_smiles checked it
+            return None
+        canonical = tautomer_enum.Canonicalize(reparsed)
+        next_smiles = _roundtrip_safe_smiles(canonical)
+        if next_smiles is None:
+            return None
+        if next_smiles == current:
+            return current
+        current = next_smiles
+
+    return current

--- a/tests/fixtures/diverse_corpus.golden.json
+++ b/tests/fixtures/diverse_corpus.golden.json
@@ -471,7 +471,7 @@
   },
   {
     "smiles": "c1ccc2c(c1)c1ccccc1n2",
-    "name": "8-azatricyclo[7.4.0.0^{2,7}]tridecane",
+    "name": "9H-carbazole",
     "category": "heterocycle"
   },
   {

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -162,11 +162,12 @@ def test_describe_orders_main_parent_trace_before_nested_substituent_trace():
     assert eth_index < amide_index < benzene_index
 
 
-def test_describe_explains_parenthesized_unsaturation_locants():
+def test_describe_explains_retained_purine_dione_parent():
     text = str(describe("CN1C=NC2=C1C(=O)N(C(=O)N2C)C"))
 
-    assert "Unsaturation: double at 1(6),8" in text
-    assert "1(6) means a multiple bond between locants 1 and 6" in text
+    assert "1,3,7-trimethylpurine-2,6-dione" in text
+    assert "retained as purine" in text
+    assert "Principal group: ketone at 2,6" in text
 
 
 def test_describe_renders_oxygen_carbonyl_shortcut_substituent_tree():

--- a/tests/integration/test_human_descriptor.py
+++ b/tests/integration/test_human_descriptor.py
@@ -11,17 +11,14 @@ def test_human_descriptor_uses_parent_metadata_without_token_spans():
     assert isinstance(d, HumanDescription)
     text = str(d)
     assert "9-membered bicyclic [4.3.0] heteroskeleton" in text
-    assert "nitrogen at positions 2 (atom id" in text
-    assert "4 (atom id" in text
+    assert "retained purine parent" in text
+    assert "nitrogen at positions 1 (atom id" in text
+    assert "3 (atom id" in text
     assert "7 (atom id" in text
     assert "9 (atom id" in text
-    assert "double bond between position 1 (atom id" in text
-    assert "and position 6 (atom id" in text
-    assert "double bond between position 8 (atom id" in text
-    assert "and position 9 (atom id" in text
-    assert "oxo groups at positions 3 (atom id" in text
-    assert "5 (atom id" in text
-    assert "methyl groups at positions 2 (atom id" in text
+    assert "oxo groups at positions 2 (atom id" in text
+    assert "6 (atom id" in text
+    assert "methyl groups at positions 1 (atom id" in text
     assert "token" not in text.lower()
     assert "span" not in text.lower()
 


### PR DESCRIPTION
## Summary by Sourcery

Improve retained fused parent handling, tautomer standardization, and OPSIN-audited roundtrip correctness, including new retained skeletons and derivative behaviors for heterocyclic systems.

New Features:
- Introduce retained fused base template loading from the graph template data table to support multiple fused skeleton families.
- Expose retained parent metadata (indicated-H defaults, fusion locants, derivative stem) for use across naming, descriptor, and production pipelines.
- Add support for additive hydrogen prefixes alongside indicated-hydrogen prefixes in parent naming.
- Add optional normalization of generation input in the regression checker and corresponding CLI flag.
- Add OPSIN-backed roundtrip tests for retained fused parents and their oxo, dione, and substituted derivatives, plus new unit tests for tautomer standardization.
- Extend retained fused parent coverage to phenazine, phenanthrolines, acridine, carbazole, purine, indazole, xanthene and selected hydrides/oxo derivatives.

Bug Fixes:
- Fix RDKit SMILES normalization so that standardized tautomeric representations are parseable, idempotent, and robust to problematic aromatic flags.
- Prevent spurious indicated-hydrogen locants on saturated fused carbons or ketone-adjacent carbons, preserving correct hydride state and locant semantics.
- Ensure ketone derivatives of retained fused parents only match production plans when the mancude unsaturation pattern is present.
- Allow retained fused template matching to tolerate loss of aromatic flags at oxo-bearing carbons without breaking parent recognition.
- Correct human-readable descriptor and explanation text for caffeine and purine-dione examples to reflect retained purine parents and updated locant assignments.

Enhancements:
- Cache retained fused base templates, graph templates, and parent metadata to avoid repeated JSON loading and graph traversal.
- Propagate retained parent metadata through component naming state and parent assembly plans for consistent downstream behavior.
- Refine hydro operation tokenization and name-atom bindings so that hydro and indicated-hydrogen operations are distinguished in bindings and emitted tokens.

Documentation:
- Update the README example and citation section to use purine-2,6-dione as the caffeine example and to provide BibTeX entries for Openclatura and OPSIN.

Tests:
- Add analysis and integration tests covering additive hydrogen operations, purine retained parent usage, and descriptor behavior.
- Add OPSIN-audited roundtrip tests for retained fused production across parent, oxo/dione, and substituted derivative classes, including hydride-state edge cases.
- Add unit tests for the new standardize_mol behavior, ensuring idempotent parsing and convergence across heterocyclic tautomer pairs.
- Extend retained fused template schema validation tests to cover new base skeletons and additional guarded core entries.

Chores:
- Adjust regression checking metadata to record whether standardized SMILES were used as generation input in reports.