### PR TITLE
frozen RenderedSubstituentName dataclass

### DIFF
--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -27,15 +27,32 @@ class NameTokenBinding:
     right_context: str = ""
 
 
-class RenderedSubstituentName(str):
-    """A rendered substituent carrying construction-time boundary metadata."""
+@dataclass(frozen=True)
+class RenderedSubstituentName:
+    """Rendered text plus construction-time parenthesis-boundary metadata."""
 
-    outer_parentheses_optional: bool
+    text: str
+    outer_parentheses_optional: bool = False
 
-    def __new__(cls, value: str, *, outer_parentheses_optional: bool = False):
-        rendered = super().__new__(cls, value)
-        rendered.outer_parentheses_optional = outer_parentheses_optional
-        return rendered
+    def __str__(self) -> str:
+        return self.text
+
+
+RenderedSubstituentText = str | RenderedSubstituentName
+
+
+def split_rendered_substituent_name(name: RenderedSubstituentText) -> tuple[str, bool]:
+    """Return plain text and explicit boundary metadata for a rendered name."""
+
+    if isinstance(name, RenderedSubstituentName):
+        return name.text, name.outer_parentheses_optional
+    return name, False
+
+
+def rendered_substituent_text(name: RenderedSubstituentText) -> str:
+    """Return plain text when boundary metadata is no longer needed."""
+
+    return name.text if isinstance(name, RenderedSubstituentName) else name
 
 
 @dataclass
@@ -50,6 +67,7 @@ class SubstituentItem:
     nested_decisions: list[dict] = field(default_factory=list)
     substituent_tree: dict | None = None
     spiro: SpiroAssembly | None = None
+    outer_parentheses_optional: bool = False
 
 
 @dataclass

--- a/src/openclatura/assembly_prefixes.py
+++ b/src/openclatura/assembly_prefixes.py
@@ -3,7 +3,7 @@
 import re
 
 from .assembly_charge import inferred_ionic_retained_parent, single_charged_replacement_locants
-from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
+from .assembly_parts import AssemblyParts, SubstituentItem
 from .assembly_utils import is_fully_enclosed, needs_hyphen, parse_locant
 from .formatting import is_complex_prefix
 from .nomenclature import RULES
@@ -148,6 +148,7 @@ def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:
     prefix_parts = []
     for name in sorted(grouped.keys(), key=substituent_sort_key):
         items = grouped[name]
+        outer_parentheses_optional = all(item.outer_parentheses_optional for item in items)
         locs = sorted([loc for item in items for loc in item.locants], key=parse_locant)
         attachments_per_group = 2 if ("diyl" in name and "ylidene" not in name) else 1
         count_raw = len(locs) if locs else len(items)
@@ -156,7 +157,14 @@ def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:
         mult = (multipliers.complex_(count) if is_complex else multipliers.basic(count)) if count > 1 else ""
         loc_str = substituent_locant_string(parts, locs, len(grouped), spiro_subs)
 
-        name_to_use = _omit_optional_outer_parentheses(parts, name, count, loc_str, len(grouped))
+        name_to_use = _omit_optional_outer_parentheses(
+            parts,
+            name,
+            count,
+            loc_str,
+            len(grouped),
+            outer_parentheses_optional=outer_parentheses_optional,
+        )
         if is_complex and not is_fully_enclosed(name_to_use):
             if count > 1 or loc_str:
                 name_to_use = f"({name_to_use})"
@@ -177,6 +185,8 @@ def _omit_optional_outer_parentheses(
     count: int,
     locant_text: str,
     grouped_count: int,
+    *,
+    outer_parentheses_optional: bool,
 ) -> str:
     """Unwrap a directly rendered fragment when its parent boundary is clear."""
 
@@ -185,8 +195,7 @@ def _omit_optional_outer_parentheses(
         or count != 1
         or locant_text
         or grouped_count != 1
-        or not isinstance(name, RenderedSubstituentName)
-        or not name.outer_parentheses_optional
+        or not outer_parentheses_optional
         or not is_fully_enclosed(name)
     ):
         return name

--- a/src/openclatura/component_modifiers.py
+++ b/src/openclatura/component_modifiers.py
@@ -1,6 +1,6 @@
 """Data-driven component modifiers attached after parent numbering."""
 
-from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem
+from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem, split_rendered_substituent_name
 from .formatting import strip_outer_parentheses
 from .group_atom_roles import ester_or_peroxy_single_oxygen
 from .locants import parse_locant
@@ -119,10 +119,12 @@ def add_component_n_substituents(
                         bond_ids_within(mol, {single_n, n_sub}),
                     )
                     if _use_hydrazone_suffix_modifier(parts, principal_key):
