### PR TITLE
feat: add naming feature from rdkit mol obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ results = name_many(
 [r.name for r in results if r.ok]
 ```
 
+### Naming an existing RDKit molecule
+
+If you already hold an `rdkit.Chem.rdchem.Mol` — from an SD file, a reaction,
+or an earlier step in a pipeline — skip the SMILES round-trip:
+
+```python
+from rdkit import Chem
+from openclatura import name_rdkit_mol, name_mol, name_many
+
+for mol in Chem.SDMolSupplier("compounds.sdf"):
+    if mol is not None:
+        print(name_rdkit_mol(mol))          # -> 'benzoic acid'
+
+name_mol(mol)                                # typed NamingResult, as `name`
+name_many([mol, "CCO"])                      # batches take either form
+```
+
+The input molecule is never modified, explicit hydrogens (as SD files usually
+carry them) are handled, and `name_rdkit_mol_with_trace` / `analyze_rdkit_mol`
+mirror their SMILES counterparts.
+
 For the full decision trace (one `TraceStep` per phase: parse, perception,
 parent selection, numbering, assembly, …):
 

--- a/src/openclatura/__init__.py
+++ b/src/openclatura/__init__.py
@@ -1,6 +1,7 @@
 """openclatura — deterministic SMILES → IUPAC name generator."""
 
 from collections.abc import Iterable
+from typing import Any
 
 from .describer import DescribedComponent, Description, DescriptionTokenSummary, describe
 from .engine import DEFAULT_NAMING_ENGINE, NamingEngine, NamingRequest, NamingResult
@@ -17,7 +18,14 @@ from .molecule import (
     TracePhase,
     TraceStep,
 )
-from .namer import analyze_smiles, name_smiles, name_smiles_with_trace
+from .namer import (
+    analyze_rdkit_mol,
+    analyze_smiles,
+    name_rdkit_mol,
+    name_rdkit_mol_with_trace,
+    name_smiles,
+    name_smiles_with_trace,
+)
 from .naming_context import NamingIntent
 from .nomenclature import RULES, registry
 from .opsin_verify import OpsinCheck, OpsinStatus, opsin_available, verify_with_opsin
@@ -48,8 +56,33 @@ def name(
     )
 
 
+def name_mol(
+    rdkit_mol,
+    *,
+    include_trace: bool = False,
+    verify_opsin: bool = False,
+    token_debug: bool = False,
+) -> NamingResult:
+    """One-shot naming of an existing RDKit molecule. Returns a ``NamingResult``.
+
+    The molecule-shaped counterpart of :func:`name`, for callers who already
+    have an ``rdkit.Chem.rdchem.Mol`` (say from an SD file) and would rather
+    not round-trip through SMILES.  The input molecule is left unmodified, and
+    ``result.smiles`` is only populated when ``verify_opsin`` requires it.
+    """
+
+    return DEFAULT_NAMING_ENGINE.run(
+        NamingRequest(
+            rdkit_mol=rdkit_mol,
+            include_trace=include_trace,
+            verify_opsin=verify_opsin,
+            token_debug=token_debug,
+        )
+    )
+
+
 def name_many(
-    smiles_iter: Iterable[str],
+    smiles_iter: Iterable[str | Any],
     *,
     include_trace: bool = False,
     verify_opsin: bool = False,
@@ -57,7 +90,10 @@ def name_many(
     processes: int | None | str = 1,
     chunksize: int = 64,
 ) -> list[NamingResult]:
-    """Batch convenience wrapper around :meth:`NamingEngine.name_many`."""
+    """Batch convenience wrapper around :meth:`NamingEngine.name_many`.
+
+    Items may be SMILES strings or RDKit molecules, in any mix.
+    """
 
     if processes == "auto":
         processes = None
@@ -72,7 +108,7 @@ def name_many(
     )
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.5"
 
 __all__ = [
     "AtomBinding",
@@ -96,11 +132,15 @@ __all__ = [
     "TracePhase",
     "TraceStep",
     "__version__",
+    "analyze_rdkit_mol",
     "analyze_smiles",
     "describe",
     "describe_human",
     "name",
     "name_many",
+    "name_mol",
+    "name_rdkit_mol",
+    "name_rdkit_mol_with_trace",
     "name_smiles",
     "name_smiles_with_trace",
     "opsin_available",

--- a/src/openclatura/engine.py
+++ b/src/openclatura/engine.py
@@ -14,8 +14,8 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field, replace
 from typing import Any
 
-from .graph_io import get_connected_components, read_smiles
-from .molecule import DecisionTrace, NameAnalysis, TracePhase
+from .graph_io import get_connected_components, read_rdkit_mol, read_smiles
+from .molecule import DecisionTrace, Molecule, NameAnalysis, TracePhase
 from .namer_config import SALT_METAL_NAMES
 from .operations import infer_operations
 from .opsin_verify import OpsinCheck, verify_with_opsin
@@ -61,12 +61,18 @@ class NamingRequest:
     the generated name back through OPSIN and compares the canonical
     SMILES to the input.  Verification is graceful when py2opsin or Java
     are missing (see :class:`openclatura.opsin_verify.OpsinCheck`).
+
+    Structures arrive either as ``smiles`` or as an already-parsed
+    ``rdkit_mol`` (``rdkit.Chem.rdchem.Mol``); when a molecule is given, a
+    SMILES is only generated if something downstream actually needs one, so
+    callers holding an RDKit molecule or an SD record pay no round-trip cost.
     """
 
-    smiles: str
+    smiles: str = ""
     include_trace: bool = False
     verify_opsin: bool = False
     token_debug: bool = False
+    rdkit_mol: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -150,6 +156,25 @@ class NamingEngine:
 
         return self.name(smiles)
 
+    def name_rdkit_mol(self, rdkit_mol: Any) -> str:
+        """Return the generated name for an existing ``rdkit.Chem.rdchem.Mol``."""
+
+        return self.run(NamingRequest(rdkit_mol=rdkit_mol)).name
+
+    def name_rdkit_mol_with_trace(self, rdkit_mol: Any) -> tuple[str, list[dict]]:
+        """Return the generated name and assembly trace for an RDKit molecule."""
+
+        result = self.run(NamingRequest(rdkit_mol=rdkit_mol, include_trace=True))
+        return result.name, result.trace_segments
+
+    def analyze_rdkit_mol(self, rdkit_mol: Any, *, token_debug: bool = False) -> NameAnalysis:
+        """Return the full explainable naming analysis for an RDKit molecule."""
+
+        result = self.run(NamingRequest(rdkit_mol=rdkit_mol, include_trace=True, token_debug=token_debug))
+        if result.analysis is None:
+            return NameAnalysis(result.name, result.trace_segments, result.decisions, result.substituent_tree)
+        return result.analysis
+
     def name_with_trace(self, smiles: str) -> tuple[str, list[dict]]:
         """Return the generated name and assembly trace segments."""
 
@@ -183,12 +208,13 @@ class NamingEngine:
         """
 
         try:
+            mol, smiles = self._prepare_input(request)
             if request.include_trace or request.verify_opsin:
-                analysis = self._analyze(request.smiles, token_debug=request.token_debug)
+                analysis = self._analyze(mol, smiles=smiles, token_debug=request.token_debug)
                 rules, hints = _extract_rules_hit(analysis.trace_segments)
                 result = NamingResult(
                     name=analysis.name,
-                    smiles=request.smiles,
+                    smiles=smiles,
                     trace_segments=analysis.trace_segments,
                     substituent_tree=analysis.substituent_tree,
                     decisions=analysis.decisions,
@@ -197,19 +223,19 @@ class NamingEngine:
                     rule_hints=hints,
                 )
             else:
-                result = NamingResult(name=self._name(request.smiles), smiles=request.smiles)
+                result = NamingResult(name=self._name(mol), smiles=smiles)
         except Exception as exc:  # noqa: BLE001 - intentionally permissive boundary
             return NamingResult(name="", smiles=request.smiles, error=f"{type(exc).__name__}: {exc}")
 
         if request.verify_opsin:
-            check = verify_with_opsin(result.name, request.smiles)
+            check = verify_with_opsin(result.name, result.smiles)
             result = replace(result, opsin_check=check)
 
         return result
 
     def name_many(
         self,
-        smiles_iter: Iterable[str],
+        smiles_iter: Iterable[str | Any],
         *,
         include_trace: bool = False,
         verify_opsin: bool = False,
@@ -217,7 +243,7 @@ class NamingEngine:
         processes: int | None | str = 1,
         chunksize: int = 64,
     ) -> list[NamingResult]:
-        """Name a batch of SMILES, optionally in parallel.
+        """Name a batch of SMILES (or RDKit molecules), optionally in parallel.
 
         ``processes=1`` runs in the current process (good default for
         notebooks and short scripts). ``processes=None`` uses all CPU
@@ -232,14 +258,14 @@ class NamingEngine:
         if processes == 1:
             return [
                 self.run(
-                    NamingRequest(
-                        smiles=s,
+                    _request_for(
+                        item,
                         include_trace=include_trace,
                         verify_opsin=verify_opsin,
                         token_debug=token_debug,
                     )
                 )
-                for s in smiles_list
+                for item in smiles_list
             ]
 
         worker_count = processes if processes is not None else os.cpu_count() or 1
@@ -252,8 +278,25 @@ class NamingEngine:
             chunksize=chunksize,
         )
 
-    def _name(self, smiles: str) -> str:
-        mol = read_smiles(smiles)
+    @staticmethod
+    def _prepare_input(request: NamingRequest) -> tuple[Molecule, str]:
+        """Build the internal graph from whichever input the request carries.
+
+        For RDKit input the SMILES stays empty unless it is needed (OPSIN
+        verification), so the common case never pays for ``MolToSmiles``.
+        """
+
+        if request.rdkit_mol is None:
+            return read_smiles(request.smiles), request.smiles
+
+        smiles = request.smiles
+        if not smiles and request.verify_opsin:
+            from rdkit import Chem
+
+            smiles = Chem.MolToSmiles(request.rdkit_mol)
+        return read_rdkit_mol(request.rdkit_mol), smiles
+
+    def _name(self, mol: Molecule) -> str:
         if not mol.atoms:
             return ""
 
@@ -265,9 +308,8 @@ class NamingEngine:
         names.sort(key=self._component_sort_key)
         return " ".join(names)
 
-    def _analyze(self, smiles: str, *, token_debug: bool = False) -> NameAnalysis:
+    def _analyze(self, mol: Molecule, *, smiles: str = "", token_debug: bool = False) -> NameAnalysis:
         decisions = DecisionTrace()
-        mol = read_smiles(smiles)
         trace_decision(
             decisions,
             TracePhase.PARSE,
@@ -345,15 +387,33 @@ DEFAULT_NAMING_ENGINE = NamingEngine()
 # --- multiprocessing helpers ---------------------------------------------
 
 
-def _name_one_for_worker(args: tuple[str, bool, bool, bool]) -> NamingResult:
-    smiles, include_trace, verify_opsin, token_debug = args
+def _request_for(
+    item: str | Any,
+    *,
+    include_trace: bool,
+    verify_opsin: bool,
+    token_debug: bool,
+) -> NamingRequest:
+    """Build a request from a batch item, which may be a SMILES or an RDKit molecule."""
+
+    kwargs: dict[str, Any] = {"smiles": item} if isinstance(item, str) else {"rdkit_mol": item}
+    return NamingRequest(
+        include_trace=include_trace,
+        verify_opsin=verify_opsin,
+        token_debug=token_debug,
+        **kwargs,
+    )
+
+
+def _name_one_for_worker(args: tuple[str | Any, bool, bool, bool]) -> NamingResult:
+    item, include_trace, verify_opsin, token_debug = args
     return DEFAULT_NAMING_ENGINE.run(
-        NamingRequest(smiles=smiles, include_trace=include_trace, verify_opsin=verify_opsin, token_debug=token_debug)
+        _request_for(item, include_trace=include_trace, verify_opsin=verify_opsin, token_debug=token_debug)
     )
 
 
 def _run_parallel(
-    smiles_list: list[str],
+    smiles_list: list[str | Any],
     *,
     include_trace: bool,
     verify_opsin: bool,

--- a/src/openclatura/graph_io.py
+++ b/src/openclatura/graph_io.py
@@ -22,6 +22,62 @@ def read_smiles(smiles: str) -> Molecule:
         except Exception:
             pass
 
+    return _build_molecule(rdmol, atom_metadata)
+
+
+def read_rdkit_mol(rdmol: Chem.Mol | None, *, copy: bool = True) -> Molecule:
+    """Convert an existing RDKit molecule into the internal graph model.
+
+    Naming needs a kekulized graph, so the input is copied by default and the
+    caller's molecule is left untouched.  Pass ``copy=False`` only when the
+    molecule is a throwaway.  Molecules that were never sanitized (for example
+    ``MolFromSmiles(..., sanitize=False)`` or a partially read SD record) get
+    the minimal property-cache and ring perception the namer relies on.
+
+    Explicit hydrogens, as SD records usually carry them, are folded back into
+    implicit hydrogen counts; that renumbers the heavy atoms of such a
+    molecule, so atom indices in a trace refer to the hydrogen-suppressed
+    graph rather than to the input molecule.
+    """
+
+    if rdmol is None:
+        return Molecule()
+    if copy:
+        rdmol = Chem.Mol(rdmol)
+
+    _ensure_perception(rdmol)
+    if any(atom.GetAtomicNum() == 1 for atom in rdmol.GetAtoms()):
+        try:
+            rdmol = Chem.RemoveHs(rdmol, sanitize=False)
+            _ensure_perception(rdmol)
+        except Exception:
+            pass
+
+    atom_metadata = _atom_metadata(rdmol)
+    try:
+        Chem.Kekulize(rdmol, clearAromaticFlags=True)
+    except Exception:
+        pass
+
+    return _build_molecule(rdmol, atom_metadata)
+
+
+def _ensure_perception(rdmol: Chem.Mol) -> None:
+    """Give an externally supplied molecule the valence and ring data we need."""
+
+    try:
+        rdmol.UpdatePropertyCache(strict=False)
+    except Exception:
+        pass
+    try:
+        rdmol.GetRingInfo().NumRings()
+    except RuntimeError:
+        Chem.FastFindRings(rdmol)
+
+
+def _build_molecule(rdmol: Chem.Mol | None, atom_metadata: dict | None) -> Molecule:
+    """Populate the internal graph model from a prepared RDKit molecule."""
+
     mol = Molecule()
     if rdmol is None:
         return mol

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -1744,3 +1744,26 @@ def name_smiles(smiles: str) -> str:
     """
 
     return DEFAULT_NAMING_ENGINE.name_smiles(smiles)
+
+
+def name_rdkit_mol(rdkit_mol) -> str:
+    """Return an IUPAC-style name for an existing ``rdkit.Chem.rdchem.Mol``.
+
+    Equivalent to :func:`name_smiles` without the SMILES round-trip, for
+    callers that already hold an RDKit molecule (for example from an SD file).
+    The input molecule is not modified.
+    """
+
+    return DEFAULT_NAMING_ENGINE.name_rdkit_mol(rdkit_mol)
+
+
+def name_rdkit_mol_with_trace(rdkit_mol) -> tuple[str, list[dict]]:
+    """RDKit-molecule counterpart of :func:`name_smiles_with_trace`."""
+
+    return DEFAULT_NAMING_ENGINE.name_rdkit_mol_with_trace(rdkit_mol)
+
+
+def analyze_rdkit_mol(rdkit_mol, *, token_debug: bool = False) -> NameAnalysis:
+    """RDKit-molecule counterpart of :func:`analyze_smiles`."""
+
+    return DEFAULT_NAMING_ENGINE.analyze_rdkit_mol(rdkit_mol, token_debug=token_debug)

--- a/src/openclatura/tests/test_public_api.py
+++ b/src/openclatura/tests/test_public_api.py
@@ -16,10 +16,15 @@ from openclatura import (
     NamingRequest,
     NamingResult,
     OpsinCheck,
+    analyze_rdkit_mol,
     analyze_smiles,
     name,
     name_many,
+    name_mol,
+    name_rdkit_mol,
+    name_rdkit_mol_with_trace,
     name_smiles,
+    name_smiles_with_trace,
 )
 
 
@@ -292,3 +297,80 @@ def test_name_many_parallel_and_serial_agree(processes):
     serial = name_many(inputs, processes=1)
     other = name_many(inputs, processes=processes)
     assert [r.name for r in serial] == [r.name for r in other]
+
+
+# --- RDKit molecule input -------------------------------------------------
+
+
+def _mol(smiles: str):
+    from rdkit import Chem
+
+    return Chem.MolFromSmiles(smiles)
+
+
+def test_name_rdkit_mol_matches_name_smiles():
+    smiles = "CC(=O)Oc1ccccc1C(=O)O"
+    assert name_rdkit_mol(_mol(smiles)) == name_smiles(smiles)
+
+
+def test_name_rdkit_mol_leaves_the_callers_molecule_untouched():
+    from rdkit import Chem
+
+    smiles = "c1ccccc1C(=O)O"
+    mol = _mol(smiles)
+    name_rdkit_mol(mol)
+    # Naming kekulizes internally; the caller's aromatic molecule must survive.
+    assert Chem.MolToSmiles(mol) == Chem.MolToSmiles(_mol(smiles))
+    assert all(atom.GetIsAromatic() for atom in mol.GetAtoms() if atom.IsInRing())
+
+
+def test_name_mol_returns_naming_result_without_generating_smiles():
+    result = name_mol(_mol("CCO"))
+    assert isinstance(result, NamingResult)
+    assert result.name == "ethanol"
+    assert result.ok is True
+    # No SMILES round-trip is paid for unless something downstream needs one.
+    assert result.smiles == ""
+
+
+def test_name_mol_populates_smiles_when_opsin_verification_needs_it(monkeypatch):
+    seen = {}
+
+    def fake_verify(name_str, smiles):
+        seen["smiles"] = smiles
+        return OpsinCheck(status="skipped_no_opsin", name=name_str)
+
+    monkeypatch.setattr("openclatura.engine.verify_with_opsin", fake_verify)
+    result = name_mol(_mol("CCO"), verify_opsin=True)
+    # The molecule had no SMILES of its own, so one is derived for the check.
+    assert result.smiles == "CCO"
+    assert seen["smiles"] == "CCO"
+
+
+def test_name_rdkit_mol_reads_sd_style_molecules_with_explicit_hydrogens():
+    from rdkit import Chem
+
+    block = Chem.MolToMolBlock(Chem.AddHs(_mol("c1ccccc1C(=O)O")))
+    with_hs = Chem.MolFromMolBlock(block, removeHs=False)
+    assert name_rdkit_mol(with_hs) == "benzoic acid"
+
+    unsanitized = Chem.MolFromMolBlock(block, sanitize=False)
+    assert name_rdkit_mol(unsanitized) == "benzoic acid"
+
+
+def test_name_rdkit_mol_of_none_is_an_empty_name():
+    assert name_rdkit_mol(None) == ""
+
+
+def test_name_rdkit_mol_with_trace_and_analysis_match_the_smiles_paths():
+    smiles = "CC(=O)O"
+    mol_name, mol_trace = name_rdkit_mol_with_trace(_mol(smiles))
+    smiles_name, smiles_trace = name_smiles_with_trace(smiles)
+    assert mol_name == smiles_name
+    assert len(mol_trace) == len(smiles_trace)
+    assert analyze_rdkit_mol(_mol(smiles)).name == analyze_smiles(smiles).name
+
+
+def test_name_many_accepts_a_mix_of_smiles_and_molecules():
+    results = name_many([_mol("CCO"), "c1ccccc1", _mol("CC(=O)O")])
+    assert [r.name for r in results] == ["ethanol", "benzene", "acetic acid"]


### PR DESCRIPTION
## Summary by Sourcery

Introduce RDKit molecule–based naming and analysis alongside existing SMILES APIs, allowing callers to bypass SMILES round-trips while maintaining compatibility with verification and batch processing workflows.

New Features:
- Add support for naming and analyzing existing RDKit Mol objects, including batch APIs that accept mixtures of SMILES and RDKit molecules

Enhancements:
- Refactor the naming engine to accept a molecule object as primary input, deferring SMILES generation until needed (e.g., for OPSIN verification) and preserving caller molecules unmodified
- Extend graph I/O to build the internal molecule representation directly from RDKit Mol inputs, including unsanitized and SD-style molecules with explicit hydrogens

Documentation:
- Update README to document RDKit-based naming functions and mixed SMILES/RDKit batch usage

Tests:
- Add tests covering RDKit molecule input, SD-style and unsanitized molecules, OPSIN verification behavior, and mixed SMILES/molecule batches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating IUPAC names directly from RDKit molecules.
  * Added analysis and trace-enabled naming options for RDKit inputs.
  * Batch naming now accepts mixed SMILES strings and RDKit molecules.
  * Added safeguards to preserve input molecules, including explicit hydrogens.
  * Expanded public API exports and updated the package version to 0.1.5.

* **Documentation**
  * Added usage examples and guidance for naming existing RDKit molecules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->