### PR TITLE
Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,8 @@ jobs:
       packages: write
     uses: ./.github/workflows/docker-image.yml
     secrets: inherit
-
   paper-evaluations:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/tests'
+    if: github.event_name == 'pull_request' && github.base_ref == 'tests'
     needs: [lint, test, rdkit-compat]
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Attached to this framework are methyl groups at positions 1 (atom id 8), 3 (atom
 ## Development
 
 ```bash
-git clone https://github.com/lamalab-org/iupac-name-generator
-cd iupac-name-generator
+git clone https://github.com/lamalab-org/openclatura
+cd openclatura
 pip install -e ".[dev]"
 
 # run the unit + round-trip tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,13 @@ Issues = "https://github.com/lamalab-org/openclatura/issues"
 [project.scripts]
 openclatura = "openclatura.cli:main"
 
+[tool.hatch.build]
+exclude = [
+    "/examples",
+    "/evaluations",
+    "/eval_failures",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/openclatura"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclatura"
-version = "0.1.3"
+version = "0.1.4"
 description = "Deterministic SMILES-to-IUPAC name generator based on the IUPAC Blue Book"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -27,15 +27,32 @@ class NameTokenBinding:
     right_context: str = ""
 
 
-class RenderedSubstituentName(str):
-    """A rendered substituent carrying construction-time boundary metadata."""
+@dataclass(frozen=True)
+class RenderedSubstituentName:
+    """Rendered text plus construction-time parenthesis-boundary metadata."""
 
-    outer_parentheses_optional: bool
+    text: str
+    outer_parentheses_optional: bool = False
 
-    def __new__(cls, value: str, *, outer_parentheses_optional: bool = False):
-        rendered = super().__new__(cls, value)
-        rendered.outer_parentheses_optional = outer_parentheses_optional
-        return rendered
+    def __str__(self) -> str:
+        return self.text
+
+
+RenderedSubstituentText = str | RenderedSubstituentName
+
+
+def split_rendered_substituent_name(name: RenderedSubstituentText) -> tuple[str, bool]:
+    """Return plain text and explicit boundary metadata for a rendered name."""
+
+    if isinstance(name, RenderedSubstituentName):
+        return name.text, name.outer_parentheses_optional
+    return name, False
+
+
+def rendered_substituent_text(name: RenderedSubstituentText) -> str:
+    """Return plain text when boundary metadata is no longer needed."""
+
+    return name.text if isinstance(name, RenderedSubstituentName) else name
 
 
 @dataclass
@@ -50,6 +67,7 @@ class SubstituentItem:
     nested_decisions: list[dict] = field(default_factory=list)
     substituent_tree: dict | None = None
     spiro: SpiroAssembly | None = None
+    outer_parentheses_optional: bool = False
 
 
 @dataclass

--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -27,6 +27,17 @@ class NameTokenBinding:
     right_context: str = ""
 
 
+class RenderedSubstituentName(str):
+    """A rendered substituent carrying construction-time boundary metadata."""
+
+    outer_parentheses_optional: bool
+
+    def __new__(cls, value: str, *, outer_parentheses_optional: bool = False):
+        rendered = super().__new__(cls, value)
+        rendered.outer_parentheses_optional = outer_parentheses_optional
+        return rendered
+
+
 @dataclass
 class SubstituentItem:
     name: str

--- a/src/openclatura/assembly_prefixes.py
+++ b/src/openclatura/assembly_prefixes.py
@@ -3,7 +3,7 @@
 import re
 
 from .assembly_charge import inferred_ionic_retained_parent, single_charged_replacement_locants
-from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
+from .assembly_parts import AssemblyParts, SubstituentItem
 from .assembly_utils import is_fully_enclosed, needs_hyphen, parse_locant
 from .formatting import is_complex_prefix
 from .nomenclature import RULES
@@ -148,6 +148,7 @@ def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:
     prefix_parts = []
     for name in sorted(grouped.keys(), key=substituent_sort_key):
         items = grouped[name]
+        outer_parentheses_optional = all(item.outer_parentheses_optional for item in items)
         locs = sorted([loc for item in items for loc in item.locants], key=parse_locant)
         attachments_per_group = 2 if ("diyl" in name and "ylidene" not in name) else 1
         count_raw = len(locs) if locs else len(items)
@@ -156,7 +157,14 @@ def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:
         mult = (multipliers.complex_(count) if is_complex else multipliers.basic(count)) if count > 1 else ""
         loc_str = substituent_locant_string(parts, locs, len(grouped), spiro_subs)
 
-        name_to_use = _omit_optional_outer_parentheses(parts, name, count, loc_str, len(grouped))
+        name_to_use = _omit_optional_outer_parentheses(
+            parts,
+            name,
+            count,
+            loc_str,
+            len(grouped),
+            outer_parentheses_optional=outer_parentheses_optional,
+        )
         if is_complex and not is_fully_enclosed(name_to_use):
             if count > 1 or loc_str:
                 name_to_use = f"({name_to_use})"
@@ -177,6 +185,8 @@ def _omit_optional_outer_parentheses(
     count: int,
     locant_text: str,
     grouped_count: int,
+    *,
+    outer_parentheses_optional: bool,
 ) -> str:
     """Unwrap a directly rendered fragment when its parent boundary is clear."""
 
@@ -185,8 +195,7 @@ def _omit_optional_outer_parentheses(
         or count != 1
         or locant_text
         or grouped_count != 1
-        or not isinstance(name, RenderedSubstituentName)
-        or not name.outer_parentheses_optional
+        or not outer_parentheses_optional
         or not is_fully_enclosed(name)
     ):
         return name

--- a/src/openclatura/assembly_prefixes.py
+++ b/src/openclatura/assembly_prefixes.py
@@ -3,7 +3,7 @@
 import re
 
 from .assembly_charge import inferred_ionic_retained_parent, single_charged_replacement_locants
-from .assembly_parts import AssemblyParts, SubstituentItem
+from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
 from .assembly_utils import is_fully_enclosed, needs_hyphen, parse_locant
 from .formatting import is_complex_prefix
 from .nomenclature import RULES
@@ -156,19 +156,41 @@ def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:
         mult = (multipliers.complex_(count) if is_complex else multipliers.basic(count)) if count > 1 else ""
         loc_str = substituent_locant_string(parts, locs, len(grouped), spiro_subs)
 
-        name_to_use = name
-        if is_complex and not is_fully_enclosed(name):
+        name_to_use = _omit_optional_outer_parentheses(parts, name, count, loc_str, len(grouped))
+        if is_complex and not is_fully_enclosed(name_to_use):
             if count > 1 or loc_str:
-                name_to_use = f"({name})"
-        elif not loc_str and len(grouped) > 1 and not is_fully_enclosed(name):
+                name_to_use = f"({name_to_use})"
+        elif not loc_str and len(grouped) > 1 and not is_fully_enclosed(name_to_use):
             if name not in ["fluoro", "chloro", "bromo", "iodo"]:
-                name_to_use = f"({name})"
+                name_to_use = f"({name_to_use})"
         prefix_parts.append(f"{loc_str}-{mult}{name_to_use}" if loc_str else f"{mult}{name_to_use}")
 
     prefix_str = prefix_parts[0]
     for part in prefix_parts[1:]:
         prefix_str += f"-{part}" if needs_hyphen(prefix_str, part) else part
     return prefix_str
+
+
+def _omit_optional_outer_parentheses(
+    parts: AssemblyParts,
+    name: str,
+    count: int,
+    locant_text: str,
+    grouped_count: int,
+) -> str:
+    """Unwrap a directly rendered fragment when its parent boundary is clear."""
+
+    if (
+        parts.is_substituent
+        or count != 1
+        or locant_text
+        or grouped_count != 1
+        or not isinstance(name, RenderedSubstituentName)
+        or not name.outer_parentheses_optional
+        or not is_fully_enclosed(name)
+    ):
+        return name
+    return name[1:-1]
 
 
 def format_replacement_prefixes(parts: AssemblyParts) -> str:

--- a/src/openclatura/component_modifiers.py
+++ b/src/openclatura/component_modifiers.py
@@ -5,7 +5,7 @@ from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
 from .molecule import DecisionTrace, Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .subgraph_tools import subgraph_component
@@ -19,7 +19,7 @@ def add_component_front_modifiers(
     perceived_groups: list[PerceivedGroup],
     principal_key: str | None,
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> None:
     """Add ester/sulfonate front modifiers such as the alcohol component name."""
 
@@ -64,7 +64,7 @@ def add_component_n_substituents(
     numbered_path: list[int],
     get_loc,
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> None:
     """Add N-substituent prefixes and N/N' locants for principal groups."""
 
@@ -183,7 +183,7 @@ def _nitrogen_substituent_name(
     nitrogen: int,
     substituent: int,
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
     decision_trace: DecisionTrace | None = None,
 ) -> tuple[str, list, dict | None]:
     """Render graph-bound N-substituents on principal nitrogen groups."""

--- a/src/openclatura/component_modifiers.py
+++ b/src/openclatura/component_modifiers.py
@@ -1,73 +1,16 @@
 """Data-driven component modifiers attached after parent numbering."""
 
-from typing import Literal, Protocol, overload
-
 from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem
 from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
 from .molecule import DecisionTrace, Molecule
+from .naming_protocols import BranchNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .subgraph_tools import subgraph_component
 from .substituent_tokens import graph_bound_substituent_tokens
 from .trace_helpers import add_substituent_trace, bond_ids_within, decision_trace_data
-
-
-class BranchNamer(Protocol):
-    """Recursive branch namer with simple and traced/tree return modes."""
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> str: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict]]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict], dict | None]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, dict | None]: ...
 
 
 def add_component_front_modifiers(

--- a/src/openclatura/component_modifiers.py
+++ b/src/openclatura/component_modifiers.py
@@ -1,6 +1,6 @@
 """Data-driven component modifiers attached after parent numbering."""
 
-from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem
+from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem, split_rendered_substituent_name
 from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
@@ -119,10 +119,12 @@ def add_component_n_substituents(
                         bond_ids_within(mol, {single_n, n_sub}),
                     )
                     if _use_hydrazone_suffix_modifier(parts, principal_key):
+                        branch_text, outer_parentheses_optional = split_rendered_substituent_name(branch_name)
                         parts.principal_suffix_modifiers.append(
                             SubstituentItem(
-                                branch_name,
+                                branch_text,
                                 [],
+                                outer_parentheses_optional=outer_parentheses_optional,
                                 atom_ids=branch_atoms,
                                 bond_ids=bond_ids_within(mol, branch_atoms | {single_n}),
                                 charge_atom_ids=_charged_atoms(mol, branch_atoms),

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -1,7 +1,6 @@
 """Connected-component naming pipeline."""
 
 from collections.abc import Callable
-from typing import Literal, Protocol, overload
 
 from .assembly_parts import AssemblyParts, NameAtomBinding, SubstituentItem
 from .chains import find_all_carbon_paths, find_ring_systems, get_cyclic_atoms
@@ -17,6 +16,7 @@ from .name_assembly import NameAssemblyResult, assert_final_name_assembly, token
 from .name_bindings import binding_trace_data, refresh_name_atom_bindings
 from .naming_audit import UnnamedAtomError, assert_component_fully_named
 from .naming_context import ComponentNamingState, NamingIntent
+from .naming_protocols import SubgraphNamer
 from .parent_pipeline import build_parent_assembly_plan, resolve_retained_parent
 from .parent_selection import select_principal_parent
 from .principal_groups import (
@@ -48,67 +48,11 @@ from .trace_helpers import (
     assembly_substituent_tree,
     assembly_trace_segments,
     bond_ids_within,
+    build_shortcut_tree_node,
     decision_trace_data,
     functional_group_trace_data,
     trace_decision,
 )
-
-
-class SubgraphNamer(Protocol):
-    """Recursive subgraph namer with simple and traced/tree return modes."""
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> str: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[False] = False,
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict]]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[True],
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict], dict | None]: ...
-
-    @overload
-    def __call__(
-        self,
-        mol: Molecule,
-        start_idx: int,
-        exclude_atoms: set[int],
-        *,
-        upstream_atom: int | None = None,
-        return_trace: Literal[False] = False,
-        return_tree: Literal[True],
-        decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, dict | None]: ...
-
 
 SpiroSubgraphNamer = Callable[[Molecule, int, set[int]], SpiroAssembly]
 ParentAssembler = Callable[..., str]
@@ -332,11 +276,11 @@ def name_component(
             },
         )
         if return_trace and return_tree:
-            return name, [], _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, [], _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
         if return_tree:
-            return name, _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         return name
 
     def name_component_again(next_mol: Molecule, next_atoms: set[int], is_substituent: bool = False):
@@ -376,11 +320,11 @@ def name_component(
             },
         )
         if return_trace and return_tree:
-            return name, [], _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, [], _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
         if return_tree:
-            return name, _shortcut_tree(name, component_atoms, bindings, token_spans)
+            return name, _component_shortcut_tree(name, component_atoms, bindings, token_spans)
         return name
 
     state = ComponentNamingState(component_atoms=set(component_atoms), is_substituent=is_substituent)
@@ -431,11 +375,11 @@ def name_component(
             },
         )
         if return_trace and return_tree:
-            return name, [], _shortcut_tree(name, state.component_atoms, bindings, token_spans)
+            return name, [], _component_shortcut_tree(name, state.component_atoms, bindings, token_spans)
         if return_trace:
             return name, []
         if return_tree:
-            return name, _shortcut_tree(name, state.component_atoms, bindings, token_spans)
+            return name, _component_shortcut_tree(name, state.component_atoms, bindings, token_spans)
         return name
 
     state.exclude_atoms = set(mol.atoms.keys()) - state.component_atoms
@@ -654,21 +598,15 @@ def name_component(
     return name
 
 
-def _shortcut_tree(name: str, component_atoms: set[int], bindings: list[dict], token_spans: list[dict]) -> dict:
+def _component_shortcut_tree(
+    name: str, component_atoms: set[int], bindings: list[dict], token_spans: list[dict]
+) -> dict:
     """Return a minimal component tree for shortcut component names."""
 
-    return {
-        "kind": "component",
-        "name": name,
-        "atoms": sorted(component_atoms),
-        "bonds": [],
-        "parent": None,
-        "principal_group": None,
-        "substituents": [],
-        "replacement_prefixes": [],
-        "unsaturations": [],
-        "trace_segments": [],
-        "nested_decisions": [],
-        "name_atom_bindings": bindings,
-        "name_token_spans": token_spans,
-    }
+    return build_shortcut_tree_node(
+        kind="component",
+        name=name,
+        atom_ids=component_atoms,
+        name_atom_bindings=bindings,
+        name_token_spans=token_spans,
+    )

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 
-from .assembly_parts import AssemblyParts, NameAtomBinding, SubstituentItem
+from .assembly_parts import AssemblyParts, NameAtomBinding, SubstituentItem, split_rendered_substituent_name
 from .chains import find_all_carbon_paths, find_ring_systems, get_cyclic_atoms
 from .component_group_rules import (
     exclude_nonparent_group_atoms,
@@ -132,6 +132,7 @@ def collect_component_branch_substituents(
                     )
                     branch_trace = []
                     branch_tree = None
+                branch_name, outer_parentheses_optional = split_rendered_substituent_name(branch_name)
                 if branch_name:
                     branch_exclude = sub_exclude | main_set
                     branch_atoms = subgraph_component(mol, n_idx, branch_exclude)
@@ -139,6 +140,7 @@ def collect_component_branch_substituents(
                         SubstituentItem(
                             name=branch_name,
                             locants=[],
+                            outer_parentheses_optional=outer_parentheses_optional,
                             atom_ids=branch_atoms,
                             bond_ids=bond_ids_within(mol, branch_atoms | {c_idx}),
                             charge_atom_ids=_charged_atoms(mol, branch_atoms),
@@ -183,6 +185,7 @@ def add_component_substituents(
                     item.emitted_tokens,
                     substituent_tree=item.substituent_tree,
                     spiro=item.spiro,
+                    outer_parentheses_optional=item.outer_parentheses_optional,
                 )
 
 

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -16,7 +16,7 @@ from .name_assembly import NameAssemblyResult, assert_final_name_assembly, token
 from .name_bindings import binding_trace_data, refresh_name_atom_bindings
 from .naming_audit import UnnamedAtomError, assert_component_fully_named
 from .naming_context import ComponentNamingState, NamingIntent
-from .naming_protocols import SubgraphNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .parent_pipeline import build_parent_assembly_plan, resolve_retained_parent
 from .parent_selection import select_principal_parent
 from .principal_groups import (
@@ -77,7 +77,7 @@ def collect_component_branch_substituents(
     base_exclude: set[int],
     sub_exclude: set[int],
     *,
-    name_subgraph: SubgraphNamer,
+    name_subgraph: RecursiveSubgraphNamer,
     name_spiro_subgraph: SpiroSubgraphNamer,
     emit_metadata: bool = True,
 ) -> None:
@@ -242,7 +242,7 @@ def name_component(
     return_trace: bool = False,
     return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
-    name_subgraph: SubgraphNamer,
+    name_subgraph: RecursiveSubgraphNamer,
     name_spiro_subgraph: SpiroSubgraphNamer,
     assemble_parent_name: ParentAssembler,
     token_debug: bool = False,

--- a/src/openclatura/formatting.py
+++ b/src/openclatura/formatting.py
@@ -2,6 +2,7 @@
 
 import re
 
+from .assembly_parts import RenderedSubstituentName, rendered_substituent_text
 from .namer_config import ALKYL_OXY_PREFIXES
 from .rules import multipliers, stems
 
@@ -22,9 +23,10 @@ def is_fully_enclosed(s: str) -> bool:
     return depth == 0
 
 
-def strip_outer_parentheses(name: str) -> str:
+def strip_outer_parentheses(name: str | RenderedSubstituentName) -> str:
     """Remove one balanced outer parenthesis pair from a fragment."""
 
+    name = rendered_substituent_text(name)
     if name.startswith("(") and name.endswith(")"):
         return name[1:-1]
     return name

--- a/src/openclatura/functional_prefixes.py
+++ b/src/openclatura/functional_prefixes.py
@@ -5,7 +5,7 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from .assembly_parts import NameTokenBinding, SubstituentItem
+from .assembly_parts import NameTokenBinding, SubstituentItem, rendered_substituent_text
 from .formatting import format_counted_prefixes, is_complex_prefix, oxy_prefix_from_branch, strip_outer_parentheses
 from .group_atom_roles import amide_nitrogen, ester_or_peroxy_single_oxygen
 from .molecule import Molecule
@@ -45,6 +45,7 @@ def ester_prefix_from_group(
     branch_name = branch_namer(mol, r_group_c, sub_exclude | {single_o}, upstream_atom=single_o)
     if not branch_name:
         return ""
+    branch_name = rendered_substituent_text(branch_name)
     return f"({oxy_prefix_from_branch(branch_name)}{suffix_text})"
 
 
@@ -62,7 +63,10 @@ def amide_prefix_from_group(
         return ""
     if not n_subs:
         return base
-    sub_names = [branch_namer(mol, x, sub_exclude | {single_n}, upstream_atom=single_n) for x in n_subs]
+    sub_names = [
+        rendered_substituent_text(branch_namer(mol, x, sub_exclude | {single_n}, upstream_atom=single_n))
+        for x in n_subs
+    ]
     return f"({format_counted_prefixes(sub_names)}{base})"
 
 
@@ -87,7 +91,14 @@ def iminium_prefix_handler(context: PrefixContext, group: PerceivedGroup) -> str
     if not n_subs:
         return "iminio"
     sub_names = [
-        context.branch_namer(context.mol, n_sub, context.sub_exclude | {iminium_n}, upstream_atom=iminium_n)
+        rendered_substituent_text(
+            context.branch_namer(
+                context.mol,
+                n_sub,
+                context.sub_exclude | {iminium_n},
+                upstream_atom=iminium_n,
+            )
+        )
         for n_sub in n_subs
     ]
     return f"({format_counted_prefixes(sub_names)}iminio)"

--- a/src/openclatura/functional_prefixes.py
+++ b/src/openclatura/functional_prefixes.py
@@ -9,13 +9,13 @@ from .assembly_parts import NameTokenBinding, SubstituentItem
 from .formatting import format_counted_prefixes, is_complex_prefix, oxy_prefix_from_branch, strip_outer_parentheses
 from .group_atom_roles import amide_nitrogen, ester_or_peroxy_single_oxygen
 from .molecule import Molecule
+from .naming_protocols import BranchNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .rules import multipliers
 from .subgraph_tools import subgraph_component
 from .trace_helpers import bond_ids_within
 
-BranchNamer = Callable[..., str]
 PrefixHandler = Callable[["PrefixContext", PerceivedGroup], str]
 
 

--- a/src/openclatura/functional_prefixes.py
+++ b/src/openclatura/functional_prefixes.py
@@ -9,7 +9,7 @@ from .assembly_parts import NameTokenBinding, SubstituentItem
 from .formatting import format_counted_prefixes, is_complex_prefix, oxy_prefix_from_branch, strip_outer_parentheses
 from .group_atom_roles import amide_nitrogen, ester_or_peroxy_single_oxygen
 from .molecule import Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .rules import multipliers
@@ -24,11 +24,15 @@ class PrefixContext:
     mol: Molecule
     parent_path: list[int]
     sub_exclude: set[int]
-    branch_namer: BranchNamer
+    branch_namer: RecursiveSubgraphNamer
 
 
 def ester_prefix_from_group(
-    mol: Molecule, group: PerceivedGroup, sub_exclude: set[int], suffix_text: str, branch_namer: BranchNamer
+    mol: Molecule,
+    group: PerceivedGroup,
+    sub_exclude: set[int],
+    suffix_text: str,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     """Return an alkoxycarbonyl or alkoxysulfonyl-style prefix."""
 
@@ -45,7 +49,7 @@ def ester_prefix_from_group(
 
 
 def amide_prefix_from_group(
-    mol: Molecule, group: PerceivedGroup, sub_exclude: set[int], branch_namer: BranchNamer
+    mol: Molecule, group: PerceivedGroup, sub_exclude: set[int], branch_namer: RecursiveSubgraphNamer
 ) -> str:
     """Return carbamoyl or carbamothioyl prefix text for an amide-like group."""
 
@@ -201,7 +205,7 @@ def collect_component_prefix_substituents(
     prefix_groups: list[PerceivedGroup],
     parent_path: list[int],
     sub_exclude: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[dict[int, list[SubstituentItem]], set[int]]:
     """Collect characteristic groups cited as prefixes on the component parent."""
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -466,7 +466,9 @@ def _sulfur_imide_branch_name(
         cyclic_name = _cyclic_sulfur_imide_ligand_name(mol, sulfur, nitrogen, next_atoms, s_oxygens)
         if cyclic_name:
             return cyclic_name
-        branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, local_exclude, sulfur))]
+        branches = [
+            br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, local_exclude, sulfur))
+        ]
         branches.extend(["oxo"] * len(s_oxygens))
         if not branches:
             return "sulfanylidene"
@@ -588,7 +590,9 @@ def name_sulfur_subgraph(
             br
             for nxt in next_atoms
             if (
-                br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx)
+                br := _branch_name_text(
+                    branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx
+                )
             )
         ]
         branches.extend(["oxo"] * len(s_oxygens))
@@ -609,7 +613,9 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx))
+            if (
+                br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx)
+            )
         ]
         branches.extend(["oxo"] * len(s_oxygens))
         return format_lambda_substituent(
@@ -623,7 +629,11 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx))
+            if (
+                br := _branch_name_text(
+                    branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx
+                )
+            )
         ]
         if len(s_nitrogens) == 1:
             branches = ["imino", *branches]
@@ -648,7 +658,11 @@ def name_sulfur_subgraph(
             return format_element_substituent(stereo_prefix_text, branch, "sulfanyl", is_double=is_double)
         return f"{stereo_prefix_text}{'sulfanylidene' if is_double else 'sulfanyl'}"
 
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, "sulfanylidene" if is_double else "sulfanyl"
     )
@@ -679,7 +693,11 @@ def name_chalcogen_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx))
+            if (
+                br := _branch_name_text(
+                    branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx
+                )
+            )
         ]
         branches.extend(["oxo"] * len(oxo_ligands))
         return format_lambda_substituent(
@@ -706,7 +724,11 @@ def name_chalcogen_subgraph(
         if branch:
             return format_element_substituent(stereo_prefix_text, branch, element_suffix, is_double=is_double)
         return f"{stereo_prefix_text}{element_suffix + ('idene' if is_double else '')}"
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, element_suffix + ("idene" if is_double else "")
     )
@@ -754,7 +776,11 @@ def name_group_13_14_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return suffix
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     return f"({format_counted_prefixes(branches)}{suffix})"
 
 
@@ -769,7 +795,11 @@ def name_halogen_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return HALOGEN_PREFIXES[symbol]
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     valence = sum(mol.get_bond(start_idx, n).order for n in mol.get_neighbors(start_idx))
     return f"({format_counted_prefixes(branches)}lambda^{valence}-{HALOGEN_LAMBDA_SUFFIXES[symbol]})"
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -19,7 +19,7 @@ from .namer_config import (
     SIMPLE_SELANYL_PREFIXES,
     SIMPLE_SULFANYL_PREFIXES,
 )
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nitrogen_roles import terminal_n3_substituent_role
 from .nomenclature import RULES
 from .oxoacid_roles import OxoLigandRole, central_oxo_substituent_role
@@ -72,7 +72,7 @@ def _single_imino_n_substituent_name(
     mol: Molecule,
     nitrogen: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     roots = [
         neighbor
@@ -148,7 +148,7 @@ def name_branch_or_none(
     branch_idx: int | None,
     exclude_atoms: set[int],
     upstream_atom: int,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     if branch_idx is None:
         return ""
@@ -163,7 +163,7 @@ def name_carbonyl_like_fragment(
     exclude_atoms: set[int],
     branch_suffix: str,
     fallback: str,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
     amino_base: str | None = None,
     wrap_result: bool = False,
 ) -> str:
@@ -281,7 +281,7 @@ def name_oxygen_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
@@ -342,7 +342,7 @@ def name_nitrogen_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     upstream_order = upstream_bond_order(mol, start_idx, upstream_atom)
     is_double = upstream_order == 2
@@ -431,7 +431,7 @@ def _sulfur_imide_branch_name(
     sulfur: int,
     exclude_atoms: set[int],
     s_oxygens: list[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     """Render an N=S(=O)n branch without collapsing it to sulfo-amino acid wording."""
 
@@ -534,7 +534,7 @@ def name_sulfur_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     s_oxygens = central_oxo_substituent_excluded_ligand_atoms(mol, start_idx, exclude_atoms)
@@ -642,7 +642,7 @@ def name_chalcogen_subgraph(
     simple_prefixes: set[str],
     element_suffix: str,
     oxo_prefix: str,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     oxo_ligands = central_oxo_substituent_excluded_ligand_atoms(mol, start_idx, exclude_atoms)
@@ -697,7 +697,7 @@ def name_phosphorus_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     upstream_order = upstream_bond_order(mol, start_idx, upstream_atom)
     multiple_bond_suffix = {2: "idene", 3: "idyne"}.get(upstream_order, "")
@@ -724,7 +724,7 @@ def name_group_13_14_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     is_double = upstream_bond_order(mol, start_idx, upstream_atom) == 2
     base_suffix = unsubstituted_prefix(mol.atoms[start_idx].symbol) or (
@@ -743,7 +743,7 @@ def name_halogen_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str:
     symbol = mol.atoms[start_idx].symbol
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
@@ -759,7 +759,7 @@ def name_heteroatom_subgraph(
     start_idx: int,
     exclude_atoms: set[int],
     upstream_atom: int | None,
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> str | None:
     """Name supported heteroatom-starting recursive fragments."""
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -1,5 +1,6 @@
 """Heteroatom-starting recursive substituent naming."""
 
+from .assembly_parts import split_rendered_substituent_name
 from .formatting import (
     count_names,
     format_counted_prefixes,
@@ -24,6 +25,25 @@ from .nitrogen_roles import terminal_n3_substituent_role
 from .nomenclature import RULES
 from .oxoacid_roles import OxoLigandRole, central_oxo_substituent_role
 from .rules import multipliers
+
+
+def _branch_name_text(
+    branch_namer: RecursiveSubgraphNamer,
+    mol: Molecule,
+    start_idx: int,
+    exclude_atoms: set[int],
+    upstream_atom: int,
+) -> str:
+    """Render a nested branch as text, consuming its boundary metadata."""
+
+    rendered = branch_namer(
+        mol,
+        start_idx,
+        exclude_atoms,
+        upstream_atom=upstream_atom,
+    )
+    name, _ = split_rendered_substituent_name(rendered)
+    return name
 
 
 def upstream_bond_order(mol: Molecule, start_idx: int, upstream_atom: int | None) -> int:
@@ -152,7 +172,7 @@ def name_branch_or_none(
 ) -> str:
     if branch_idx is None:
         return ""
-    return strip_outer_parentheses(branch_namer(mol, branch_idx, exclude_atoms, upstream_atom))
+    return strip_outer_parentheses(_branch_name_text(branch_namer, mol, branch_idx, exclude_atoms, upstream_atom))
 
 
 def name_carbonyl_like_fragment(
@@ -331,7 +351,7 @@ def name_oxygen_subgraph(
         branch = name_branch_or_none(mol, branch_idx, exclude_atoms | {start_idx, nxt}, nxt, branch_namer)
         return f"({branch}peroxy)" if branch else "hydroperoxy"
 
-    branch = branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx)
+    branch = _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx)
     if branch:
         return oxy_prefix_from_branch(branch)
     return "hydroxy"
@@ -406,7 +426,7 @@ def name_nitrogen_subgraph(
                 if sulfur_imide:
                     branches.append(sulfur_imide)
             else:
-                branch = branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx)
+                branch = _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx)
                 if branch:
                     branches.append(branch)
 
@@ -446,7 +466,7 @@ def _sulfur_imide_branch_name(
         cyclic_name = _cyclic_sulfur_imide_ligand_name(mol, sulfur, nitrogen, next_atoms, s_oxygens)
         if cyclic_name:
             return cyclic_name
-        branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, local_exclude, sulfur))]
+        branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, local_exclude, sulfur))]
         branches.extend(["oxo"] * len(s_oxygens))
         if not branches:
             return "sulfanylidene"
@@ -568,7 +588,7 @@ def name_sulfur_subgraph(
             br
             for nxt in next_atoms
             if (
-                br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx)
+                br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx)
             )
         ]
         branches.extend(["oxo"] * len(s_oxygens))
@@ -589,7 +609,7 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx))
+            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx))
         ]
         branches.extend(["oxo"] * len(s_oxygens))
         return format_lambda_substituent(
@@ -603,7 +623,7 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx))
+            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx))
         ]
         if len(s_nitrogens) == 1:
             branches = ["imino", *branches]
@@ -619,7 +639,7 @@ def name_sulfur_subgraph(
         return "thioxo" if is_double else f"{stereo_prefix_text}{unsubstituted_prefix('S') or 'sulfanyl'}"
 
     if len(next_atoms) == 1:
-        branch = branch_namer(mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
+        branch = _branch_name_text(branch_namer, mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
         if not is_double and mol.atoms[start_idx].charge > 0:
             return f"({stereo_prefix_text}{branch}sulfaniumyl)" if branch else f"{stereo_prefix_text}sulfaniumyl"
         if branch in SIMPLE_SULFANYL_PREFIXES:
@@ -628,7 +648,7 @@ def name_sulfur_subgraph(
             return format_element_substituent(stereo_prefix_text, branch, "sulfanyl", is_double=is_double)
         return f"{stereo_prefix_text}{'sulfanylidene' if is_double else 'sulfanyl'}"
 
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, "sulfanylidene" if is_double else "sulfanyl"
     )
@@ -659,7 +679,7 @@ def name_chalcogen_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx))
+            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx))
         ]
         branches.extend(["oxo"] * len(oxo_ligands))
         return format_lambda_substituent(
@@ -676,7 +696,7 @@ def name_chalcogen_subgraph(
             else f"{stereo_prefix_text}{unsubstituted_prefix(mol.atoms[start_idx].symbol) or element_suffix}"
         )
     if len(next_atoms) == 1:
-        branch = branch_namer(mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
+        branch = _branch_name_text(branch_namer, mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
         if branch and substituent_bonding_number(mol, start_idx) != mol.atoms[start_idx].element.standard_valence:
             return format_lambda_substituent(
                 mol, start_idx, [branch], stereo_prefix_text, element_suffix + ("idene" if is_double else "")
@@ -686,7 +706,7 @@ def name_chalcogen_subgraph(
         if branch:
             return format_element_substituent(stereo_prefix_text, branch, element_suffix, is_double=is_double)
         return f"{stereo_prefix_text}{element_suffix + ('idene' if is_double else '')}"
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, element_suffix + ("idene" if is_double else "")
     )
@@ -714,7 +734,7 @@ def name_phosphorus_subgraph(
     branches = [
         br
         for nxt in next_atoms
-        if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(p_oxygens), start_idx))
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(p_oxygens), start_idx))
     ]
     return f"({stereo_prefix_text}{format_counted_prefixes(branches)}{suffix})"
 
@@ -734,7 +754,7 @@ def name_group_13_14_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return suffix
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     return f"({format_counted_prefixes(branches)}{suffix})"
 
 
@@ -749,7 +769,7 @@ def name_halogen_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return HALOGEN_PREFIXES[symbol]
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     valence = sum(mol.get_bond(start_idx, n).order for n in mol.get_neighbors(start_idx))
     return f"({format_counted_prefixes(branches)}lambda^{valence}-{HALOGEN_LAMBDA_SUFFIXES[symbol]})"
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -1,7 +1,5 @@
 """Heteroatom-starting recursive substituent naming."""
 
-from collections.abc import Callable
-
 from .formatting import (
     count_names,
     format_counted_prefixes,
@@ -21,12 +19,11 @@ from .namer_config import (
     SIMPLE_SELANYL_PREFIXES,
     SIMPLE_SULFANYL_PREFIXES,
 )
+from .naming_protocols import BranchNamer
 from .nitrogen_roles import terminal_n3_substituent_role
 from .nomenclature import RULES
 from .oxoacid_roles import OxoLigandRole, central_oxo_substituent_role
 from .rules import multipliers
-
-BranchNamer = Callable[[Molecule, int, set[int], int | None], str]
 
 
 def upstream_bond_order(mol: Molecule, start_idx: int, upstream_atom: int | None) -> int:

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -51,7 +51,11 @@ from .trace_helpers import (
 from .trace_helpers import (
     bond_ids_within as _bond_ids_within,
 )
-from .trace_helpers import decision_trace_data, trace_decision
+from .trace_helpers import (
+    build_shortcut_tree_node,
+    decision_trace_data,
+    trace_decision,
+)
 
 
 @dataclass
@@ -1338,19 +1342,13 @@ def _shortcut_substituent_tree(
 ) -> dict:
     """Return a minimal recursive tree node for shortcut substituent names."""
 
-    node = {
-        "kind": "substituent",
-        "name": name,
-        "atoms": sorted(component),
-        "bonds": sorted(_bond_ids_within(mol, component)),
-        "parent": None,
-        "principal_group": None,
-        "substituents": [],
-        "replacement_prefixes": [],
-        "unsaturations": [],
-        "trace_segments": [],
-        "nested_decisions": decision_trace_data(decision_trace),
-    }
+    node = build_shortcut_tree_node(
+        kind="substituent",
+        name=name,
+        atom_ids=component,
+        bond_ids=_bond_ids_within(mol, component),
+        decisions=decision_trace_data(decision_trace),
+    )
     if direct_prefix is not None:
         node["functional_prefix"] = {
             "kind": "functional_prefix",

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -4,7 +4,14 @@ import re
 from dataclasses import dataclass, field
 
 from .assembler import assemble_name_raw, post_process_rewrite_rules
-from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
+from .assembly_parts import (
+    AssemblyParts,
+    RenderedSubstituentName,
+    RenderedSubstituentText,
+    SubstituentItem,
+    rendered_substituent_text,
+    split_rendered_substituent_name,
+)
 from .assembly_spiro import extract_spiro_side_prefixes
 from .chains import find_ring_systems, get_cyclic_atoms
 from .component_namer import name_component as _name_component_impl
@@ -440,7 +447,9 @@ def _spiro_side_ring_branch_prefixes(
                 continue
             branch = _name_heteroaromatic_branch_substituent(mol, neighbor, atom_idx, allowed_branch_atoms)
             if not branch:
-                branch = name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+                branch = rendered_substituent_text(
+                    name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+                )
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{format_multiplier(branch, 1, safe_enclose=True)}")
     return side_prefixes
@@ -478,7 +487,9 @@ def _name_heteroaromatic_branch_substituent(
         for neighbor in sorted(mol.get_neighbors(atom_idx)):
             if neighbor == upstream_atom or neighbor not in branch_allowed:
                 continue
-            substituent = name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            substituent = rendered_substituent_text(
+                name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            )
             if substituent:
                 prefix_items.append(f"{locant_map[atom_idx]}-{substituent}")
     stem = parent_name[:-1] if parent_name.endswith("e") else parent_name
@@ -717,7 +728,9 @@ def _retained_n_ring_spiro_assembly(mol: Molecule, c_idx: int, sub_comp: set[int
         for neighbor in sorted(mol.get_neighbors(atom_idx)):
             if neighbor not in allowed_branch_atoms:
                 continue
-            branch = name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            branch = rendered_substituent_text(
+                name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            )
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{branch}")
 
@@ -896,6 +909,7 @@ def _collect_subgraph_substituents(
                     )
                     branch_trace = []
                     branch_tree = None
+                branch_name, outer_parentheses_optional = split_rendered_substituent_name(branch_name)
                 if branch_name:
                     branch_atoms = _subgraph_component(mol, n_idx, branch_exclude)
                     branch_with_attachment = branch_atoms | {c_idx}
@@ -916,6 +930,7 @@ def _collect_subgraph_substituents(
                         SubstituentItem(
                             name=branch_name,
                             locants=[],
+                            outer_parentheses_optional=outer_parentheses_optional,
                             atom_ids=branch_atoms,
                             bond_ids=_bond_ids_within(mol, branch_with_attachment),
                             charge_atom_ids=_charged_atoms(mol, branch_atoms),
@@ -951,6 +966,7 @@ def _add_subgraph_substituents(parts: AssemblyParts, subst_mapping: dict[int, li
                 item.emitted_tokens,
                 substituent_tree=item.substituent_tree,
                 spiro=item.spiro,
+                outer_parentheses_optional=item.outer_parentheses_optional,
             )
 
 
@@ -984,7 +1000,9 @@ def _finalize_subgraph_name(name: str, parts: AssemblyParts) -> str:
     return f"({name})"
 
 
-def _mark_optional_substituent_boundary(name: str, parts: AssemblyParts, finalize_subgraph: bool) -> str:
+def _mark_optional_substituent_boundary(
+    name: str, parts: AssemblyParts, finalize_subgraph: bool
+) -> RenderedSubstituentText:
     """Preserve whether construction made a subgraph boundary optional.
 
     This marker is applied after all name rewrites, since those rewrites return
@@ -1006,7 +1024,7 @@ def _assemble_parent_name(
     *,
     finalize_subgraph: bool = False,
     emit_metadata: bool = True,
-) -> str:
+) -> RenderedSubstituentText:
     """Assemble a parent name and apply shared post-assembly charge rules."""
 
     name = assemble_name_raw(parts)
@@ -1122,6 +1140,7 @@ def name_subgraph(
     mol: Molecule,
     start_idx: int,
     exclude_atoms: set[int],
+    *,
     upstream_atom: int = None,
     return_trace: bool = False,
     return_tree: bool = False,
@@ -1295,7 +1314,7 @@ def name_subgraph(
         parent_selection.is_polycycle,
     )
 
-    name = _assemble_parent_name(
+    rendered_name = _assemble_parent_name(
         mol,
         parts,
         numbered_path,
@@ -1303,6 +1322,7 @@ def name_subgraph(
         finalize_subgraph=True,
         emit_metadata=emit_metadata,
     )
+    name, _ = split_rendered_substituent_name(rendered_name)
     trace_segments = _assembly_trace_segments(parts) if return_trace or return_tree else []
     if decision_trace is not None:
         trace_decision(
@@ -1320,7 +1340,7 @@ def name_subgraph(
     if return_trace:
         if return_tree:
             return (
-                name,
+                rendered_name,
                 trace_segments,
                 _assembly_substituent_tree(
                     parts,
@@ -1331,10 +1351,10 @@ def name_subgraph(
                     trace_segments=trace_segments,
                 ),
             )
-        return name, trace_segments
+        return rendered_name, trace_segments
     if return_tree:
         return (
-            name,
+            rendered_name,
             _assembly_substituent_tree(
                 parts,
                 name=name,
@@ -1344,7 +1364,7 @@ def name_subgraph(
                 trace_segments=trace_segments,
             ),
         )
-    return name
+    return rendered_name
 
 
 def _shortcut_substituent_tree(

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -981,6 +981,11 @@ def _finalize_subgraph_name(name: str, parts: AssemblyParts) -> str:
         and not name.startswith("tricyclo")
     ):
         return name
+    # The stereodescriptor already establishes the fragment's leading
+    # boundary. Its parent will add protective parentheses if the attachment
+    # is locanted, repeated, or otherwise ambiguous.
+    if parts.stereo_features:
+        return name
     return f"({name})"
 
 

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass, field
 
 from .assembler import assemble_name_raw, post_process_rewrite_rules
-from .assembly_parts import AssemblyParts, SubstituentItem
+from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
 from .assembly_spiro import extract_spiro_side_prefixes
 from .chains import find_ring_systems, get_cyclic_atoms
 from .component_namer import name_component as _name_component_impl
@@ -981,12 +981,21 @@ def _finalize_subgraph_name(name: str, parts: AssemblyParts) -> str:
         and not name.startswith("tricyclo")
     ):
         return name
-    # The stereodescriptor already establishes the fragment's leading
-    # boundary. Its parent will add protective parentheses if the attachment
-    # is locanted, repeated, or otherwise ambiguous.
-    if parts.stereo_features:
-        return name
     return f"({name})"
+
+
+def _mark_optional_substituent_boundary(name: str, parts: AssemblyParts, finalize_subgraph: bool) -> str:
+    """Preserve whether construction made a subgraph boundary optional.
+
+    This marker is applied after all name rewrites, since those rewrites return
+    ordinary strings. String composition in a higher recursive layer then
+    intentionally drops the marker, retaining parentheses needed to delimit a
+    compound substituent.
+    """
+
+    if finalize_subgraph and parts.stereo_features:
+        return RenderedSubstituentName(name, outer_parentheses_optional=True)
+    return name
 
 
 def _assemble_parent_name(
@@ -1030,7 +1039,7 @@ def _assemble_parent_name(
                 name = rewrite[1](name)
             else:
                 name = rewrite.rewrite(name)
-        return name
+        return _mark_optional_substituent_boundary(name, parts, finalize_subgraph)
     result = NameAssemblyResult.from_rewrite_pipeline(name, parts.name_atom_bindings, rewrites=tuple(rewrites))
     parts.name_atom_bindings = list(result.bindings)
     parts.name_token_spans = token_span_trace_data(result)
@@ -1072,7 +1081,7 @@ def _assemble_parent_name(
         }
         for operation in result.rewrite_history
     ]
-    return result.text
+    return _mark_optional_substituent_boundary(result.text, parts, finalize_subgraph)
 
 
 def _simple_rooted_carbanion_substituent_name(
@@ -1352,7 +1361,7 @@ def _shortcut_substituent_tree(
         name=name,
         atom_ids=component,
         bond_ids=_bond_ids_within(mol, component),
-        decisions=decision_trace_data(decision_trace),
+        nested_decisions=decision_trace_data(decision_trace),
     )
     if direct_prefix is not None:
         node["functional_prefix"] = {

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -447,9 +447,7 @@ def _spiro_side_ring_branch_prefixes(
                 continue
             branch = _name_heteroaromatic_branch_substituent(mol, neighbor, atom_idx, allowed_branch_atoms)
             if not branch:
-                branch = rendered_substituent_text(
-                    name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
-                )
+                branch = rendered_substituent_text(name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx))
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{format_multiplier(branch, 1, safe_enclose=True)}")
     return side_prefixes
@@ -728,9 +726,7 @@ def _retained_n_ring_spiro_assembly(mol: Molecule, c_idx: int, sub_comp: set[int
         for neighbor in sorted(mol.get_neighbors(atom_idx)):
             if neighbor not in allowed_branch_atoms:
                 continue
-            branch = rendered_substituent_text(
-                name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
-            )
+            branch = rendered_substituent_text(name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx))
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{branch}")
 

--- a/src/openclatura/naming_protocols.py
+++ b/src/openclatura/naming_protocols.py
@@ -59,8 +59,3 @@ class RecursiveSubgraphNamer(Protocol):
         return_tree: Literal[True],
         decision_trace: DecisionTrace | None = None,
     ) -> tuple[str, dict | None]: ...
-
-
-# Domain aliases keep call sites readable while sharing one source of truth.
-SubgraphNamer = RecursiveSubgraphNamer
-BranchNamer = RecursiveSubgraphNamer

--- a/src/openclatura/naming_protocols.py
+++ b/src/openclatura/naming_protocols.py
@@ -1,0 +1,66 @@
+"""Shared callable contracts for recursive structure naming."""
+
+from typing import Literal, Protocol, overload
+
+from .molecule import DecisionTrace, Molecule
+
+
+class RecursiveSubgraphNamer(Protocol):
+    """Name a branch, optionally returning trace segments and its tree node."""
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> str: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[True],
+        return_tree: Literal[False] = False,
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict]]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[True],
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, list[dict], dict | None]: ...
+
+    @overload
+    def __call__(
+        self,
+        mol: Molecule,
+        start_idx: int,
+        exclude_atoms: set[int],
+        upstream_atom: int | None = None,
+        *,
+        return_trace: Literal[False] = False,
+        return_tree: Literal[True],
+        decision_trace: DecisionTrace | None = None,
+    ) -> tuple[str, dict | None]: ...
+
+
+# Domain aliases keep call sites readable while sharing one source of truth.
+SubgraphNamer = RecursiveSubgraphNamer
+BranchNamer = RecursiveSubgraphNamer

--- a/src/openclatura/naming_protocols.py
+++ b/src/openclatura/naming_protocols.py
@@ -2,6 +2,7 @@
 
 from typing import Literal, Protocol, overload
 
+from .assembly_parts import RenderedSubstituentText
 from .molecule import DecisionTrace, Molecule
 
 
@@ -14,12 +15,12 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[False] = False,
         return_tree: Literal[False] = False,
         decision_trace: DecisionTrace | None = None,
-    ) -> str: ...
+    ) -> RenderedSubstituentText: ...
 
     @overload
     def __call__(
@@ -27,12 +28,12 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[True],
         return_tree: Literal[False] = False,
         decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict]]: ...
+    ) -> tuple[RenderedSubstituentText, list[dict]]: ...
 
     @overload
     def __call__(
@@ -40,12 +41,12 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[True],
         return_tree: Literal[True],
         decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict], dict | None]: ...
+    ) -> tuple[RenderedSubstituentText, list[dict], dict | None]: ...
 
     @overload
     def __call__(
@@ -53,9 +54,9 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[False] = False,
         return_tree: Literal[True],
         decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, dict | None]: ...
+    ) -> tuple[RenderedSubstituentText, dict | None]: ...

--- a/src/openclatura/special_cases.py
+++ b/src/openclatura/special_cases.py
@@ -8,6 +8,7 @@ from .assembly_parts import NameAtomBinding, NameTokenBinding
 from .charge_pair_roles import charge_pair_roles
 from .formatting import format_counted_prefixes, format_multiplier, oxy_prefix_from_branch, strip_outer_parentheses
 from .molecule import Molecule
+from .naming_protocols import BranchNamer
 from .nitrogen_roles import azine_roles
 from .nomenclature import RULES
 from .oxoacid_roles import CentralOxoRole, OxoLigandRole, central_oxo_roles
@@ -17,7 +18,6 @@ from .retained_specs import retained_parent_spec
 from .rules import multipliers, retained, stems
 
 ComponentNamer = Callable[..., str]
-BranchNamer = Callable[..., str]
 
 
 @dataclass(frozen=True)

--- a/src/openclatura/special_cases.py
+++ b/src/openclatura/special_cases.py
@@ -8,7 +8,7 @@ from .assembly_parts import NameAtomBinding, NameTokenBinding
 from .charge_pair_roles import charge_pair_roles
 from .formatting import format_counted_prefixes, format_multiplier, oxy_prefix_from_branch, strip_outer_parentheses
 from .molecule import Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .nitrogen_roles import azine_roles
 from .nomenclature import RULES
 from .oxoacid_roles import CentralOxoRole, OxoLigandRole, central_oxo_roles
@@ -95,7 +95,7 @@ def single_atom_component_name(mol: Molecule, component_atoms: set[int]) -> str:
 def structural_replacement_parent_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Return a replacement-parent hydride name from graph-derived specs."""
 
@@ -106,7 +106,7 @@ def structural_replacement_parent_name(
 def structural_replacement_parent_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Return a graph-bound replacement-parent hydride name result."""
 
@@ -391,7 +391,7 @@ def _lambda_ring_unsaturation_suffix(mol: Molecule, path: list[int]) -> str:
 def simple_azine_parent_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name simple acyclic ketazines/aldazines from a graph C=N-N=C role."""
 
@@ -439,7 +439,7 @@ def simple_azine_parent_name(
 def phosphane_borane_zwitterion_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name graph-proven B(-)(H)3-P(+) zwitterions as boranuide parents."""
 
@@ -450,7 +450,7 @@ def phosphane_borane_zwitterion_name(
 def phosphane_borane_zwitterion_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Name graph-proven B(-)(H)3-P(+) zwitterions with bound ligands and charges."""
 
@@ -856,7 +856,7 @@ def _hydrazone_stereo_prefix(mol: Molecule, carbon: int, nitrogen: int, parent_n
 def sulfonium_ylide_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name graph-proven sulfonium/carbanion ylides as full components."""
 
@@ -951,7 +951,7 @@ def sulfonium_ylide_name(
 def sulfonium_ylide_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Return a typed sulfonium ylide result for the graph-proven renderer."""
 
@@ -1025,7 +1025,7 @@ def _linear_alkyl_carbanion_parent_name(mol: Molecule, carbon_atoms: set[int], r
 def hydroxyurea_parent_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name graph-proven N-hydroxyureas without carbamic-acid fallback wording."""
 
@@ -1036,7 +1036,7 @@ def hydroxyurea_parent_name(
 def hydroxyurea_parent_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Name graph-proven N-hydroxyureas with core/hydroxy/ligand bindings."""
 
@@ -1163,7 +1163,7 @@ def _urea_n_ligand_names(
     component_atoms: set[int],
     nitrogen: int,
     core_atoms: set[int],
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> list[tuple[set[int], str]] | None:
     ligands = []
     for root in mol.get_neighbors(nitrogen):
@@ -1254,7 +1254,7 @@ def oxoacid_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialCo
 def oxoacid_ester_name(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> str:
     """Name organic esters of data-backed oxoacid parent hydrides."""
 
@@ -1265,7 +1265,7 @@ def oxoacid_ester_name(
 def oxoacid_ester_result(
     mol: Molecule,
     component_atoms: set[int],
-    branch_namer: BranchNamer | None = None,
+    branch_namer: RecursiveSubgraphNamer | None = None,
 ) -> SpecialComponentName | None:
     """Name organic esters with separate modifier and central-oxo suffix bindings."""
 
@@ -1328,7 +1328,7 @@ def _peroxy_oxoacid_ester_name(
     component_atoms: set[int],
     role: CentralOxoRole,
     suffix: str,
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> str:
     result = _peroxy_oxoacid_ester_result(mol, component_atoms, role, suffix, branch_namer)
     return result.name if result is not None else ""
@@ -1339,7 +1339,7 @@ def _peroxy_oxoacid_ester_result(
     component_atoms: set[int],
     role: CentralOxoRole,
     suffix: str,
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> SpecialComponentName | None:
     peroxy_ligands = [ligand for ligand in role.ligands if ligand.role == OxoLigandRole.PEROXY]
     if len(peroxy_ligands) != 1 or not suffix:
@@ -1478,7 +1478,7 @@ def _ester_modifier_name(
     root: int,
     ester_oxygen: int,
     acid_atoms: set[int],
-    branch_namer: BranchNamer | None,
+    branch_namer: RecursiveSubgraphNamer | None,
 ) -> str:
     if branch_namer is not None:
         name = branch_namer(mol, root, set(mol.atoms) - component_atoms | acid_atoms, upstream_atom=ester_oxygen)

--- a/src/openclatura/substituent_tokens.py
+++ b/src/openclatura/substituent_tokens.py
@@ -1,16 +1,14 @@
 """Graph-derived emitted-token metadata for composed substituent prefixes."""
 
 import re
-from collections.abc import Callable
 
 from .assembly_parts import NameTokenBinding
 from .formatting import strip_outer_parentheses
 from .molecule import Molecule
+from .naming_protocols import BranchNamer
 from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, RELATIVE_STEREO_DESCRIPTORS
 from .token_grammar import is_locant_token, lexical_token_spans, lexical_tokens
 from .trace_helpers import bond_ids_within
-
-BranchNamer = Callable[..., str]
 
 
 def graph_bound_substituent_tokens(

--- a/src/openclatura/substituent_tokens.py
+++ b/src/openclatura/substituent_tokens.py
@@ -5,7 +5,7 @@ import re
 from .assembly_parts import NameTokenBinding
 from .formatting import strip_outer_parentheses
 from .molecule import Molecule
-from .naming_protocols import BranchNamer
+from .naming_protocols import RecursiveSubgraphNamer
 from .stereo_descriptors import ABSOLUTE_STEREO_DESCRIPTORS, RELATIVE_STEREO_DESCRIPTORS
 from .token_grammar import is_locant_token, lexical_token_spans, lexical_tokens
 from .trace_helpers import bond_ids_within
@@ -18,7 +18,7 @@ def graph_bound_substituent_tokens(
     term: str,
     upstream_atom: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[NameTokenBinding, ...]:
     """Return precise token bindings for graph-composed substituent terms."""
 
@@ -100,7 +100,7 @@ def _generic_heteroatom_substituent_tokens(
     term: str,
     upstream_atom: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[NameTokenBinding, ...]:
     """Return graph-bound tokens for non-nitrogen heteroatom-center prefixes."""
 
@@ -492,7 +492,7 @@ def _nitrogen_substituent_tokens(
     term: str,
     upstream_atom: int,
     exclude_atoms: set[int],
-    branch_namer: BranchNamer,
+    branch_namer: RecursiveSubgraphNamer,
 ) -> tuple[NameTokenBinding, ...]:
     term_text = strip_outer_parentheses(term)
     lower_term = term_text.lower()

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -26,6 +26,7 @@ from openclatura.assembly_parts import (
     NameTokenBinding,
     ParentChargeItem,
     PrincipalGroupItem,
+    RenderedSubstituentName,
     SubstituentItem,
     UnsaturationItem,
 )
@@ -279,7 +280,13 @@ def test_substituent_suffix_metadata_is_emitted_by_assembly_parts():
 
 def test_tree_builders_share_schema_without_mutable_defaults():
     assembled = build_naming_tree_node(kind="fragment", name="ethyl", atom_ids={2, 1}, bond_ids={7})
-    shortcut = build_shortcut_tree_node(kind="component", name="methane", atom_ids={0})
+    nested_decisions = [{"decision": "shortcut selected"}]
+    shortcut = build_shortcut_tree_node(
+        kind="component",
+        name="methane",
+        atom_ids={0},
+        nested_decisions=nested_decisions,
+    )
 
     common_keys = {
         "kind",
@@ -297,6 +304,7 @@ def test_tree_builders_share_schema_without_mutable_defaults():
     assert common_keys <= assembled.keys()
     assert common_keys <= shortcut.keys()
     assert assembled["atoms"] == [1, 2]
+    assert shortcut["nested_decisions"] == nested_decisions
     assembled["substituents"].append({"name": "methyl"})
     assert shortcut["substituents"] == []
 
@@ -318,12 +326,27 @@ def test_locanted_stereochemical_substituent_keeps_disambiguating_parentheses():
         retained_name="benzene",
         parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 7)},
         substituents=[
-            SubstituentItem(name="((3R)-3-cyclohexylcyclohexyl)", locants=["1"]),
+            SubstituentItem(
+                name=RenderedSubstituentName(
+                    "((3R)-3-cyclohexylcyclohexyl)",
+                    outer_parentheses_optional=True,
+                ),
+                locants=["1"],
+            ),
             SubstituentItem(name="methyl", locants=["4"]),
         ],
     )
 
     assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)-4-methylbenzene"
+
+
+def test_nested_stereochemical_substituent_keeps_semantic_boundary():
+    smiles = "CC1=CCCC[C@@H]1C(NCCCn1ccnc1)c1nnnn1C1CCCC1"
+
+    assert name_smiles(smiles) == (
+        "N-((1-cyclopentyl-1H-tetrazol-5-yl)((1S)-2-methylcyclohex-2-en-1-yl)methyl)-"
+        "3-(1H-imidazol-1-yl)propan-1-amine"
+    )
 
 
 def test_hydrogen_cyanide_absorbed_nitrile_name_passes_final_audit():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -26,7 +26,6 @@ from openclatura.assembly_parts import (
     NameTokenBinding,
     ParentChargeItem,
     PrincipalGroupItem,
-    RenderedSubstituentName,
     SubstituentItem,
     UnsaturationItem,
 )
@@ -309,6 +308,14 @@ def test_tree_builders_share_schema_without_mutable_defaults():
     assert shortcut["substituents"] == []
 
 
+def test_tree_builder_rejects_unknown_or_invariant_metadata_fields():
+    with pytest.raises(ValueError, match="Unknown tree metadata fields"):
+        build_naming_tree_node(kind="component", name="methane", metadata={"unexpected": []})
+
+    with pytest.raises(ValueError, match="cannot replace invariant fields"):
+        build_naming_tree_node(kind="component", name="methane", metadata={"name": "other"})
+
+
 def test_methane_is_named_without_parent_selection_fallback():
     assert name_smiles("C") == "methane"
 
@@ -327,17 +334,32 @@ def test_locanted_stereochemical_substituent_keeps_disambiguating_parentheses():
         parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 7)},
         substituents=[
             SubstituentItem(
-                name=RenderedSubstituentName(
-                    "((3R)-3-cyclohexylcyclohexyl)",
-                    outer_parentheses_optional=True,
-                ),
+                name="((3R)-3-cyclohexylcyclohexyl)",
                 locants=["1"],
+                outer_parentheses_optional=True,
             ),
             SubstituentItem(name="methyl", locants=["4"]),
         ],
     )
 
     assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)-4-methylbenzene"
+
+
+def test_stereochemical_substituent_reused_as_substituent_preserves_optional_outer_parentheses():
+    parts = AssemblyParts(
+        parent_length=2,
+        is_substituent=True,
+        parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 3)},
+        substituents=[
+            SubstituentItem(
+                name="((3R)-3-cyclohexylcyclohexyl)",
+                locants=["1"],
+                outer_parentheses_optional=True,
+            )
+        ],
+    )
+
+    assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)ethyl"
 
 
 def test_nested_stereochemical_substituent_keeps_semantic_boundary():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -344,8 +344,7 @@ def test_nested_stereochemical_substituent_keeps_semantic_boundary():
     smiles = "CC1=CCCC[C@@H]1C(NCCCn1ccnc1)c1nnnn1C1CCCC1"
 
     assert name_smiles(smiles) == (
-        "N-((1-cyclopentyl-1H-tetrazol-5-yl)((1S)-2-methylcyclohex-2-en-1-yl)methyl)-"
-        "3-(1H-imidazol-1-yl)propan-1-amine"
+        "N-((1-cyclopentyl-1H-tetrazol-5-yl)((1S)-2-methylcyclohex-2-en-1-yl)methyl)-3-(1H-imidazol-1-yl)propan-1-amine"
     )
 
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -104,7 +104,6 @@ from openclatura.namer import (
 )
 from openclatura.naming_audit import UnnamedAtomError, assert_component_fully_named, audit_charge_pair_templates
 from openclatura.naming_data import DATA_DIR, load_json_table, namer_rules
-from openclatura.naming_protocols import BranchNamer, RecursiveSubgraphNamer, SubgraphNamer
 from openclatura.nitrogen_roles import (
     acid_derived_hydrazone_roles,
     azine_roles,
@@ -276,11 +275,6 @@ def test_substituent_suffix_metadata_is_emitted_by_assembly_parts():
         "is_double_attach": False,
         "is_triple_attach": False,
     }
-
-
-def test_recursive_namer_roles_share_one_callable_protocol():
-    assert BranchNamer is RecursiveSubgraphNamer
-    assert SubgraphNamer is RecursiveSubgraphNamer
 
 
 def test_tree_builders_share_schema_without_mutable_defaults():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -305,6 +305,27 @@ def test_methane_is_named_without_parent_selection_fallback():
     assert name_smiles("C") == "methane"
 
 
+def test_single_unlocanted_stereochemical_substituent_omits_optional_outer_parentheses():
+    smiles = "C1(CCCCC1)[C@H]1CC(CCC1)C1=CC=CC=C1"
+
+    assert name_smiles(smiles) == "(3R)-3-cyclohexylcyclohexylbenzene"
+
+
+def test_locanted_stereochemical_substituent_keeps_disambiguating_parentheses():
+    parts = AssemblyParts(
+        parent_length=6,
+        is_ring=True,
+        retained_name="benzene",
+        parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 7)},
+        substituents=[
+            SubstituentItem(name="((3R)-3-cyclohexylcyclohexyl)", locants=["1"]),
+            SubstituentItem(name="methyl", locants=["4"]),
+        ],
+    )
+
+    assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)-4-methylbenzene"
+
+
 def test_hydrogen_cyanide_absorbed_nitrile_name_passes_final_audit():
     assert name_smiles("C#N") == "hydrogen cyanide"
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -104,6 +104,7 @@ from openclatura.namer import (
 )
 from openclatura.naming_audit import UnnamedAtomError, assert_component_fully_named, audit_charge_pair_templates
 from openclatura.naming_data import DATA_DIR, load_json_table, namer_rules
+from openclatura.naming_protocols import BranchNamer, RecursiveSubgraphNamer, SubgraphNamer
 from openclatura.nitrogen_roles import (
     acid_derived_hydrazone_roles,
     azine_roles,
@@ -172,7 +173,13 @@ from openclatura.token_grammar import (
     is_locant_token,
     lexical_token_spans,
 )
-from openclatura.trace_helpers import add_substituent_trace, assembly_substituent_tree, assembly_trace_segments
+from openclatura.trace_helpers import (
+    add_substituent_trace,
+    assembly_substituent_tree,
+    assembly_trace_segments,
+    build_naming_tree_node,
+    build_shortcut_tree_node,
+)
 from openclatura.von_baeyer import _classify_secondary_bridges, find_von_baeyer_candidates
 
 
@@ -268,6 +275,35 @@ def test_substituent_suffix_metadata_is_emitted_by_assembly_parts():
         "is_double_attach": False,
         "is_triple_attach": False,
     }
+
+
+def test_recursive_namer_roles_share_one_callable_protocol():
+    assert BranchNamer is RecursiveSubgraphNamer
+    assert SubgraphNamer is RecursiveSubgraphNamer
+
+
+def test_tree_builders_share_schema_without_mutable_defaults():
+    assembled = build_naming_tree_node(kind="fragment", name="ethyl", atom_ids={2, 1}, bond_ids={7})
+    shortcut = build_shortcut_tree_node(kind="component", name="methane", atom_ids={0})
+
+    common_keys = {
+        "kind",
+        "name",
+        "atoms",
+        "bonds",
+        "parent",
+        "principal_group",
+        "substituents",
+        "replacement_prefixes",
+        "unsaturations",
+        "trace_segments",
+        "nested_decisions",
+    }
+    assert common_keys <= assembled.keys()
+    assert common_keys <= shortcut.keys()
+    assert assembled["atoms"] == [1, 2]
+    assembled["substituents"].append({"name": "methyl"})
+    assert shortcut["substituents"] == []
 
 
 def test_methane_is_named_without_parent_selection_fallback():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -174,6 +174,7 @@ from openclatura.token_grammar import (
     lexical_token_spans,
 )
 from openclatura.trace_helpers import (
+    NamingTreeMetadata,
     add_substituent_trace,
     assembly_substituent_tree,
     assembly_trace_segments,
@@ -314,6 +315,31 @@ def test_tree_builder_rejects_unknown_or_invariant_metadata_fields():
 
     with pytest.raises(ValueError, match="cannot replace invariant fields"):
         build_naming_tree_node(kind="component", name="methane", metadata={"name": "other"})
+
+
+def test_tree_builder_accepts_and_merges_all_supported_metadata_fields():
+    metadata: NamingTreeMetadata = {
+        "name_atom_bindings": [{"text": "methane", "atoms": [0]}],
+        "name_token_spans": [{"text": "methane", "start": 0, "end": 7}],
+        "stereo_features": [{"descriptor": "R", "atom": 0}],
+        "indicated_hydrogens": ["1H"],
+        "hydro_operations": [{"kind": "added_hydrogen", "atom": 0}],
+        "parent_charges": [{"locant": "1", "charge": 1}],
+    }
+
+    node = build_naming_tree_node(
+        kind="component",
+        name="methane",
+        atom_ids={2, 0},
+        bond_ids={4},
+        metadata=metadata,
+    )
+
+    assert node["kind"] == "component"
+    assert node["name"] == "methane"
+    assert node["atoms"] == [0, 2]
+    assert node["bonds"] == [4]
+    assert metadata.items() <= node.items()
 
 
 def test_methane_is_named_without_parent_selection_fallback():

--- a/src/openclatura/trace_helpers.py
+++ b/src/openclatura/trace_helpers.py
@@ -1,14 +1,35 @@
 """Trace and explainability helpers for generated names."""
 
 from dataclasses import replace
+from typing import TypedDict
 
-from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem
+from .assembly_parts import (
+    AssemblyParts,
+    NameTokenBinding,
+    RenderedSubstituentName,
+    SubstituentItem,
+    split_rendered_substituent_name,
+)
 from .formatting import strip_outer_parentheses
 from .molecule import DecisionTrace, Molecule, TracePhase
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .principal_suffixes import principal_suffix_terms
 from .rules import bonds, multipliers, stems
+
+
+class NamingTreeMetadata(TypedDict, total=False):
+    """Optional, non-invariant fields supported by naming-tree nodes."""
+
+    name_atom_bindings: list[dict]
+    name_token_spans: list[dict]
+    stereo_features: list[dict]
+    indicated_hydrogens: list[str]
+    hydro_operations: list[dict]
+    parent_charges: list[dict]
+
+
+NAMING_TREE_METADATA_FIELDS = frozenset(NamingTreeMetadata.__annotations__)
 
 
 def decision_trace_data(trace: DecisionTrace | list | tuple | None) -> list[dict]:
@@ -84,7 +105,7 @@ def bond_ids_within(mol: Molecule, atom_ids: set[int]) -> set[int]:
 
 def add_substituent_trace(
     parts: AssemblyParts,
-    name: str,
+    name: str | RenderedSubstituentName,
     locant: str,
     atom_ids=None,
     bond_ids=None,
@@ -94,9 +115,13 @@ def add_substituent_trace(
     emitted_tokens: tuple[NameTokenBinding, ...] = (),
     substituent_tree=None,
     spiro=None,
+    outer_parentheses_optional: bool | None = None,
 ) -> None:
     """Append or merge a substituent while preserving trace atom/bond IDs."""
 
+    name, rendered_boundary_optional = split_rendered_substituent_name(name)
+    if outer_parentheses_optional is None:
+        outer_parentheses_optional = rendered_boundary_optional
     atom_ids = set(atom_ids or ())
     bond_ids = set(bond_ids or ())
     charge_atom_ids = set(charge_atom_ids or ())
@@ -104,7 +129,16 @@ def add_substituent_trace(
     nested_decisions = list(nested_decisions or ())
     if spiro is not None:
         spiro = replace(spiro, parent_locant=str(locant))
-    existing = next((s for s in parts.substituents if s.name == name and s.spiro == spiro), None)
+    existing = next(
+        (
+            item
+            for item in parts.substituents
+            if item.name == name
+            and item.spiro == spiro
+            and item.outer_parentheses_optional == outer_parentheses_optional
+        ),
+        None,
+    )
     if existing:
         existing.locants.append(locant)
         existing.atom_ids.update(atom_ids)
@@ -124,6 +158,7 @@ def add_substituent_trace(
             SubstituentItem(
                 name=name,
                 locants=[locant],
+                outer_parentheses_optional=outer_parentheses_optional,
                 atom_ids=atom_ids,
                 bond_ids=bond_ids,
                 charge_atom_ids=charge_atom_ids,
@@ -354,7 +389,7 @@ def build_naming_tree_node(
     unsaturations=None,
     trace_segments=None,
     nested_decisions=None,
-    metadata: dict | None = None,
+    metadata: NamingTreeMetadata | None = None,
 ) -> dict:
     """Build the invariant portion of every component/substituent tree node."""
 
@@ -375,6 +410,9 @@ def build_naming_tree_node(
         overlapping_keys = node.keys() & metadata.keys()
         if overlapping_keys:
             raise ValueError(f"Tree metadata cannot replace invariant fields: {sorted(overlapping_keys)}")
+        unknown_keys = metadata.keys() - NAMING_TREE_METADATA_FIELDS
+        if unknown_keys:
+            raise ValueError(f"Unknown tree metadata fields: {sorted(unknown_keys)}")
         node.update(metadata)
     return node
 
@@ -391,7 +429,7 @@ def build_shortcut_tree_node(
 ) -> dict:
     """Build a schema-complete tree node for a shortcut-rendered name."""
 
-    metadata = {}
+    metadata: NamingTreeMetadata = {}
     if name_atom_bindings is not None:
         metadata["name_atom_bindings"] = list(name_atom_bindings)
     if name_token_spans is not None:

--- a/src/openclatura/trace_helpers.py
+++ b/src/openclatura/trace_helpers.py
@@ -341,6 +341,71 @@ def attach_main_parent_decisions(
     return enriched
 
 
+def build_naming_tree_node(
+    *,
+    kind: str,
+    name: str,
+    atom_ids=None,
+    bond_ids=None,
+    parent=None,
+    principal_group=None,
+    substituents=None,
+    replacement_prefixes=None,
+    unsaturations=None,
+    trace_segments=None,
+    nested_decisions=None,
+    metadata: dict | None = None,
+) -> dict:
+    """Build the invariant portion of every component/substituent tree node."""
+
+    node = {
+        "kind": kind,
+        "name": name,
+        "atoms": sorted(atom_ids or ()),
+        "bonds": sorted(bond_ids or ()),
+        "parent": parent,
+        "principal_group": principal_group,
+        "substituents": list(substituents or ()),
+        "replacement_prefixes": list(replacement_prefixes or ()),
+        "unsaturations": list(unsaturations or ()),
+        "trace_segments": list(trace_segments or ()),
+        "nested_decisions": list(nested_decisions or ()),
+    }
+    if metadata:
+        overlapping_keys = node.keys() & metadata.keys()
+        if overlapping_keys:
+            raise ValueError(f"Tree metadata cannot replace invariant fields: {sorted(overlapping_keys)}")
+        node.update(metadata)
+    return node
+
+
+def build_shortcut_tree_node(
+    *,
+    kind: str,
+    name: str,
+    atom_ids,
+    bond_ids=None,
+    decisions=None,
+    name_atom_bindings: list[dict] | None = None,
+    name_token_spans: list[dict] | None = None,
+) -> dict:
+    """Build a schema-complete tree node for a shortcut-rendered name."""
+
+    metadata = {}
+    if name_atom_bindings is not None:
+        metadata["name_atom_bindings"] = list(name_atom_bindings)
+    if name_token_spans is not None:
+        metadata["name_token_spans"] = list(name_token_spans)
+    return build_naming_tree_node(
+        kind=kind,
+        name=name,
+        atom_ids=atom_ids,
+        bond_ids=bond_ids,
+        nested_decisions=decisions,
+        metadata=metadata,
+    )
+
+
 def assembly_substituent_tree(
     parts: AssemblyParts,
     *,
@@ -356,16 +421,16 @@ def assembly_substituent_tree(
         trace_segments = assembly_trace_segments(parts)
     component_atoms = set(atom_ids or parts.parent_atom_ids)
     component_bonds = set(bond_ids or parts.parent_bond_ids)
-    parent_node = {
-        "kind": "fragment",
-        "name": name,
-        "atoms": sorted(component_atoms),
-        "bonds": sorted(component_bonds),
-        "parent": _parent_tree_node(parts),
-        "principal_group": _principal_group_tree_node(parts),
-        "substituents": _substituent_tree_nodes(parts.substituents),
-        "replacement_prefixes": _simple_item_tree_nodes(parts.a_prefixes, "replacement_prefix"),
-        "unsaturations": [
+    return build_naming_tree_node(
+        kind="fragment",
+        name=name,
+        atom_ids=component_atoms,
+        bond_ids=component_bonds,
+        parent=_parent_tree_node(parts),
+        principal_group=_principal_group_tree_node(parts),
+        substituents=_substituent_tree_nodes(parts.substituents),
+        replacement_prefixes=_simple_item_tree_nodes(parts.a_prefixes, "replacement_prefix"),
+        unsaturations=[
             {
                 "kind": "unsaturation",
                 "bond_key": item.bond_key,
@@ -375,33 +440,34 @@ def assembly_substituent_tree(
             }
             for item in parts.unsaturations
         ],
-        "stereo_features": [
-            {"descriptor": descriptor, "locant": locant} for descriptor, locant in parts.stereo_features
-        ],
-        "indicated_hydrogens": list(parts.indicated_hydrogens),
-        "hydro_operations": [
-            {
-                "key": operation.key,
-                "reason": operation.reason,
-                "locants": list(operation.locants),
-                "atom_ids": sorted(operation.atom_ids),
-                "operation_kind": operation.operation_kind,
-            }
-            for operation in parts.hydro_operations
-        ],
-        "parent_charges": [
-            {
-                "locant": item.locant,
-                "symbol": item.symbol,
-                "charge": item.charge,
-                "atom_id": item.atom_id,
-            }
-            for item in parts.parent_charges
-        ],
-        "trace_segments": list(trace_segments),
-        "nested_decisions": list(decisions or ()),
-    }
-    return parent_node
+        trace_segments=trace_segments,
+        nested_decisions=decisions,
+        metadata={
+            "stereo_features": [
+                {"descriptor": descriptor, "locant": locant} for descriptor, locant in parts.stereo_features
+            ],
+            "indicated_hydrogens": list(parts.indicated_hydrogens),
+            "hydro_operations": [
+                {
+                    "key": operation.key,
+                    "reason": operation.reason,
+                    "locants": list(operation.locants),
+                    "atom_ids": sorted(operation.atom_ids),
+                    "operation_kind": operation.operation_kind,
+                }
+                for operation in parts.hydro_operations
+            ],
+            "parent_charges": [
+                {
+                    "locant": item.locant,
+                    "symbol": item.symbol,
+                    "charge": item.charge,
+                    "atom_id": item.atom_id,
+                }
+                for item in parts.parent_charges
+            ],
+        },
+    )
 
 
 def _merge_substituent_tree_instances(existing: dict | None, new: dict, name: str) -> dict:

--- a/src/openclatura/trace_helpers.py
+++ b/src/openclatura/trace_helpers.py
@@ -385,7 +385,7 @@ def build_shortcut_tree_node(
     name: str,
     atom_ids,
     bond_ids=None,
-    decisions=None,
+    nested_decisions=None,
     name_atom_bindings: list[dict] | None = None,
     name_token_spans: list[dict] | None = None,
 ) -> dict:
@@ -401,7 +401,7 @@ def build_shortcut_tree_node(
         name=name,
         atom_ids=atom_ids,
         bond_ids=bond_ids,
-        nested_decisions=decisions,
+        nested_decisions=nested_decisions,
         metadata=metadata,
     )
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce shared recursive naming protocols and tree-node builders while improving stereochemical substituent formatting and updating packaging and CI configuration.

New Features:
- Add helpers to build naming tree nodes and shortcut tree nodes with a shared, schema-complete structure.
- Introduce a RecursiveSubgraphNamer protocol to standardize recursive branch/subgraph naming contracts.
- Add RenderedSubstituentName to carry metadata about optional outer parentheses around substituent names.

Enhancements:
- Refactor component and substituent shortcut tree construction to use the shared tree-node builders and metadata merging.
- Tighten handling of optional outer parentheses for complex substituent prefixes to avoid unnecessary parentheses while preserving semantic boundaries.
- Prevent tree metadata from overwriting invariant fields when assembling naming tree nodes.

Build:
- Bump project version from 0.1.3 to 0.1.4 and configure Hatch build to exclude examples and evaluation directories from distributions.

CI:
- Adjust the paper-evaluations GitHub Actions job to run on pull requests targeting the tests branch instead of direct pushes.

Documentation:
- Update README development instructions to reference the correct openclatura repository and directory name.

Tests:
- Add tests ensuring naming tree builders share a common schema and avoid mutable default pitfalls.
- Add regression tests covering stereochemical substituent naming and the omission or retention of optional parentheses around substituents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust stereochemical substituent naming with smarter optional parenthesis handling.
  * Improved naming/trace output fidelity for assembled structures.
* **Bug Fixes**
  * Fixed nested and reused stereochemical substituents to preserve correct semantic boundaries, including locanted disambiguation.
  * Improved consistency in naming tree generation.
* **Documentation**
  * Updated development instructions to point to the correct repository.
* **Chores**
  * Bumped version to 0.1.4 and refined build packaging; adjusted CI to run evaluations for the right pull-request branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->