+                        branch_text, outer_parentheses_optional = split_rendered_substituent_name(branch_name)
                         parts.principal_suffix_modifiers.append(
                             SubstituentItem(
-                                branch_name,
+                                branch_text,
                                 [],
+                                outer_parentheses_optional=outer_parentheses_optional,
                                 atom_ids=branch_atoms,
                                 bond_ids=bond_ids_within(mol, branch_atoms | {single_n}),
                                 charge_atom_ids=_charged_atoms(mol, branch_atoms),

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 
-from .assembly_parts import AssemblyParts, NameAtomBinding, SubstituentItem
+from .assembly_parts import AssemblyParts, NameAtomBinding, SubstituentItem, split_rendered_substituent_name
 from .chains import find_all_carbon_paths, find_ring_systems, get_cyclic_atoms
 from .component_group_rules import (
     exclude_nonparent_group_atoms,
@@ -132,6 +132,7 @@ def collect_component_branch_substituents(
                     )
                     branch_trace = []
                     branch_tree = None
+                branch_name, outer_parentheses_optional = split_rendered_substituent_name(branch_name)
                 if branch_name:
                     branch_exclude = sub_exclude | main_set
                     branch_atoms = subgraph_component(mol, n_idx, branch_exclude)
@@ -139,6 +140,7 @@ def collect_component_branch_substituents(
                         SubstituentItem(
                             name=branch_name,
                             locants=[],
+                            outer_parentheses_optional=outer_parentheses_optional,
                             atom_ids=branch_atoms,
                             bond_ids=bond_ids_within(mol, branch_atoms | {c_idx}),
                             charge_atom_ids=_charged_atoms(mol, branch_atoms),
@@ -183,6 +185,7 @@ def add_component_substituents(
                     item.emitted_tokens,
                     substituent_tree=item.substituent_tree,
                     spiro=item.spiro,
+                    outer_parentheses_optional=item.outer_parentheses_optional,
                 )
 
 

--- a/src/openclatura/formatting.py
+++ b/src/openclatura/formatting.py
@@ -2,6 +2,7 @@
 
 import re
 
+from .assembly_parts import RenderedSubstituentName, rendered_substituent_text
 from .namer_config import ALKYL_OXY_PREFIXES
 from .rules import multipliers, stems
 
@@ -22,9 +23,10 @@ def is_fully_enclosed(s: str) -> bool:
     return depth == 0
 
 
-def strip_outer_parentheses(name: str) -> str:
+def strip_outer_parentheses(name: str | RenderedSubstituentName) -> str:
     """Remove one balanced outer parenthesis pair from a fragment."""
 
+    name = rendered_substituent_text(name)
     if name.startswith("(") and name.endswith(")"):
         return name[1:-1]
     return name

--- a/src/openclatura/functional_prefixes.py
+++ b/src/openclatura/functional_prefixes.py
@@ -5,7 +5,7 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from .assembly_parts import NameTokenBinding, SubstituentItem
+from .assembly_parts import NameTokenBinding, SubstituentItem, rendered_substituent_text
 from .formatting import format_counted_prefixes, is_complex_prefix, oxy_prefix_from_branch, strip_outer_parentheses
 from .group_atom_roles import amide_nitrogen, ester_or_peroxy_single_oxygen
 from .molecule import Molecule
@@ -45,6 +45,7 @@ def ester_prefix_from_group(
     branch_name = branch_namer(mol, r_group_c, sub_exclude | {single_o}, upstream_atom=single_o)
     if not branch_name:
         return ""
+    branch_name = rendered_substituent_text(branch_name)
     return f"({oxy_prefix_from_branch(branch_name)}{suffix_text})"
 
 
@@ -62,7 +63,10 @@ def amide_prefix_from_group(
         return ""
     if not n_subs:
         return base
-    sub_names = [branch_namer(mol, x, sub_exclude | {single_n}, upstream_atom=single_n) for x in n_subs]
+    sub_names = [
+        rendered_substituent_text(branch_namer(mol, x, sub_exclude | {single_n}, upstream_atom=single_n))
+        for x in n_subs
+    ]
     return f"({format_counted_prefixes(sub_names)}{base})"
 
 
@@ -87,7 +91,14 @@ def iminium_prefix_handler(context: PrefixContext, group: PerceivedGroup) -> str
     if not n_subs:
         return "iminio"
     sub_names = [
-        context.branch_namer(context.mol, n_sub, context.sub_exclude | {iminium_n}, upstream_atom=iminium_n)
+        rendered_substituent_text(
+            context.branch_namer(
+                context.mol,
+                n_sub,
+                context.sub_exclude | {iminium_n},
+                upstream_atom=iminium_n,
+            )
+        )
         for n_sub in n_subs
     ]
     return f"({format_counted_prefixes(sub_names)}iminio)"

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -466,7 +466,9 @@ def _sulfur_imide_branch_name(
         cyclic_name = _cyclic_sulfur_imide_ligand_name(mol, sulfur, nitrogen, next_atoms, s_oxygens)
         if cyclic_name:
             return cyclic_name
-        branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, local_exclude, sulfur))]
+        branches = [
+            br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, local_exclude, sulfur))
+        ]
         branches.extend(["oxo"] * len(s_oxygens))
         if not branches:
             return "sulfanylidene"
@@ -588,7 +590,9 @@ def name_sulfur_subgraph(
             br
             for nxt in next_atoms
             if (
-                br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx)
+                br := _branch_name_text(
+                    branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx
+                )
             )
         ]
         branches.extend(["oxo"] * len(s_oxygens))
@@ -609,7 +613,9 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx))
+            if (
+                br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx)
+            )
         ]
         branches.extend(["oxo"] * len(s_oxygens))
         return format_lambda_substituent(
@@ -623,7 +629,11 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx))
+            if (
+                br := _branch_name_text(
+                    branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx
+                )
+            )
         ]
         if len(s_nitrogens) == 1:
             branches = ["imino", *branches]
