### PR TITLE
Unifying branches

### DIFF
--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -27,6 +27,17 @@ class NameTokenBinding:
     right_context: str = ""
 
 
+class RenderedSubstituentName(str):
+    """A rendered substituent carrying construction-time boundary metadata."""
+
+    outer_parentheses_optional: bool
+
+    def __new__(cls, value: str, *, outer_parentheses_optional: bool = False):
+        rendered = super().__new__(cls, value)
+        rendered.outer_parentheses_optional = outer_parentheses_optional
+        return rendered
+
+
 @dataclass
 class SubstituentItem:
     name: str

--- a/src/openclatura/assembly_prefixes.py
+++ b/src/openclatura/assembly_prefixes.py
@@ -3,7 +3,7 @@
 import re
 
 from .assembly_charge import inferred_ionic_retained_parent, single_charged_replacement_locants
-from .assembly_parts import AssemblyParts, SubstituentItem
+from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
 from .assembly_utils import is_fully_enclosed, needs_hyphen, parse_locant
 from .formatting import is_complex_prefix
 from .nomenclature import RULES
@@ -156,19 +156,41 @@ def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:
         mult = (multipliers.complex_(count) if is_complex else multipliers.basic(count)) if count > 1 else ""
         loc_str = substituent_locant_string(parts, locs, len(grouped), spiro_subs)
 
-        name_to_use = name
-        if is_complex and not is_fully_enclosed(name):
+        name_to_use = _omit_optional_outer_parentheses(parts, name, count, loc_str, len(grouped))
+        if is_complex and not is_fully_enclosed(name_to_use):
             if count > 1 or loc_str:
-                name_to_use = f"({name})"
-        elif not loc_str and len(grouped) > 1 and not is_fully_enclosed(name):
+                name_to_use = f"({name_to_use})"
+        elif not loc_str and len(grouped) > 1 and not is_fully_enclosed(name_to_use):
             if name not in ["fluoro", "chloro", "bromo", "iodo"]:
-                name_to_use = f"({name})"
+                name_to_use = f"({name_to_use})"
         prefix_parts.append(f"{loc_str}-{mult}{name_to_use}" if loc_str else f"{mult}{name_to_use}")
 
     prefix_str = prefix_parts[0]
     for part in prefix_parts[1:]:
         prefix_str += f"-{part}" if needs_hyphen(prefix_str, part) else part
     return prefix_str
+
+
+def _omit_optional_outer_parentheses(
+    parts: AssemblyParts,
+    name: str,
+    count: int,
+    locant_text: str,
+    grouped_count: int,
+) -> str:
+    """Unwrap a directly rendered fragment when its parent boundary is clear."""
+
+    if (
+        parts.is_substituent
+        or count != 1
+        or locant_text
+        or grouped_count != 1
+        or not isinstance(name, RenderedSubstituentName)
+        or not name.outer_parentheses_optional
+        or not is_fully_enclosed(name)
+    ):
+        return name
+    return name[1:-1]
 
 
 def format_replacement_prefixes(parts: AssemblyParts) -> str:

--- a/src/openclatura/component_modifiers.py
+++ b/src/openclatura/component_modifiers.py
@@ -5,7 +5,7 @@ from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
 from .molecule import DecisionTrace, Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .subgraph_tools import subgraph_component
@@ -19,7 +19,7 @@ def add_component_front_modifiers(
     perceived_groups: list[PerceivedGroup],
     principal_key: str | None,
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> None:
     """Add ester/sulfonate front modifiers such as the alcohol component name."""
 
@@ -64,7 +64,7 @@ def add_component_n_substituents(
     numbered_path: list[int],
     get_loc,
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> None:
     """Add N-substituent prefixes and N/N' locants for principal groups."""
 
@@ -183,7 +183,7 @@ def _nitrogen_substituent_name(
     nitrogen: int,
     substituent: int,
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
     decision_trace: DecisionTrace | None = None,
 ) -> tuple[str, list, dict | None]:
     """Render graph-bound N-substituents on principal nitrogen groups."""

--- a/src/openclatura/component_modifiers.py
+++ b/src/openclatura/component_modifiers.py
@@ -1,73 +1,16 @@
 """Data-driven component modifiers attached after parent numbering."""
 
-from typing import Literal, Protocol, overload
-
 from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem
 from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
 from .molecule import DecisionTrace, Molecule
+from .naming_protocols import BranchNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .subgraph_tools import subgraph_component
 from .substituent_tokens import graph_bound_substituent_tokens
 from .trace_helpers import add_substituent_trace, bond_ids_within, decision_trace_data
-
-
-class BranchNamer(Protocol):
-    """Recursive branch namer with simple and traced/tree return modes."""
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> str: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict]]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict], dict | None]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, dict | None]: ...
 
 
 def add_component_front_modifiers(

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -1,7 +1,6 @@
 """Connected-component naming pipeline."""
 
 from collections.abc import Callable
-from typing import Literal, Protocol, overload
 
 from .assembly_parts import AssemblyParts, NameAtomBinding, SubstituentItem
 from .chains import find_all_carbon_paths, find_ring_systems, get_cyclic_atoms
@@ -17,6 +16,7 @@ from .name_assembly import NameAssemblyResult, assert_final_name_assembly, token
 from .name_bindings import binding_trace_data, refresh_name_atom_bindings
 from .naming_audit import UnnamedAtomError, assert_component_fully_named
 from .naming_context import ComponentNamingState, NamingIntent
+from .naming_protocols import SubgraphNamer
 from .parent_pipeline import build_parent_assembly_plan, resolve_retained_parent
 from .parent_selection import select_principal_parent
 from .principal_groups import (
@@ -48,67 +48,11 @@ from .trace_helpers import (
     assembly_substituent_tree,
     assembly_trace_segments,
     bond_ids_within,
+    build_shortcut_tree_node,
     decision_trace_data,
     functional_group_trace_data,
     trace_decision,
 )
-
-
-class SubgraphNamer(Protocol):
-    """Recursive subgraph namer with simple and traced/tree return modes."""
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> str: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict]]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict], dict | None]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, dict | None]: ...
-
 
 SpiroSubgraphNamer = Callable[[Molecule, int, set[int]], SpiroAssembly]
 ParentAssembler = Callable[..., str]