@@ -648,7 +658,11 @@ def name_sulfur_subgraph(
             return format_element_substituent(stereo_prefix_text, branch, "sulfanyl", is_double=is_double)
         return f"{stereo_prefix_text}{'sulfanylidene' if is_double else 'sulfanyl'}"
 
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, "sulfanylidene" if is_double else "sulfanyl"
     )
@@ -679,7 +693,11 @@ def name_chalcogen_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx))
+            if (
+                br := _branch_name_text(
+                    branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx
+                )
+            )
         ]
         branches.extend(["oxo"] * len(oxo_ligands))
         return format_lambda_substituent(
@@ -706,7 +724,11 @@ def name_chalcogen_subgraph(
         if branch:
             return format_element_substituent(stereo_prefix_text, branch, element_suffix, is_double=is_double)
         return f"{stereo_prefix_text}{element_suffix + ('idene' if is_double else '')}"
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, element_suffix + ("idene" if is_double else "")
     )
@@ -754,7 +776,11 @@ def name_group_13_14_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return suffix
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     return f"({format_counted_prefixes(branches)}{suffix})"
 
 
@@ -769,7 +795,11 @@ def name_halogen_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return HALOGEN_PREFIXES[symbol]
-    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [
+        br
+        for nxt in next_atoms
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
+    ]
     valence = sum(mol.get_bond(start_idx, n).order for n in mol.get_neighbors(start_idx))
     return f"({format_counted_prefixes(branches)}lambda^{valence}-{HALOGEN_LAMBDA_SUFFIXES[symbol]})"
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -1,5 +1,6 @@
 """Heteroatom-starting recursive substituent naming."""
 
+from .assembly_parts import split_rendered_substituent_name
 from .formatting import (
     count_names,
     format_counted_prefixes,
@@ -24,6 +25,25 @@ from .nitrogen_roles import terminal_n3_substituent_role
 from .nomenclature import RULES
 from .oxoacid_roles import OxoLigandRole, central_oxo_substituent_role
 from .rules import multipliers
+
+
+def _branch_name_text(
+    branch_namer: RecursiveSubgraphNamer,
+    mol: Molecule,
+    start_idx: int,
+    exclude_atoms: set[int],
+    upstream_atom: int,
+) -> str:
+    """Render a nested branch as text, consuming its boundary metadata."""
+
+    rendered = branch_namer(
+        mol,
+        start_idx,
+        exclude_atoms,
+        upstream_atom=upstream_atom,
+    )
+    name, _ = split_rendered_substituent_name(rendered)
+    return name
 
 
 def upstream_bond_order(mol: Molecule, start_idx: int, upstream_atom: int | None) -> int:
@@ -152,7 +172,7 @@ def name_branch_or_none(
 ) -> str:
     if branch_idx is None:
         return ""
-    return strip_outer_parentheses(branch_namer(mol, branch_idx, exclude_atoms, upstream_atom))
+    return strip_outer_parentheses(_branch_name_text(branch_namer, mol, branch_idx, exclude_atoms, upstream_atom))
 
 
 def name_carbonyl_like_fragment(
@@ -331,7 +351,7 @@ def name_oxygen_subgraph(
         branch = name_branch_or_none(mol, branch_idx, exclude_atoms | {start_idx, nxt}, nxt, branch_namer)
         return f"({branch}peroxy)" if branch else "hydroperoxy"
 
-    branch = branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx)
+    branch = _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx)
     if branch:
         return oxy_prefix_from_branch(branch)
     return "hydroxy"
@@ -406,7 +426,7 @@ def name_nitrogen_subgraph(
                 if sulfur_imide:
                     branches.append(sulfur_imide)
             else:
-                branch = branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx)
+                branch = _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx)
                 if branch:
                     branches.append(branch)
 
@@ -446,7 +466,7 @@ def _sulfur_imide_branch_name(
         cyclic_name = _cyclic_sulfur_imide_ligand_name(mol, sulfur, nitrogen, next_atoms, s_oxygens)
         if cyclic_name:
             return cyclic_name
-        branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, local_exclude, sulfur))]
+        branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, local_exclude, sulfur))]
         branches.extend(["oxo"] * len(s_oxygens))
         if not branches:
             return "sulfanylidene"