@@ -332,11 +276,11 @@ def name_component(
             },
         )
         if return_trace and return_tree:
-            return name, [], _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, [], _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
         if return_tree:
-            return name, _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         return name
 
     def name_component_again(next_mol: Molecule, next_atoms: set[int], is_substituent: bool = False):
@@ -376,11 +320,11 @@ def name_component(
             },
         )
         if return_trace and return_tree:
-            return name, [], _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, [], _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
         if return_tree:
-            return name, _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         return name
 
     state = ComponentNamingState(component_atoms=set(component_atoms), is_substituent=is_substituent)
@@ -431,11 +375,11 @@ def name_component(
             },
         )
         if return_trace and return_tree:
-            return name, [], _shortcut_tree(name, state.component_atoms, bindings, token_spans)
+            return name, [], _component_shortcut_tree(name, state.component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
         if return_tree:
-            return name, _shortcut_tree(name, state.component_atoms, bindings, token_spans)
+            return name, _component_shortcut_tree(name, state.component_atoms, bindings, token_spans)
         return name
 
     state.exclude_atoms = set(mol.atoms.keys()) - state.component_atoms
@@ -654,21 +598,15 @@ def name_component(
     return name
 
 
-def _shortcut_tree(name: str, component_atoms: set[int], bindings: list[dict], token_spans: list[dict]) -> dict:
+def _component_shortcut_tree(
+    name: str, component_atoms: set[int], bindings: list[dict], token_spans: list[dict]
+) -> dict:
     """Return a minimal component tree for shortcut component names."""
 
-    return {
-        "kind": "component",
-        "name": name,
-        "atoms": sorted(component_atoms),
-        "bonds": [],
-        "parent": None,
-        "principal_group": None,
-        "substituents": [],
-        "replacement_prefixes": [],
-        "unsaturations": [],
-        "trace_segments": [],
-        "nested_decisions": [],
-        "name_atom_bindings": bindings,
-        "name_token_spans": token_spans,
-    }
+    return build_shortcut_tree_node(
+        kind="component",
+        name=name,
+        atom_ids=component_atoms,
+        name_atom_bindings=bindings,
+        name_token_spans=token_spans,
+    )

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -16,7 +16,7 @@ from .name_assembly import NameAssemblyResult, assert_final_name_assembly, token
 from .name_bindings import binding_trace_data, refresh_name_atom_bindings
 from .naming_audit import UnnamedAtomError, assert_component_fully_named
 from .naming_context import ComponentNamingState, NamingIntent
-from .naming_protocols import SubgraphNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .parent_pipeline import build_parent_assembly_plan, resolve_retained_parent
 from .parent_selection import select_principal_parent
 from .principal_groups import (
@@ -77,7 +77,7 @@ def collect_component_branch_substituents(
     base_exclude: set[int],
     sub_exclude: set[int],
     *,
-    name_subgraph: SubgraphNamer,
+    name_subgraph: RecursiveSubgraphNamer,
     name_spiro_subgraph: SpiroSubgraphNamer,
     emit_metadata: bool = True,
 ) -> None:
@@ -242,7 +242,7 @@ def name_component(
     return_trace: bool = False,
     return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
-    name_subgraph: SubgraphNamer,
+    name_subgraph: RecursiveSubgraphNamer,
     name_spiro_subgraph: SpiroSubgraphNamer,
     assemble_parent_name: ParentAssembler,
     token_debug: bool = False,

--- a/src/openclatura/functional_prefixes.py
+++ b/src/openclatura/functional_prefixes.py
@@ -9,13 +9,13 @@ from .assembly_parts import NameTokenBinding, SubstituentItem
 from .formatting import format_counted_prefixes, is_complex_prefix, oxy_prefix_from_branch, strip_outer_parentheses
 from .group_atom_roles import amide_nitrogen, ester_or_peroxy_single_oxygen
 from .molecule import Molecule
+from .naming_protocols import BranchNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .rules import multipliers
 from .subgraph_tools import subgraph_component
 from .trace_helpers import bond_ids_within
 
-BranchNamer = Callable[..., str]
 PrefixHandler = Callable[["PrefixContext", PerceivedGroup], str]
 
 

--- a/src/openclatura/functional_prefixes.py
+++ b/src/openclatura/functional_prefixes.py
@@ -9,7 +9,7 @@ from .assembly_parts import NameTokenBinding, SubstituentItem
 from .formatting import format_counted_prefixes, is_complex_prefix, oxy_prefix_from_branch, strip_outer_parentheses
 from .group_atom_roles import amide_nitrogen, ester_or_peroxy_single_oxygen
 from .molecule import Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .rules import multipliers
@@ -24,11 +24,15 @@ class PrefixContext:
     mol: Molecule
     parent_path: list[int]
     sub_exclude: set[int]
-    branch_namer: BranchNamer
+    branch_namer: RecursiveSubgraphNamer
 
 
 def ester_prefix_from_group(
-    mol: Molecule, group: PerceivedGroup, sub_exclude: set[int], suffix_text: str, branch_namer: BranchNamer
+    mol: Molecule,
+    group: PerceivedGroup,
+    sub_exclude: set[int],
+    suffix_text: str,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     """Return an alkoxycarbonyl or alkoxysulfonyl-style prefix."""
 
@@ -45,7 +49,7 @@ def ester_prefix_from_group(
 
 
 def amide_prefix_from_group(
-    mol: Molecule, group: PerceivedGroup, sub_exclude: set[int], branch_namer: BranchNamer
+    mol: Molecule, group: PerceivedGroup, sub_exclude: set[int], branch_namer: RecursiveSubgraphNamer
 ) -> str:
     """Return carbamoyl or carbamothioyl prefix text for an amide-like group."""
 
@@ -201,7 +205,7 @@ def collect_component_prefix_substituents(
     prefix_groups: list[PerceivedGroup],
     parent_path: list[int],
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[dict[int, list[SubstituentItem]], set[int]]:
     """Collect characteristic groups cited as prefixes on the component parent."""
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -19,7 +19,7 @@ from .namer_config import (
     SIMPLE_SELANYL_PREFIXES,
     SIMPLE_SULFANYL_PREFIXES,
 )
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nitrogen_roles import terminal_n3_substituent_role
 from .nomenclature import RULES
 from .oxoacid_roles import OxoLigandRole, central_oxo_substituent_role
@@ -72,7 +72,7 @@ def _single_imino_n_substituent_name(
     mol: Molecule,
     nitrogen: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     roots = [
         neighbor
@@ -148,7 +148,7 @@ def name_branch_or_none(
     branch_idx: int | None,
     exclude_atoms: set[int],
     upstream_atom: int,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     if branch_idx is None:
         return ""
@@ -163,7 +163,7 @@ def name_carbonyl_like_fragment(
     exclude_atoms: set[int],
     branch_suffix: str,
     fallback: str,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
     amino_base: str | None = None,
     wrap_result: bool = False,
 ) -> str:
@@ -281,7 +281,7 @@ def name_oxygen_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
@@ -342,7 +342,7 @@ def name_nitrogen_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     upstream_order = upstream_bond_order(mol, start_idx, upstream_atom)
     is_double = upstream_order == 2
@@ -431,7 +431,7 @@ def _sulfur_imide_branch_name(
     sulfur: int,
     exclude_atoms: set[int],
     s_oxygens: list[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     """Render an N=S(=O)n branch without collapsing it to sulfo-amino acid wording."""
 
@@ -534,7 +534,7 @@ def name_sulfur_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     s_oxygens = central_oxo_substituent_excluded_ligand_atoms(mol, start_idx, exclude_atoms)
@@ -642,7 +642,7 @@ def name_chalcogen_subgraph(
     simple_prefixes: set[str],
     element_suffix: str,
     oxo_prefix: str,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     oxo_ligands = central_oxo_substituent_excluded_ligand_atoms(mol, start_idx, exclude_atoms)
@@ -697,7 +697,7 @@ def name_phosphorus_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     upstream_order = upstream_bond_order(mol, start_idx, upstream_atom)
     multiple_bond_suffix = {2: "idene", 3: "idyne"}.get(upstream_order, "")
@@ -724,7 +724,7 @@ def name_group_13_14_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     base_suffix = unsubstituted_prefix(mol.atoms[start_idx].symbol) or (
@@ -743,7 +743,7 @@ def name_halogen_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     symbol = mol.atoms[start_idx].symbol
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
@@ -759,7 +759,7 @@ def name_heteroatom_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str | None:
     """Name supported heteroatom-starting recursive fragments."""
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -1,7 +1,5 @@
 """Heteroatom-starting recursive substituent naming."""
 
-from collections.abc import Callable
-
 from .formatting import (
     count_names,
     format_counted_prefixes,
@@ -21,12 +19,11 @@ from .namer_config import (
     SIMPLE_SELANYL_PREFIXES,
     SIMPLE_SULFANYL_PREFIXES,
 )
+from .naming_protocols import BranchNamer
 from .nitrogen_roles import terminal_n3_substituent_role
 from .nomenclature import RULES
 from .oxoacid_roles import OxoLigandRole, central_oxo_substituent_role
 from .rules import multipliers
-
-BranchNamer = Callable[[Molecule, int, set[int], int | None], str]
 
 
 def upstream_bond_order(mol: Molecule, start_idx: int, upstream_atom: int | None) -> int:

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -51,7 +51,11 @@ from .trace_helpers import (
 from .trace_helpers import (
     bond_ids_within as _bond_ids_within,
 )
-from .trace_helpers import decision_trace_data, trace_decision
+from .trace_helpers import (
+    build_shortcut_tree_node,
+    decision_trace_data,
+    trace_decision,
+)
 
 
 @dataclass
@@ -1338,19 +1342,13 @@ def _shortcut_substituent_tree(
 ) -> dict:
     """Return a minimal recursive tree node for shortcut substituent names."""
 
-    node = {
-        "kind": "substituent",
-        "name": name,
-        "atoms": sorted(component),
-        "bonds": sorted(_bond_ids_within(mol, component)),
-        "parent": None,
-        "principal_group": None,
-        "substituents": [],
-        "replacement_prefixes": [],
-        "unsaturations": [],
-        "trace_segments": [],
-        "nested_decisions": decision_trace_data(decision_trace),
-    }
+    node = build_shortcut_tree_node(
+        kind="substituent",
+        name=name,
+        atom_ids=component,
+        bond_ids=_bond_ids_within(mol, component),
+        decisions=decision_trace_data(decision_trace),
+    )
     if direct_prefix is not None:
         node["functional_prefix"] = {
             "kind": "functional_prefix",

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -981,6 +981,11 @@ def _finalize_subgraph_name(name: str, parts: AssemblyParts) -> str:
         and not name.startswith("tricyclo")
     ):
         return name
+    # The stereodescriptor already establishes the fragment's leading
+    # boundary. Its parent will add protective parentheses if the attachment
+    # is locanted, repeated, or otherwise ambiguous.
+    if parts.stereo_features:
+        return name
     return f"({name})"
 
 

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass, field
 
 from .assembler import assemble_name_raw, post_process_rewrite_rules
-from .assembly_parts import AssemblyParts, SubstituentItem
+from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
 from .assembly_spiro import extract_spiro_side_prefixes
 from .chains import find_ring_systems, get_cyclic_atoms
 from .component_namer import name_component as _name_component_impl
@@ -981,12 +981,21 @@ def _finalize_subgraph_name(name: str, parts: AssemblyParts) -> str:
         and not name.startswith("tricyclo")
     ):
         return name
-    # The stereodescriptor already establishes the fragment's leading
-    # boundary. Its parent will add protective parentheses if the attachment
-    # is locanted, repeated, or otherwise ambiguous.
-    if parts.stereo_features:
-        return name
     return f"({name})"
+
+
+def _mark_optional_substituent_boundary(name: str, parts: AssemblyParts, finalize_subgraph: bool) -> str:
+    """Preserve whether construction made a subgraph boundary optional.
+
+    This marker is applied after all name rewrites, since those rewrites return
+    ordinary strings. String composition in a higher recursive layer then
+    intentionally drops the marker, retaining parentheses needed to delimit a
+    compound substituent.
+    """
+
+    if finalize_subgraph and parts.stereo_features:
+        return RenderedSubstituentName(name, outer_parentheses_optional=True)
+    return name
 
 
 def _assemble_parent_name(
@@ -1030,7 +1039,7 @@ def _assemble_parent_name(
                 name = rewrite[1](name)
             else:
                 name = rewrite.rewrite(name)
-        return name
+        return _mark_optional_substituent_boundary(name, parts, finalize_subgraph)
     result = NameAssemblyResult.from_rewrite_pipeline(name, parts.name_atom_bindings, rewrites=tuple(rewrites))
     parts.name_atom_bindings = list(result.bindings)
     parts.name_token_spans = token_span_trace_data(result)
@@ -1072,7 +1081,7 @@ def _assemble_parent_name(
         }
         for operation in result.rewrite_history
     ]
-    return result.text
+    return _mark_optional_substituent_boundary(result.text, parts, finalize_subgraph)
 
 
 def _simple_rooted_carbanion_substituent_name(
@@ -1352,7 +1361,7 @@ def _shortcut_substituent_tree(
         name=name,
         atom_ids=component,
         bond_ids=_bond_ids_within(mol, component),
-        decisions=decision_trace_data(decision_trace),
+        nested_decisions=decision_trace_data(decision_trace),
     )
     if direct_prefix is not None:
         node["functional_prefix"] = {

--- a/src/openclatura/naming_protocols.py
+++ b/src/openclatura/naming_protocols.py
@@ -59,8 +59,3 @@ class RecursiveSubgraphNamer(Protocol):
         return_tree: Literal[True],
         decision_trace: DecisionTrace | None = None,
     ) -> tuple[str, dict | None]: ...
-
-
-# Domain aliases keep call sites readable while sharing one source of truth.
-SubgraphNamer = RecursiveSubgraphNamer
-BranchNamer = RecursiveSubgraphNamer

--- a/src/openclatura/naming_protocols.py
+++ b/src/openclatura/naming_protocols.py
@@ -1,0 +1,66 @@
+"""Shared callable contracts for recursive structure naming."""
+
+from typing import Literal, Protocol, overload
+
+from .molecule import DecisionTrace, Molecule
+
+
+class RecursiveSubgraphNamer(Protocol):
+    """Name a branch, optionally returning trace segments and its tree node."""
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> str: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[True],
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict]]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[True],
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict], dict | None]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, dict | None]: ...
+
+
+# Domain aliases keep call sites readable while sharing one source of truth.
+SubgraphNamer = RecursiveSubgraphNamer
+BranchNamer = RecursiveSubgraphNamer

--- a/src/openclatura/special_cases.py
+++ b/src/openclatura/special_cases.py
@@ -8,6 +8,7 @@ from .assembly_parts import NameAtomBinding, NameTokenBinding
 from .charge_pair_roles import charge_pair_roles
 from .formatting import format_counted_prefixes, format_multiplier, oxy_prefix_from_branch, strip_outer_parentheses
 from .molecule import Molecule
+from .naming_protocols import BranchNamer
 from .nitrogen_roles import azine_roles
 from .nomenclature import RULES
 from .oxoacid_roles import CentralOxoRole, OxoLigandRole, central_oxo_roles
@@ -17,7 +18,6 @@ from .retained_specs import retained_parent_spec
 from .rules import multipliers, retained, stems
 
 ComponentNamer = Callable[..., str]
-BranchNamer = Callable[..., str]
 
 
 @dataclass(frozen=True)

--- a/src/openclatura/special_cases.py
+++ b/src/openclatura/special_cases.py
@@ -8,7 +8,7 @@ from .assembly_parts import NameAtomBinding, NameTokenBinding
 from .charge_pair_roles import charge_pair_roles
 from .formatting import format_counted_prefixes, format_multiplier, oxy_prefix_from_branch, strip_outer_parentheses
 from .molecule import Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nitrogen_roles import azine_roles
 from .nomenclature import RULES
 from .oxoacid_roles import CentralOxoRole, OxoLigandRole, central_oxo_roles
@@ -95,7 +95,7 @@ def single_atom_component_name(mol: Molecule, component_atoms: set[int]) -> str:
 def structural_replacement_parent_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Return a replacement-parent hydride name from graph-derived specs."""
 
@@ -106,7 +106,7 @@ def structural_replacement_parent_name(
 def structural_replacement_parent_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Return a graph-bound replacement-parent hydride name result."""
 
@@ -391,7 +391,7 @@ def _lambda_ring_unsaturation_suffix(mol: Molecule, path: list[int]) -> str:
 def simple_azine_parent_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name simple acyclic ketazines/aldazines from a graph C=N-N=C role."""
 
@@ -439,7 +439,7 @@ def simple_azine_parent_name(
 def phosphane_borane_zwitterion_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name graph-proven B(-)(H)3-P(+) zwitterions as boranuide parents."""
 
@@ -450,7 +450,7 @@ def phosphane_borane_zwitterion_name(
 def phosphane_borane_zwitterion_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Name graph-proven B(-)(H)3-P(+) zwitterions with bound ligands and charges."""
 
@@ -856,7 +856,7 @@ def _hydrazone_stereo_prefix(mol: Molecule, carbon: int, nitrogen: int, parent_n
 def sulfonium_ylide_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name graph-proven sulfonium/carbanion ylides as full components."""
 
@@ -951,7 +951,7 @@ def sulfonium_ylide_name(
 def sulfonium_ylide_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Return a typed sulfonium ylide result for the graph-proven renderer."""
 
@@ -1025,7 +1025,7 @@ def _linear_alkyl_carbanion_parent_name(mol: Molecule, carbon_atoms: set[int], r
 def hydroxyurea_parent_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name graph-proven N-hydroxyureas without carbamic-acid fallback wording."""
 
@@ -1036,7 +1036,7 @@ def hydroxyurea_parent_name(
 def hydroxyurea_parent_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Name graph-proven N-hydroxyureas with core/hydroxy/ligand bindings."""
 
@@ -1163,7 +1163,7 @@ def _urea_n_ligand_names(
     component_atoms: set[int],
     nitrogen: int,
     core_atoms: set[int],
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> list[tuple[set[int], str]] | None:
     ligands = []
     for root in mol.get_neighbors(nitrogen):
@@ -1254,7 +1254,7 @@ def oxoacid_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialCo
 def oxoacid_ester_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name organic esters of data-backed oxoacid parent hydrides."""
 
@@ -1265,7 +1265,7 @@ def oxoacid_ester_name(
 def oxoacid_ester_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Name organic esters with separate modifier and central-oxo suffix bindings."""
 
@@ -1328,7 +1328,7 @@ def _peroxy_oxoacid_ester_name(
     component_atoms: set[int],
     role: CentralOxoRole,
     suffix: str,
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> str:
     result = _peroxy_oxoacid_ester_result(mol, component_atoms, role, suffix, branch_namer)
     return result.name if result is not None else ""
@@ -1339,7 +1339,7 @@ def _peroxy_oxoacid_ester_result(
     component_atoms: set[int],
     role: CentralOxoRole,
     suffix: str,
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> SpecialComponentName | None:
     peroxy_ligands = [ligand for ligand in role.ligands if ligand.role == OxoLigandRole.PEROXY]
     if len(peroxy_ligands) != 1 or not suffix:
@@ -1478,7 +1478,7 @@ def _ester_modifier_name(
     root: int,
     ester_oxygen: int,
     acid_atoms: set[int],
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> str:
     if branch_namer is not None:
         name = branch_namer(mol, root, set(mol.atoms) - component_atoms | acid_atoms, upstream_atom=ester_oxygen)

--- a/src/openclatura/substituent_tokens.py
+++ b/src/openclatura/substituent_tokens.py
@@ -1,16 +1,14 @@
 """Graph-derived emitted-token metadata for composed substituent prefixes."""
 
 import re
-from collections.abc import Callable
 
 from .assembly_parts import NameTokenBinding
 from .formatting import strip_outer_parentheses
 from .molecule import Molecule
+from .naming_protocols import BranchNamer
 from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, RELATIVE_STEREO_DESCRIPTORS
 from .token_grammar import is_locant_token, lexical_token_spans, lexical_tokens
 from .trace_helpers import bond_ids_within
-
-BranchNamer = Callable[..., str]
 
 
 def graph_bound_substituent_tokens(

--- a/src/openclatura/substituent_tokens.py
+++ b/src/openclatura/substituent_tokens.py
@@ -5,7 +5,7 @@ import re
 from .assembly_parts import NameTokenBinding
 from .formatting import strip_outer_parentheses
 from .molecule import Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, RELATIVE_STEREO_DESCRIPTORS
 from .token_grammar import is_locant_token, lexical_token_spans, lexical_tokens
 from .trace_helpers import bond_ids_within
@@ -18,7 +18,7 @@ def graph_bound_substituent_tokens(
     term: str,
     upstream_atom: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[NameTokenBinding, ...]:
     """Return precise token bindings for graph-composed substituent terms."""
 
@@ -100,7 +100,7 @@ def _generic_heteroatom_substituent_tokens(
     term: str,
     upstream_atom: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[NameTokenBinding, ...]:
     """Return graph-bound tokens for non-nitrogen heteroatom-center prefixes."""
 
@@ -492,7 +492,7 @@ def _nitrogen_substituent_tokens(
     term: str,
     upstream_atom: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[NameTokenBinding, ...]:
     term_text = strip_outer_parentheses(term)
     lower_term = term_text.lower()

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -26,6 +26,7 @@ from openclatura.assembly_parts import (
     NameTokenBinding,
     ParentChargeItem,
     PrincipalGroupItem,
+    RenderedSubstituentName,
     SubstituentItem,
     UnsaturationItem,
 )
@@ -279,7 +280,13 @@ def test_substituent_suffix_metadata_is_emitted_by_assembly_parts():
 
 def test_tree_builders_share_schema_without_mutable_defaults():
     assembled = build_naming_tree_node(kind="fragment", name="ethyl", atom_ids={2, 1}, bond_ids={7})
-    shortcut = build_shortcut_tree_node(kind="component", name="methane", atom_ids={0})
+    nested_decisions = [{"decision": "shortcut selected"}]
+    shortcut = build_shortcut_tree_node(
+        kind="component",
+        name="methane",
+        atom_ids={0},
+        nested_decisions=nested_decisions,
+    )
 
     common_keys = {
         "kind",
@@ -297,6 +304,7 @@ def test_tree_builders_share_schema_without_mutable_defaults():
     assert common_keys <= assembled.keys()
     assert common_keys <= shortcut.keys()
     assert assembled["atoms"] == [1, 2]
+    assert shortcut["nested_decisions"] == nested_decisions
     assembled["substituents"].append({"name": "methyl"})
     assert shortcut["substituents"] == []
 
@@ -318,12 +326,27 @@ def test_locanted_stereochemical_substituent_keeps_disambiguating_parentheses():
         retained_name="benzene",
         parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 7)},
         substituents=[
-            SubstituentItem(name="((3R)-3-cyclohexylcyclohexyl)", locants=["1"]),
+            SubstituentItem(
+                name=RenderedSubstituentName(
+                    "((3R)-3-cyclohexylcyclohexyl)",
+                    outer_parentheses_optional=True,
+                ),
+                locants=["1"],
+            ),
             SubstituentItem(name="methyl", locants=["4"]),
         ],
     )
 
     assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)-4-methylbenzene"
+
+
+def test_nested_stereochemical_substituent_keeps_semantic_boundary():
+    smiles = "CC1=CCCC[C@@H]1C(NCCCn1ccnc1)c1nnnn1C1CCCC1"
+
+    assert name_smiles(smiles) == (
+        "N-((1-cyclopentyl-1H-tetrazol-5-yl)((1S)-2-methylcyclohex-2-en-1-yl)methyl)-"
+        "3-(1H-imidazol-1-yl)propan-1-amine"
+    )
 
 
 def test_hydrogen_cyanide_absorbed_nitrile_name_passes_final_audit():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -344,8 +344,7 @@ def test_nested_stereochemical_substituent_keeps_semantic_boundary():
     smiles = "CC1=CCCC[C@@H]1C(NCCCn1ccnc1)c1nnnn1C1CCCC1"
 
     assert name_smiles(smiles) == (
-        "N-((1-cyclopentyl-1H-tetrazol-5-yl)((1S)-2-methylcyclohex-2-en-1-yl)methyl)-"
-        "3-(1H-imidazol-1-yl)propan-1-amine"
+        "N-((1-cyclopentyl-1H-tetrazol-5-yl)((1S)-2-methylcyclohex-2-en-1-yl)methyl)-3-(1H-imidazol-1-yl)propan-1-amine"
     )
 
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -104,7 +104,6 @@ from openclatura.namer import (
 )
 from openclatura.naming_audit import UnnamedAtomError, assert_component_fully_named, audit_charge_pair_templates
 from openclatura.naming_data import DATA_DIR, load_json_table, namer_rules
-from openclatura.naming_protocols import BranchNamer, RecursiveSubgraphNamer, SubgraphNamer
 from openclatura.nitrogen_roles import (
     acid_derived_hydrazone_roles,
     azine_roles,
@@ -276,11 +275,6 @@ def test_substituent_suffix_metadata_is_emitted_by_assembly_parts():
         "is_double_attach": False,
         "is_triple_attach": False,
     }
-
-
-def test_recursive_namer_roles_share_one_callable_protocol():
-    assert BranchNamer is RecursiveSubgraphNamer
-    assert SubgraphNamer is RecursiveSubgraphNamer
 
 
 def test_tree_builders_share_schema_without_mutable_defaults():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -305,6 +305,27 @@ def test_methane_is_named_without_parent_selection_fallback():
     assert name_smiles("C") == "methane"
 
 
+def test_single_unlocanted_stereochemical_substituent_omits_optional_outer_parentheses():
+    smiles = "C1(CCCCC1)[C@H]1CC(CCC1)C1=CC=CC=C1"
+
+    assert name_smiles(smiles) == "(3R)-3-cyclohexylcyclohexylbenzene"
+
+
+def test_locanted_stereochemical_substituent_keeps_disambiguating_parentheses():
+    parts = AssemblyParts(
+        parent_length=6,
+        is_ring=True,
+        retained_name="benzene",
+        parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 7)},
+        substituents=[
+            SubstituentItem(name="((3R)-3-cyclohexylcyclohexyl)", locants=["1"]),
+            SubstituentItem(name="methyl", locants=["4"]),
+        ],
+    )
+
+    assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)-4-methylbenzene"
+
+
 def test_hydrogen_cyanide_absorbed_nitrile_name_passes_final_audit():
     assert name_smiles("C#N") == "hydrogen cyanide"
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -104,6 +104,7 @@ from openclatura.namer import (
 )
 from openclatura.naming_audit import UnnamedAtomError, assert_component_fully_named, audit_charge_pair_templates
 from openclatura.naming_data import DATA_DIR, load_json_table, namer_rules
+from openclatura.naming_protocols import BranchNamer, RecursiveSubgraphNamer, SubgraphNamer
 from openclatura.nitrogen_roles import (
     acid_derived_hydrazone_roles,
     azine_roles,
@@ -172,7 +173,13 @@ from openclatura.token_grammar import (
     is_locant_token,
     lexical_token_spans,
 )
-from openclatura.trace_helpers import add_substituent_trace, assembly_substituent_tree, assembly_trace_segments
+from openclatura.trace_helpers import (
+    add_substituent_trace,
+    assembly_substituent_tree,
+    assembly_trace_segments,
+    build_naming_tree_node,
+    build_shortcut_tree_node,
+)
 from openclatura.von_baeyer import _classify_secondary_bridges, find_von_baeyer_candidates
 
 
@@ -268,6 +275,35 @@ def test_substituent_suffix_metadata_is_emitted_by_assembly_parts():
         "is_double_attach": False,
         "is_triple_attach": False,
     }
+
+
+def test_recursive_namer_roles_share_one_callable_protocol():
+    assert BranchNamer is RecursiveSubgraphNamer
+    assert SubgraphNamer is RecursiveSubgraphNamer
+
+
+def test_tree_builders_share_schema_without_mutable_defaults():
+    assembled = build_naming_tree_node(kind="fragment", name="ethyl", atom_ids={2, 1}, bond_ids={7})
+    shortcut = build_shortcut_tree_node(kind="component", name="methane", atom_ids={0})
+
+    common_keys = {
+        "kind",
+        "name",
+        "atoms",
+        "bonds",
+        "parent",
+        "principal_group",
+        "substituents",
+        "replacement_prefixes",
+        "unsaturations",
+        "trace_segments",
+        "nested_decisions",
+    }
+    assert common_keys <= assembled.keys()
+    assert common_keys <= shortcut.keys()
+    assert assembled["atoms"] == [1, 2]
+    assembled["substituents"].append({"name": "methyl"})
+    assert shortcut["substituents"] == []
 
 
 def test_methane_is_named_without_parent_selection_fallback():

--- a/src/openclatura/trace_helpers.py
+++ b/src/openclatura/trace_helpers.py
@@ -341,6 +341,71 @@ def attach_main_parent_decisions(
     return enriched
 
 
+def build_naming_tree_node(
+    *,
+    kind: str,
+    name: str,
+    atom_ids=None,
+    bond_ids=None,
+    parent=None,
+    principal_group=None,
+    substituents=None,
+    replacement_prefixes=None,
+    unsaturations=None,
+    trace_segments=None,
+    nested_decisions=None,
+    metadata: dict | None = None,
+) -> dict:
+    """Build the invariant portion of every component/substituent tree node."""
+
+    node = {
+        "kind": kind,
+        "name": name,
+        "atoms": sorted(atom_ids or ()),
+        "bonds": sorted(bond_ids or ()),
+        "parent": parent,
+        "principal_group": principal_group,
+        "substituents": list(substituents or ()),
+        "replacement_prefixes": list(replacement_prefixes or ()),
+        "unsaturations": list(unsaturations or ()),
+        "trace_segments": list(trace_segments or ()),
+        "nested_decisions": list(nested_decisions or ()),
+    }
+    if metadata:
+        overlapping_keys = node.keys() & metadata.keys()
+        if overlapping_keys:
+            raise ValueError(f"Tree metadata cannot replace invariant fields: {sorted(overlapping_keys)}")
+        node.update(metadata)
+    return node
+
+
+def build_shortcut_tree_node(
+    *,
+    kind: str,
+    name: str,
+    atom_ids,
+    bond_ids=None,
+    decisions=None,
+    name_atom_bindings: list[dict] | None = None,
+    name_token_spans: list[dict] | None = None,
+) -> dict:
+    """Build a schema-complete tree node for a shortcut-rendered name."""
+
+    metadata = {}
+    if name_atom_bindings is not None:
+        metadata["name_atom_bindings"] = list(name_atom_bindings)
+    if name_token_spans is not None:
+        metadata["name_token_spans"] = list(name_token_spans)
+    return build_naming_tree_node(
+        kind=kind,
+        name=name,
+        atom_ids=atom_ids,
+        bond_ids=bond_ids,
+        nested_decisions=decisions,
+        metadata=metadata,
+    )
+
+
 def assembly_substituent_tree(
     parts: AssemblyParts,
     *,
@@ -356,16 +421,16 @@ def assembly_substituent_tree(
         trace_segments = assembly_trace_segments(parts)
     component_atoms = set(atom_ids or parts.parent_atom_ids)
     component_bonds = set(bond_ids or parts.parent_bond_ids)
-    parent_node = {
-        "kind": "fragment",
-        "name": name,
-        "atoms": sorted(component_atoms),
-        "bonds": sorted(component_bonds),
-        "parent": _parent_tree_node(parts),
-        "principal_group": _principal_group_tree_node(parts),
-        "substituents": _substituent_tree_nodes(parts.substituents),
-        "replacement_prefixes": _simple_item_tree_nodes(parts.a_prefixes, "replacement_prefix"),
-        "unsaturations": [
+    return build_naming_tree_node(
+        kind="fragment",
+        name=name,
+        atom_ids=component_atoms,
+        bond_ids=component_bonds,
+        parent=_parent_tree_node(parts),
+        principal_group=_principal_group_tree_node(parts),
+        substituents=_substituent_tree_nodes(parts.substituents),
+        replacement_prefixes=_simple_item_tree_nodes(parts.a_prefixes, "replacement_prefix"),
+        unsaturations=[
             {
                 "kind": "unsaturation",
                 "bond_key": item.bond_key,
@@ -375,33 +440,34 @@ def assembly_substituent_tree(
             }
             for item in parts.unsaturations
         ],
-        "stereo_features": [
-            {"descriptor": descriptor, "locant": locant} for descriptor, locant in parts.stereo_features
-        ],
-        "indicated_hydrogens": list(parts.indicated_hydrogens),
-        "hydro_operations": [
-            {
-                "key": operation.key,
-                "reason": operation.reason,
-                "locants": list(operation.locants),
-                "atom_ids": sorted(operation.atom_ids),
-                "operation_kind": operation.operation_kind,
-            }
-            for operation in parts.hydro_operations
-        ],
-        "parent_charges": [
-            {
-                "locant": item.locant,
-                "symbol": item.symbol,
-                "charge": item.charge,
-                "atom_id": item.atom_id,
-            }
-            for item in parts.parent_charges
-        ],
-        "trace_segments": list(trace_segments),
-        "nested_decisions": list(decisions or ()),
-    }
-    return parent_node
+        trace_segments=trace_segments,
+        nested_decisions=decisions,
+        metadata={
+            "stereo_features": [
+                {"descriptor": descriptor, "locant": locant} for descriptor, locant in parts.stereo_features
+            ],
+            "indicated_hydrogens": list(parts.indicated_hydrogens),
+            "hydro_operations": [
+                {
+                    "key": operation.key,
+                    "reason": operation.reason,
+                    "locants": list(operation.locants),
+                    "atom_ids": sorted(operation.atom_ids),
+                    "operation_kind": operation.operation_kind,
+                }
+                for operation in parts.hydro_operations
+            ],
+            "parent_charges": [
+                {
+                    "locant": item.locant,
+                    "symbol": item.symbol,
+                    "charge": item.charge,
+                    "atom_id": item.atom_id,
+                }
+                for item in parts.parent_charges
+            ],
+        },
+    )
 
 
 def _merge_substituent_tree_instances(existing: dict | None, new: dict, name: str) -> dict:

--- a/src/openclatura/trace_helpers.py
+++ b/src/openclatura/trace_helpers.py
@@ -385,7 +385,7 @@ def build_shortcut_tree_node(
     name: str,
     atom_ids,
     bond_ids=None,
-    decisions=None,
+    nested_decisions=None,
     name_atom_bindings: list[dict] | None = None,
     name_token_spans: list[dict] | None = None,
 ) -> dict:
@@ -401,7 +401,7 @@ def build_shortcut_tree_node(
         name=name,
         atom_ids=atom_ids,
         bond_ids=bond_ids,
-        nested_decisions=decisions,
+        nested_decisions=nested_decisions,
         metadata=metadata,
     )
 


### PR DESCRIPTION
## Summary by Sourcery

Unify recursive subgraph naming and tree construction, and refine how stereochemical substituent boundaries are represented and formatted.

New Features:
- Introduce shared RecursiveSubgraphNamer protocol for branch and component subgraph naming with optional trace and tree outputs.
- Add RenderedSubstituentName type to carry metadata about optional outer parentheses around substituent names.

Enhancements:
- Factor out build_naming_tree_node and build_shortcut_tree_node helpers to standardize naming tree schema and avoid mutable default issues.
- Refactor shortcut component and substituent tree construction to use the shared tree builders.
- Adjust parent name assembly to mark when substituent boundaries are optional, enabling downstream formatting decisions.
- Update substituent and prefix formatting to optionally drop outer parentheses when the substituent boundary is semantically clear.

Tests:
- Add tests verifying that naming tree builders share a common schema without mutable defaults.
- Add tests covering stereochemical substituent naming and the conditions under which outer parentheses are omitted or retained.