@@ -568,7 +588,7 @@ def name_sulfur_subgraph(
             br
             for nxt in next_atoms
             if (
-                br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx)
+                br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens) | set(s_nitrogens), start_idx)
             )
         ]
         branches.extend(["oxo"] * len(s_oxygens))
@@ -589,7 +609,7 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx))
+            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_oxygens), start_idx))
         ]
         branches.extend(["oxo"] * len(s_oxygens))
         return format_lambda_substituent(
@@ -603,7 +623,7 @@ def name_sulfur_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx))
+            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(s_nitrogens), start_idx))
         ]
         if len(s_nitrogens) == 1:
             branches = ["imino", *branches]
@@ -619,7 +639,7 @@ def name_sulfur_subgraph(
         return "thioxo" if is_double else f"{stereo_prefix_text}{unsubstituted_prefix('S') or 'sulfanyl'}"
 
     if len(next_atoms) == 1:
-        branch = branch_namer(mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
+        branch = _branch_name_text(branch_namer, mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
         if not is_double and mol.atoms[start_idx].charge > 0:
             return f"({stereo_prefix_text}{branch}sulfaniumyl)" if branch else f"{stereo_prefix_text}sulfaniumyl"
         if branch in SIMPLE_SULFANYL_PREFIXES:
@@ -628,7 +648,7 @@ def name_sulfur_subgraph(
             return format_element_substituent(stereo_prefix_text, branch, "sulfanyl", is_double=is_double)
         return f"{stereo_prefix_text}{'sulfanylidene' if is_double else 'sulfanyl'}"
 
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, "sulfanylidene" if is_double else "sulfanyl"
     )
@@ -659,7 +679,7 @@ def name_chalcogen_subgraph(
         branches = [
             br
             for nxt in next_atoms
-            if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx))
+            if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(oxo_ligands), start_idx))
         ]
         branches.extend(["oxo"] * len(oxo_ligands))
         return format_lambda_substituent(
@@ -676,7 +696,7 @@ def name_chalcogen_subgraph(
             else f"{stereo_prefix_text}{unsubstituted_prefix(mol.atoms[start_idx].symbol) or element_suffix}"
         )
     if len(next_atoms) == 1:
-        branch = branch_namer(mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
+        branch = _branch_name_text(branch_namer, mol, next_atoms[0], exclude_atoms | {start_idx}, start_idx)
         if branch and substituent_bonding_number(mol, start_idx) != mol.atoms[start_idx].element.standard_valence:
             return format_lambda_substituent(
                 mol, start_idx, [branch], stereo_prefix_text, element_suffix + ("idene" if is_double else "")
@@ -686,7 +706,7 @@ def name_chalcogen_subgraph(
         if branch:
             return format_element_substituent(stereo_prefix_text, branch, element_suffix, is_double=is_double)
         return f"{stereo_prefix_text}{element_suffix + ('idene' if is_double else '')}"
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, element_suffix + ("idene" if is_double else "")
     )
@@ -714,7 +734,7 @@ def name_phosphorus_subgraph(
     branches = [
         br
         for nxt in next_atoms
-        if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx} | set(p_oxygens), start_idx))
+        if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx} | set(p_oxygens), start_idx))
     ]
     return f"({stereo_prefix_text}{format_counted_prefixes(branches)}{suffix})"
 
@@ -734,7 +754,7 @@ def name_group_13_14_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return suffix
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     return f"({format_counted_prefixes(branches)}{suffix})"
 
 
@@ -749,7 +769,7 @@ def name_halogen_subgraph(
     next_atoms = subgraph_neighbors(mol, start_idx, exclude_atoms, upstream_atom)
     if not next_atoms:
         return HALOGEN_PREFIXES[symbol]
-    branches = [br for nxt in next_atoms if (br := branch_namer(mol, nxt, exclude_atoms | {start_idx}, start_idx))]
+    branches = [br for nxt in next_atoms if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))]
     valence = sum(mol.get_bond(start_idx, n).order for n in mol.get_neighbors(start_idx))
     return f"({format_counted_prefixes(branches)}lambda^{valence}-{HALOGEN_LAMBDA_SUFFIXES[symbol]})"
 

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -4,7 +4,14 @@ import re
 from dataclasses import dataclass, field
 
 from .assembler import assemble_name_raw, post_process_rewrite_rules
-from .assembly_parts import AssemblyParts, RenderedSubstituentName, SubstituentItem
+from .assembly_parts import (
+    AssemblyParts,
+    RenderedSubstituentName,
+    RenderedSubstituentText,
+    SubstituentItem,
+    rendered_substituent_text,
+    split_rendered_substituent_name,
+)
 from .assembly_spiro import extract_spiro_side_prefixes
 from .chains import find_ring_systems, get_cyclic_atoms
 from .component_namer import name_component as _name_component_impl
@@ -440,7 +447,9 @@ def _spiro_side_ring_branch_prefixes(
                 continue
             branch = _name_heteroaromatic_branch_substituent(mol, neighbor, atom_idx, allowed_branch_atoms)
             if not branch:
-                branch = name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+                branch = rendered_substituent_text(
+                    name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+                )
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{format_multiplier(branch, 1, safe_enclose=True)}")
     return side_prefixes
@@ -478,7 +487,9 @@ def _name_heteroaromatic_branch_substituent(
         for neighbor in sorted(mol.get_neighbors(atom_idx)):
             if neighbor == upstream_atom or neighbor not in branch_allowed:
                 continue
-            substituent = name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            substituent = rendered_substituent_text(
+                name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            )
             if substituent:
                 prefix_items.append(f"{locant_map[atom_idx]}-{substituent}")
     stem = parent_name[:-1] if parent_name.endswith("e") else parent_name
@@ -717,7 +728,9 @@ def _retained_n_ring_spiro_assembly(mol: Molecule, c_idx: int, sub_comp: set[int
         for neighbor in sorted(mol.get_neighbors(atom_idx)):
             if neighbor not in allowed_branch_atoms:
                 continue
-            branch = name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            branch = rendered_substituent_text(
+                name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
+            )
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{branch}")
 
@@ -896,6 +909,7 @@ def _collect_subgraph_substituents(
                     )
                     branch_trace = []
                     branch_tree = None
+                branch_name, outer_parentheses_optional = split_rendered_substituent_name(branch_name)
                 if branch_name:
                     branch_atoms = _subgraph_component(mol, n_idx, branch_exclude)
                     branch_with_attachment = branch_atoms | {c_idx}
@@ -916,6 +930,7 @@ def _collect_subgraph_substituents(
                         SubstituentItem(
                             name=branch_name,
                             locants=[],
+                            outer_parentheses_optional=outer_parentheses_optional,
                             atom_ids=branch_atoms,
                             bond_ids=_bond_ids_within(mol, branch_with_attachment),
                             charge_atom_ids=_charged_atoms(mol, branch_atoms),
@@ -951,6 +966,7 @@ def _add_subgraph_substituents(parts: AssemblyParts, subst_mapping: dict[int, li
                 item.emitted_tokens,
                 substituent_tree=item.substituent_tree,
                 spiro=item.spiro,
+                outer_parentheses_optional=item.outer_parentheses_optional,
             )
 
 
@@ -984,7 +1000,9 @@ def _finalize_subgraph_name(name: str, parts: AssemblyParts) -> str:
     return f"({name})"
 
 
-def _mark_optional_substituent_boundary(name: str, parts: AssemblyParts, finalize_subgraph: bool) -> str:
+def _mark_optional_substituent_boundary(
+    name: str, parts: AssemblyParts, finalize_subgraph: bool
+) -> RenderedSubstituentText:
     """Preserve whether construction made a subgraph boundary optional.
 
     This marker is applied after all name rewrites, since those rewrites return
@@ -1006,7 +1024,7 @@ def _assemble_parent_name(
     *,
     finalize_subgraph: bool = False,
     emit_metadata: bool = True,
-) -> str:
+) -> RenderedSubstituentText:
     """Assemble a parent name and apply shared post-assembly charge rules."""
 
     name = assemble_name_raw(parts)
@@ -1122,6 +1140,7 @@ def name_subgraph(
     mol: Molecule,
     start_idx: int,
     exclude_atoms: set[int],
+    *,
     upstream_atom: int = None,
     return_trace: bool = False,
     return_tree: bool = False,
@@ -1295,7 +1314,7 @@ def name_subgraph(
         parent_selection.is_polycycle,
     )
 
-    name = _assemble_parent_name(
+    rendered_name = _assemble_parent_name(
         mol,
         parts,
         numbered_path,
@@ -1303,6 +1322,7 @@ def name_subgraph(
         finalize_subgraph=True,
         emit_metadata=emit_metadata,
     )
+    name, _ = split_rendered_substituent_name(rendered_name)
     trace_segments = _assembly_trace_segments(parts) if return_trace or return_tree else []
     if decision_trace is not None:
         trace_decision(
@@ -1320,7 +1340,7 @@ def name_subgraph(
     if return_trace:
         if return_tree:
             return (
-                name,
+                rendered_name,
                 trace_segments,
                 _assembly_substituent_tree(
                     parts,
@@ -1331,10 +1351,10 @@ def name_subgraph(
                     trace_segments=trace_segments,
                 ),
             )
-        return name, trace_segments
+        return rendered_name, trace_segments
     if return_tree:
         return (
-            name,
+            rendered_name,
             _assembly_substituent_tree(
                 parts,
                 name=name,
@@ -1344,7 +1364,7 @@ def name_subgraph(
                 trace_segments=trace_segments,
             ),
         )
-    return name
+    return rendered_name
 
 
 def _shortcut_substituent_tree(

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -447,9 +447,7 @@ def _spiro_side_ring_branch_prefixes(
                 continue
             branch = _name_heteroaromatic_branch_substituent(mol, neighbor, atom_idx, allowed_branch_atoms)
             if not branch:
-                branch = rendered_substituent_text(
-                    name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
-                )
+                branch = rendered_substituent_text(name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx))
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{format_multiplier(branch, 1, safe_enclose=True)}")
     return side_prefixes
@@ -728,9 +726,7 @@ def _retained_n_ring_spiro_assembly(mol: Molecule, c_idx: int, sub_comp: set[int
         for neighbor in sorted(mol.get_neighbors(atom_idx)):
             if neighbor not in allowed_branch_atoms:
                 continue
-            branch = rendered_substituent_text(
-                name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx)
-            )
+            branch = rendered_substituent_text(name_subgraph(mol, neighbor, branch_exclude, upstream_atom=atom_idx))
             if branch:
                 side_prefixes.append(f"{locant_map[atom_idx]}'-{branch}")
 

--- a/src/openclatura/naming_protocols.py
+++ b/src/openclatura/naming_protocols.py
@@ -2,6 +2,7 @@
 
 from typing import Literal, Protocol, overload
 
+from .assembly_parts import RenderedSubstituentText
 from .molecule import DecisionTrace, Molecule
 
 
@@ -14,12 +15,12 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[False] = False,
         return_tree: Literal[False] = False,
         decision_trace: DecisionTrace | None = None,
-    ) -> str: ...
+    ) -> RenderedSubstituentText: ...
 
     @overload
     def __call__(
@@ -27,12 +28,12 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[True],
         return_tree: Literal[False] = False,
         decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict]]: ...
+    ) -> tuple[RenderedSubstituentText, list[dict]]: ...
 
     @overload
     def __call__(
@@ -40,12 +41,12 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[True],
         return_tree: Literal[True],
         decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, list[dict], dict | None]: ...
+    ) -> tuple[RenderedSubstituentText, list[dict], dict | None]: ...
 
     @overload
     def __call__(
@@ -53,9 +54,9 @@ class RecursiveSubgraphNamer(Protocol):
         mol: Molecule,
         start_idx: int,
         exclude_atoms: set[int],
-        upstream_atom: int | None = None,
         *,
+        upstream_atom: int | None = None,
         return_trace: Literal[False] = False,
         return_tree: Literal[True],
         decision_trace: DecisionTrace | None = None,
-    ) -> tuple[str, dict | None]: ...
+    ) -> tuple[RenderedSubstituentText, dict | None]: ...

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -26,7 +26,6 @@ from openclatura.assembly_parts import (
     NameTokenBinding,
     ParentChargeItem,
     PrincipalGroupItem,
-    RenderedSubstituentName,
     SubstituentItem,
     UnsaturationItem,
 )
@@ -309,6 +308,14 @@ def test_tree_builders_share_schema_without_mutable_defaults():
     assert shortcut["substituents"] == []
 
 
+def test_tree_builder_rejects_unknown_or_invariant_metadata_fields():
+    with pytest.raises(ValueError, match="Unknown tree metadata fields"):
+        build_naming_tree_node(kind="component", name="methane", metadata={"unexpected": []})
+
+    with pytest.raises(ValueError, match="cannot replace invariant fields"):
+        build_naming_tree_node(kind="component", name="methane", metadata={"name": "other"})
+
+
 def test_methane_is_named_without_parent_selection_fallback():
     assert name_smiles("C") == "methane"
 
@@ -327,17 +334,32 @@ def test_locanted_stereochemical_substituent_keeps_disambiguating_parentheses():
         parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 7)},
         substituents=[
             SubstituentItem(
-                name=RenderedSubstituentName(
-                    "((3R)-3-cyclohexylcyclohexyl)",
-                    outer_parentheses_optional=True,
-                ),
+                name="((3R)-3-cyclohexylcyclohexyl)",
                 locants=["1"],
+                outer_parentheses_optional=True,
             ),
             SubstituentItem(name="methyl", locants=["4"]),
         ],
     )
 
     assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)-4-methylbenzene"
+
+
+def test_stereochemical_substituent_reused_as_substituent_preserves_optional_outer_parentheses():
+    parts = AssemblyParts(
+        parent_length=2,
+        is_substituent=True,
+        parent_atom_symbols_by_locant={str(locant): "C" for locant in range(1, 3)},
+        substituents=[
+            SubstituentItem(
+                name="((3R)-3-cyclohexylcyclohexyl)",
+                locants=["1"],
+                outer_parentheses_optional=True,
+            )
+        ],
+    )
+
+    assert assemble_name(parts) == "1-((3R)-3-cyclohexylcyclohexyl)ethyl"
 
 
 def test_nested_stereochemical_substituent_keeps_semantic_boundary():

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -174,6 +174,7 @@ from openclatura.token_grammar import (
     lexical_token_spans,
 )
 from openclatura.trace_helpers import (
+    NamingTreeMetadata,
     add_substituent_trace,
     assembly_substituent_tree,
     assembly_trace_segments,
@@ -314,6 +315,31 @@ def test_tree_builder_rejects_unknown_or_invariant_metadata_fields():
 
     with pytest.raises(ValueError, match="cannot replace invariant fields"):
         build_naming_tree_node(kind="component", name="methane", metadata={"name": "other"})
+
+
+def test_tree_builder_accepts_and_merges_all_supported_metadata_fields():
+    metadata: NamingTreeMetadata = {
+        "name_atom_bindings": [{"text": "methane", "atoms": [0]}],
+        "name_token_spans": [{"text": "methane", "start": 0, "end": 7}],
+        "stereo_features": [{"descriptor": "R", "atom": 0}],
+        "indicated_hydrogens": ["1H"],
+        "hydro_operations": [{"kind": "added_hydrogen", "atom": 0}],
+        "parent_charges": [{"locant": "1", "charge": 1}],
+    }
+
+    node = build_naming_tree_node(
+        kind="component",
+        name="methane",
+        atom_ids={2, 0},
+        bond_ids={4},
+        metadata=metadata,
+    )
+
+    assert node["kind"] == "component"
+    assert node["name"] == "methane"
+    assert node["atoms"] == [0, 2]
+    assert node["bonds"] == [4]
+    assert metadata.items() <= node.items()
 
 
 def test_methane_is_named_without_parent_selection_fallback():

--- a/src/openclatura/trace_helpers.py
+++ b/src/openclatura/trace_helpers.py
@@ -1,14 +1,35 @@
 """Trace and explainability helpers for generated names."""
 
 from dataclasses import replace
+from typing import TypedDict
 
-from .assembly_parts import AssemblyParts, NameTokenBinding, SubstituentItem
+from .assembly_parts import (
+    AssemblyParts,
+    NameTokenBinding,
+    RenderedSubstituentName,
+    SubstituentItem,
+    split_rendered_substituent_name,
+)
 from .formatting import strip_outer_parentheses
 from .molecule import DecisionTrace, Molecule, TracePhase
 from .nomenclature import RULES
 from .perception import PerceivedGroup
 from .principal_suffixes import principal_suffix_terms
 from .rules import bonds, multipliers, stems
+
+
+class NamingTreeMetadata(TypedDict, total=False):
+    """Optional, non-invariant fields supported by naming-tree nodes."""
+
+    name_atom_bindings: list[dict]
+    name_token_spans: list[dict]
+    stereo_features: list[dict]
+    indicated_hydrogens: list[str]
+    hydro_operations: list[dict]
+    parent_charges: list[dict]
+
+
+NAMING_TREE_METADATA_FIELDS = frozenset(NamingTreeMetadata.__annotations__)
 
 
 def decision_trace_data(trace: DecisionTrace | list | tuple | None) -> list[dict]:
@@ -84,7 +105,7 @@ def bond_ids_within(mol: Molecule, atom_ids: set[int]) -> set[int]:
 
 def add_substituent_trace(
     parts: AssemblyParts,
-    name: str,
+    name: str | RenderedSubstituentName,
     locant: str,
     atom_ids=None,
     bond_ids=None,
@@ -94,9 +115,13 @@ def add_substituent_trace(
     emitted_tokens: tuple[NameTokenBinding, ...] = (),
     substituent_tree=None,
     spiro=None,
+    outer_parentheses_optional: bool | None = None,
 ) -> None:
     """Append or merge a substituent while preserving trace atom/bond IDs."""
 
+    name, rendered_boundary_optional = split_rendered_substituent_name(name)
+    if outer_parentheses_optional is None:
+        outer_parentheses_optional = rendered_boundary_optional
     atom_ids = set(atom_ids or ())
     bond_ids = set(bond_ids or ())
     charge_atom_ids = set(charge_atom_ids or ())
@@ -104,7 +129,16 @@ def add_substituent_trace(
     nested_decisions = list(nested_decisions or ())
     if spiro is not None:
         spiro = replace(spiro, parent_locant=str(locant))
-    existing = next((s for s in parts.substituents if s.name == name and s.spiro == spiro), None)
+    existing = next(
+        (
+            item
+            for item in parts.substituents
+            if item.name == name
+            and item.spiro == spiro
+            and item.outer_parentheses_optional == outer_parentheses_optional
+        ),
+        None,
+    )
     if existing:
         existing.locants.append(locant)
         existing.atom_ids.update(atom_ids)
@@ -124,6 +158,7 @@ def add_substituent_trace(
             SubstituentItem(
                 name=name,
                 locants=[locant],
+                outer_parentheses_optional=outer_parentheses_optional,
                 atom_ids=atom_ids,
                 bond_ids=bond_ids,
                 charge_atom_ids=charge_atom_ids,
@@ -354,7 +389,7 @@ def build_naming_tree_node(
     unsaturations=None,
     trace_segments=None,
     nested_decisions=None,
-    metadata: dict | None = None,
+    metadata: NamingTreeMetadata | None = None,
 ) -> dict:
     """Build the invariant portion of every component/substituent tree node."""
 
@@ -375,6 +410,9 @@ def build_naming_tree_node(
         overlapping_keys = node.keys() & metadata.keys()
         if overlapping_keys:
             raise ValueError(f"Tree metadata cannot replace invariant fields: {sorted(overlapping_keys)}")
+        unknown_keys = metadata.keys() - NAMING_TREE_METADATA_FIELDS
+        if unknown_keys:
+            raise ValueError(f"Unknown tree metadata fields: {sorted(unknown_keys)}")
         node.update(metadata)
     return node
 
@@ -391,7 +429,7 @@ def build_shortcut_tree_node(
 ) -> dict:
     """Build a schema-complete tree node for a shortcut-rendered name."""
 
-    metadata = {}
+    metadata: NamingTreeMetadata = {}
     if name_atom_bindings is not None:
         metadata["name_atom_bindings"] = list(name_atom_bindings)
     if name_token_spans is not None:


### PR DESCRIPTION
## Summary by Sourcery

Track and propagate optional outer-parenthesis boundary metadata on rendered substituent names using a frozen dataclass wrapper, and tighten naming-tree metadata validation.

Enhancements:
- Replace the mutable string subclass used for rendered substituent names with an immutable dataclass carrying text and boundary metadata, plus helpers to split or discard that metadata.
- Thread rendered substituent boundary information through branch/subgraph naming, component/subgraph substituent collection, and prefix assembly so optional outer parentheses are preserved or omitted correctly.
- Strengthen naming-tree construction by introducing a typed metadata dict and rejecting unknown or invariant-overwriting metadata fields.
- Generalize naming protocol and formatting helpers to work with rendered substituent name objects while exposing plain text where required.

Tests:
- Extend analysis tests to cover naming-tree metadata validation and ensure optional outer parentheses on stereochemical substituents are preserved when reused as substituents or prefixes.