### PR TITLE
fix remaining graph errors and drop unused code

### DIFF
--- a/src/openclatura/assembler.py
+++ b/src/openclatura/assembler.py
@@ -146,6 +146,56 @@ LEGACY_POSTPROCESS_LITERAL_REPLACEMENTS = (
 )
 
 
+def _balanced_group_end(name: str, start: int) -> int | None:
+    """If ``name[start]`` opens a parenthesis, return the index just past its match."""
+
+    if start >= len(name) or name[start] != "(":
+        return None
+    depth = 0
+    for i in range(start, len(name)):
+        if name[i] == "(":
+            depth += 1
+        elif name[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return None
+
+
+def _oxo_group_methyl_to_carbonyl(name: str) -> str:
+    """Contract a one-carbon ``methyl`` parent bearing ``(oxo)`` and one parenthesized
+    group into ``(group)carbonyl``, for either substituent order.
+
+    Paren-aware replacement for two regexes that mis-matched the inner ``)methyl`` of a
+    group ending in a substituent methyl (e.g. heteroaryl-methyl), which corrupted names
+    like ``(oxo)(1-((thiophen-2-yl)methyl)cyclohexyl)methyl``.
+    """
+
+    def _word_char(idx: int) -> bool:
+        return idx < len(name) and (name[idx].isalnum() or name[idx] == "_")
+
+    out: list[str] = []
+    i = 0
+    while i < len(name):
+        # (oxo)(GROUP)methyl
+        if name.startswith("(oxo)", i):
+            g_end = _balanced_group_end(name, i + 5)
+            if g_end is not None and name.startswith("methyl", g_end) and not _word_char(g_end + 6):
+                out.append(name[i + 5 : g_end] + "carbonyl")
+                i = g_end + 6
+                continue
+        # (GROUP)(oxo)methyl
+        if name[i] == "(":
+            g_end = _balanced_group_end(name, i)
+            if g_end is not None and name.startswith("(oxo)methyl", g_end) and not _word_char(g_end + 11):
+                out.append(name[i:g_end] + "carbonyl")
+                i = g_end + 11
+                continue
+        out.append(name[i])
+        i += 1
+    return "".join(out)
+
+
 def _post_process_name(name: str) -> str:
     name = apply_data_postprocessing(name)
     name = ensure_stereo_descriptor_boundary(name)
@@ -170,8 +220,7 @@ def _post_process_name(name: str) -> str:
 
     name = re.sub(r"-1-formate\b", "-formate", name)
 
-    name = re.sub(r"\((.*?)\)\((?<!thi)oxo\)methyl\b", r"(\1)carbonyl", name)
-    name = re.sub(r"\((?<!thi)oxo\)\((.*?)\)methyl\b", r"(\1)carbonyl", name)
+    name = _oxo_group_methyl_to_carbonyl(name)
     name = name.replace("(oxo)methyl", "formyl")
     name = re.sub(r"(?<!thi)oxomethyl\b", "formyl", name)
     name = name.replace("thioxomethyl", "carbonothioyl")

--- a/src/openclatura/assembler.py
+++ b/src/openclatura/assembler.py
@@ -375,11 +375,40 @@ def _add_relative_stereo_prefix(parts: AssemblyParts, final_word: str) -> str:
     return "".join(f"{prefix}-" for prefix in prefixes) + final_word
 
 
+def _front_modifier_sort_key(name: str) -> str:
+    """Alphanumeric ordering key: ignore the italic ``tert-``/``sec-`` prefixes."""
+
+    key = name
+    for prefix in ("tert-", "sec-"):
+        if key.startswith(prefix):
+            key = key[len(prefix) :]
+            break
+    return key.lstrip("([").lower()
+
+
 def _add_front_modifiers(parts: AssemblyParts, final_word: str) -> str:
     if not parts.front_modifiers:
         return final_word
-    counts = {}
-    for mod in parts.front_modifiers:
+    mods = parts.front_modifiers
+    locants = parts.front_modifier_locants
+    have_locants = len(locants) == len(mods) and all(loc is not None for loc in locants)
+    # Unsymmetrical polyacid esters need locants so each alkyl pairs with its own
+    # carboxyl (e.g. 1-tert-butyl 2-methyl ...dicarboxylate); a single ester or a
+    # symmetrical one keeps the simpler unlocanted (multiplied) form.
+    if have_locants and len(set(mods)) > 1:
+        by_name: dict[str, list[str]] = {}
+        for mod, loc in zip(mods, locants):
+            by_name.setdefault(mod, []).append(loc)
+        entries = []
+        for name in sorted(by_name, key=_front_modifier_sort_key):
+            group_locants = sorted(by_name[name], key=lambda loc: (len(loc), loc))
+            locant_str = ",".join(group_locants)
+            count = len(group_locants)
+            rendered = format_multiplier(name, count, safe_enclose=True) if count > 1 else name
+            entries.append(f"{locant_str}-{rendered}")
+        return f"{' '.join(entries)} {final_word}"
+    counts: dict[str, int] = {}
+    for mod in mods:
         counts[mod] = counts.get(mod, 0) + 1
     front_words = [format_multiplier(m, c, safe_enclose=True) if c > 1 else m for m, c in sorted(counts.items())]
     return f"{' '.join(front_words)} {final_word}"

--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -136,6 +136,7 @@ class AssemblyParts:
     retained_name: str | None = None
     retained_parent_metadata: RetainedParentMetadata | None = None
     front_modifiers: list[str] = field(default_factory=list)
+    front_modifier_locants: list[str | None] = field(default_factory=list)
     front_modifier_atom_ids: set[int] = field(default_factory=set)
     front_modifier_charge_atom_ids: set[int] = field(default_factory=set)
     principal_suffix_modifiers: list[SubstituentItem] = field(default_factory=list)

--- a/src/openclatura/chains.py
+++ b/src/openclatura/chains.py
@@ -861,18 +861,6 @@ def _audited_ring_numberings(
     return _dedupe_ring_numberings(audited)
 
 
-def _audited_ring_paths(
-    mol: Molecule,
-    kind: str,
-    descriptor_numbers: tuple[int, ...],
-    paths: tuple[tuple[int, ...], ...] | list[tuple[int, ...]],
-    edges: frozenset[tuple[int, int]],
-) -> list[list[int]]:
-    return _dedupe_numbering_paths(
-        [list(numbering.path) for numbering in _audited_ring_numberings(mol, kind, descriptor_numbers, paths, edges)]
-    )
-
-
 def _audited_von_baeyer_numberings(
     mol: Molecule,
     descriptor: str,
@@ -1137,13 +1125,6 @@ def _polyspiro_or_von_baeyer_candidate(
         is_von_baeyer=True,
         numberings=numberings,
     )
-
-
-def _polyspiro_descriptor_or_von_baeyer(mol: Molecule, atoms: set[int], edges: set[tuple[int, int]]):
-    """Legacy tuple wrapper for callers that have not migrated to candidates."""
-
-    candidate = _polyspiro_or_von_baeyer_candidate(mol, atoms, edges)
-    return candidate.descriptor, candidate.paths
 
 
 def _has_multiple_spiro_centers(nodes: set[int], edges: set[tuple[int, int]]) -> bool:

--- a/src/openclatura/charge_specs.py
+++ b/src/openclatura/charge_specs.py
@@ -1,6 +1,0 @@
-"""Compatibility views for charge-aware parent assembly data."""
-
-from .nomenclature import RULES
-
-IONIC_RETAINED_N_PARENTS = RULES.charges.retained_ionic_n_parents
-IONIC_SATURATED_N_RING_PARENTS = RULES.charges.saturated_n_ring_ionic_parents

--- a/src/openclatura/component_modifiers.py
+++ b/src/openclatura/component_modifiers.py
@@ -20,6 +20,7 @@ def add_component_front_modifiers(
     principal_key: str | None,
     sub_exclude: set[int],
     branch_namer: RecursiveSubgraphNamer,
+    get_loc=None,
 ) -> None:
     """Add ester/sulfonate front modifiers such as the alcohol component name."""
 
@@ -38,6 +39,8 @@ def add_component_front_modifiers(
         if branch_name:
             modifier_atoms = subgraph_component(mol, r_group_c, sub_exclude | {single_o})
             parts.front_modifiers.append(strip_outer_parentheses(branch_name))
+            locant = str(get_loc(group.attachment_carbon)) if get_loc is not None else None
+            parts.front_modifier_locants.append(locant)
             parts.front_modifier_atom_ids.update(modifier_atoms)
             parts.front_modifier_charge_atom_ids.update(_charged_atoms(mol, modifier_atoms))
 

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -523,7 +523,7 @@ def name_component(
     parts = parent_plan.parts
     emit_bond_stereo(mol, parts, numbered_path, get_loc, state.base_exclude)
     add_component_front_modifiers(
-        mol, parts, state.perceived_groups, state.principal_key, state.sub_exclude, name_subgraph
+        mol, parts, state.perceived_groups, state.principal_key, state.sub_exclude, name_subgraph, get_loc
     )
     add_component_n_substituents(
         mol,

--- a/src/openclatura/fused_ion_templates.py
+++ b/src/openclatura/fused_ion_templates.py
@@ -167,22 +167,6 @@ def consume_fused_ion_operation(parts: AssemblyParts, candidate: FusedIonOperati
     _replace_fused_ion_bindings(parts, candidate)
 
 
-def render_fused_ion_template_name(parts: AssemblyParts) -> str | None:
-    """Render graph-certified retained fused ion names.
-
-    This is a production renderer only for generic graph operations whose
-    represented atoms are already present in ``AssemblyParts``.  It does not
-    inspect the assembled string.  New ion classes should add a graph operation
-    renderer here, then opt into template rows through the registry.
-    """
-
-    candidate = select_fused_ion_operation(parts)
-    if candidate is not None:
-        consume_fused_ion_operation(parts, candidate)
-        return candidate.rendered_name
-    return None
-
-
 def fused_ion_operation_candidates(parts: AssemblyParts) -> tuple[FusedIonOperationCandidate, ...]:
     """Return graph-derived retained fused ion operations for assembly parts."""
 

--- a/src/openclatura/heteroatom_subgraphs.py
+++ b/src/openclatura/heteroatom_subgraphs.py
@@ -663,6 +663,8 @@ def name_sulfur_subgraph(
         for nxt in next_atoms
         if (br := _branch_name_text(branch_namer, mol, nxt, exclude_atoms | {start_idx}, start_idx))
     ]
+    if not is_double and mol.atoms[start_idx].charge > 0:
+        return f"({stereo_prefix_text}{format_counted_prefixes(branches)}sulfaniumyl)"
     return format_lambda_substituent(
         mol, start_idx, branches, stereo_prefix_text, "sulfanylidene" if is_double else "sulfanyl"
     )

--- a/src/openclatura/ionic_naming.py
+++ b/src/openclatura/ionic_naming.py
@@ -96,27 +96,6 @@ def apply_parent_charge_names(
     return name
 
 
-def apply_parent_ion_suffixes(
-    name: str,
-    mol: Molecule,
-    numbered_path: list[int],
-    get_loc,
-    retained_name: str | None = None,
-    allow_retained_stem_inference: bool = False,
-) -> str:
-    """Compatibility wrapper for parent charge spelling."""
-
-    return apply_parent_charge_names(
-        name,
-        mol,
-        numbered_path,
-        get_loc,
-        retained_name,
-        allow_retained_stem_inference,
-        charge_signs={1},
-    )
-
-
 def apply_anionic_parent_names(
     name: str,
     mol: Molecule,
@@ -145,12 +124,6 @@ def parent_charge_sites(mol: Molecule, numbered_path: list[int], get_loc) -> lis
             )
         )
     return sites
-
-
-def apply_fused_heteroaromatic_nitrogen_zwitterion(name: str, mol: Molecule, numbered_path: list[int], get_loc) -> str:
-    """Compatibility wrapper for the ring N-zwitterion parent stack."""
-
-    return apply_ring_parent_nitrogen_zwitterion_stack(name, mol, numbered_path, get_loc)
 
 
 def apply_ring_parent_nitrogen_zwitterion_stack(name: str, mol: Molecule, numbered_path: list[int], get_loc) -> str:
@@ -211,10 +184,6 @@ def _is_unsaturated_ring_parent(mol: Molecule, parent_set: set[int]) -> bool:
             if bond is not None and bond.order > 1:
                 has_unsaturation = True
     return internal_edge_count >= len(parent_set) and has_unsaturation
-
-
-def _name_has_parent_ium_locant(name: str, locant: str) -> bool:
-    return _name_has_parent_ium_locants(name, (locant,))
 
 
 def _name_has_parent_ium_locants(name: str, locants: tuple[str, ...]) -> bool:

--- a/src/openclatura/locants.py
+++ b/src/openclatura/locants.py
@@ -1,7 +1,7 @@
 """Locant parsing and atom/bond locant helpers."""
 
 import re
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 
 from .molecule import Molecule
 
@@ -31,14 +31,6 @@ def locant_text(locant: int, display: str | None = None) -> str:
         return str(display)
     inherited_display = getattr(locant, "display", None)
     return str(locant) if inherited_display is None else str(inherited_display)
-
-
-def locant_texts(locants: Iterable[int], display_locants: Iterable[str] | None = None) -> tuple[str, ...]:
-    """Return rendered text for multiple locants."""
-
-    if display_locants is not None:
-        return tuple(str(locant) for locant in display_locants)
-    return tuple(locant_text(locant) for locant in locants)
 
 
 def coerce_display_numbering(

--- a/src/openclatura/name_operations.py
+++ b/src/openclatura/name_operations.py
@@ -27,38 +27,6 @@ class ParentSuffixOperation(NameOperation):
 
 
 @dataclass(frozen=True)
-class ReplacementPrefixOperation(NameOperation):
-    """A replacement prefix operation tied to parent locants."""
-
-    locants: tuple[str, ...] = ()
-    prefix: str = ""
-    atom_symbols: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True)
-class RetainedParentSubstitution(NameOperation):
-    """A retained parent spelling chosen from graph and charge metadata."""
-
-    neutral_parent: str = ""
-    charged_parent: str = ""
-
-
-@dataclass(frozen=True)
-class FunctionalGroupChargeVariant(NameOperation):
-    """A charged spelling variant for a perceived functional group."""
-
-    group_key: str = ""
-    charged_group_key: str = ""
-
-
-@dataclass(frozen=True)
-class IndicatedHydrogenOperation(NameOperation):
-    """An indicated-hydrogen operation tied to parent locants."""
-
-    locants: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True)
 class HydroOperation(NameOperation):
     """An additive hydrogen operation tied to parent locants."""
 

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -1186,7 +1186,11 @@ def _acylamino_amido_prefix(
         """True when ``carbon`` is a single-bonded carboxamide acyl on this nitrogen."""
         if not mol.atoms[carbon].is_carbon or mol.get_bond(n_idx, carbon).order != 1:
             return False
-        c_os = [nb for nb in mol.get_neighbors(carbon) if mol.atoms[nb].symbol == "O" and mol.get_bond(carbon, nb).order == 2]
+        c_os = [
+            nb
+            for nb in mol.get_neighbors(carbon)
+            if mol.atoms[nb].symbol == "O" and mol.get_bond(carbon, nb).order == 2
+        ]
         if len(c_os) != 1:
             return False
         rest = [nb for nb in mol.get_neighbors(carbon) if nb not in {n_idx, c_os[0]}]

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -1,6 +1,7 @@
 # openclatura/api.py
 
 import re
+from collections import Counter
 from dataclasses import dataclass, field
 
 from .assembler import assemble_name_raw, post_process_rewrite_rules
@@ -16,7 +17,7 @@ from .assembly_spiro import extract_spiro_side_prefixes
 from .chains import find_ring_systems, get_cyclic_atoms
 from .component_namer import name_component as _name_component_impl
 from .engine import DEFAULT_NAMING_ENGINE
-from .formatting import format_counted_prefixes, format_multiplier, strip_outer_parentheses
+from .formatting import format_counted_prefixes, format_multiplier, is_complex_prefix, strip_outer_parentheses
 from .group_atom_roles import amide_nitrogen
 from .heteroatom_subgraphs import name_heteroatom_subgraph
 from .ionic_naming import apply_anionic_parent_names, apply_cationic_imino_names, apply_cationic_imino_parent_prefixes
@@ -1132,6 +1133,121 @@ def _simple_rooted_carbanion_substituent_name(
     return f"{side_stem}ylmethanidyl"
 
 
+def _carboxylic_acid_to_amido(acid_name: str) -> str | None:
+    """Convert a carboxylic-acid component name to its N-acyl (amido) substituent form."""
+
+    for ending, replacement in (("carboxylic acid", "carboxamido"), ("oic acid", "amido"), ("ic acid", "amido")):
+        if acid_name.endswith(ending):
+            return acid_name[: -len(ending)] + replacement
+    return None
+
+
+def _format_n_locant_prefix(names: list[str]) -> str:
+    """Format amide N-substituents with N-locants, e.g. 'N-methyl', 'N,N-dimethyl'."""
+
+    counts = Counter(strip_outer_parentheses(name) for name in names)
+    parts = []
+    for name in sorted(counts):
+        k = counts[name]
+        display = f"({name})" if is_complex_prefix(name) else name
+        locants = ",".join(["N"] * k)
+        if k == 1:
+            parts.append(f"{locants}-{display}")
+        else:
+            mult = multipliers.complex_(k) if is_complex_prefix(name) else multipliers.basic(k)
+            parts.append(f"{locants}-{mult}{display}")
+    return "-".join(parts)
+
+
+def _acylamino_amido_prefix(
+    mol: Molecule, n_idx: int, exclude_atoms: set[int], upstream_atom: int | None
+) -> str | None:
+    """Name an acylamino substituent ``R-C(=O)-N(R')-`` as an ``[N-R'-]<acid>amido`` prefix.
+
+    Routes the acyl through the carboxylic-acid component namer so it renders with a
+    proper substitutive amido name (acetamido, benzamido, 2-phenylacetamido,
+    2-(piperidin-4-yl)acetamido, ...) rather than the ambiguous functional-class
+    ``<sub>carbonylamino`` spelling.  N-substituents (tertiary amides) are rendered as
+    ``N-`` locanted prefixes.  Returns ``None`` for anything that is not a plain
+    carboxamide nitrogen, leaving the existing renderer in charge.
+    """
+
+    n_atom = mol.atoms[n_idx]
+    if n_atom.symbol != "N" or n_atom.charge != 0 or n_atom.is_aromatic or upstream_atom is None:
+        return None
+    up_bond = mol.get_bond(n_idx, upstream_atom)
+    if up_bond is None or up_bond.order != 1:
+        return None
+    neighbors = [nb for nb in mol.get_neighbors(n_idx) if nb not in exclude_atoms and nb != upstream_atom]
+    if not neighbors:
+        return None
+
+    def _amide_acyl(carbon: int) -> bool:
+        """True when ``carbon`` is a single-bonded carboxamide acyl on this nitrogen."""
+        if not mol.atoms[carbon].is_carbon or mol.get_bond(n_idx, carbon).order != 1:
+            return False
+        c_os = [nb for nb in mol.get_neighbors(carbon) if mol.atoms[nb].symbol == "O" and mol.get_bond(carbon, nb).order == 2]
+        if len(c_os) != 1:
+            return False
+        rest = [nb for nb in mol.get_neighbors(carbon) if nb not in {n_idx, c_os[0]}]
+        # The acid's R group (if any) must be carbon; formyl (no R) contracts to formamido.
+        return len(rest) <= 1 and all(mol.atoms[nb].is_carbon for nb in rest)
+
+    acyl_cands = [c for c in neighbors if _amide_acyl(c)]
+    if len(acyl_cands) != 1:
+        return None
+    acyl_c = acyl_cands[0]
+    n_substituents = [nb for nb in neighbors if nb != acyl_c]
+
+    blocked = set(exclude_atoms) | {n_idx}
+    acid_atoms: set[int] = set()
+    stack = [acyl_c]
+    while stack:
+        cur = stack.pop()
+        if cur in acid_atoms or cur in blocked:
+            continue
+        acid_atoms.add(cur)
+        stack.extend(nb for nb in mol.get_neighbors(cur) if nb not in acid_atoms and nb not in blocked)
+
+    acid_mol = Molecule()
+    for idx in acid_atoms:
+        atom = mol.atoms[idx]
+        acid_mol.add_atom(
+            symbol=atom.symbol,
+            idx=idx,
+            charge=atom.charge,
+            stereo=atom.stereo,
+            raw_stereo=atom.raw_stereo,
+            is_aromatic=atom.is_aromatic,
+            explicit_h_count=atom.explicit_h_count,
+            total_h_count=atom.total_h_count,
+        )
+    for idx in acid_atoms:
+        for nb in mol.get_neighbors(idx):
+            if nb in acid_atoms and idx < nb:
+                bond = mol.get_bond(idx, nb)
+                acid_mol.add_bond(u=idx, v=nb, order=bond.order, stereo=bond.stereo, in_small_ring=bond.in_small_ring)
+    hydroxyl_idx = max(mol.atoms) + 1
+    acid_mol.add_atom(symbol="O", idx=hydroxyl_idx)
+    acid_mol.add_bond(u=acyl_c, v=hydroxyl_idx, order=1)
+
+    try:
+        acid_name = name_component(acid_mol, acid_atoms | {hydroxyl_idx}, is_substituent=False)
+    except Exception:
+        return None
+    amido = _carboxylic_acid_to_amido(str(acid_name))
+    if amido is None:
+        return None
+    if n_substituents:
+        sub_exclude = set(exclude_atoms) | {n_idx} | acid_atoms
+        sub_names = [str(name_subgraph(mol, s, sub_exclude, upstream_atom=n_idx)) for s in n_substituents]
+        if not all(sub_names):
+            return None
+        n_prefix = _format_n_locant_prefix(sub_names)
+        amido = f"{n_prefix}-{amido}" if amido[0].isdigit() else f"{n_prefix}{amido}"
+    return f"({amido})" if is_complex_prefix(amido) else amido
+
+
 def name_subgraph(
     mol: Molecule,
     start_idx: int,
@@ -1169,7 +1285,9 @@ def name_subgraph(
         )
 
     if not start_atom.is_carbon and start_idx not in cyclic_atoms_global:
-        name = name_heteroatom_subgraph(mol, start_idx, exclude_atoms, upstream_atom, name_subgraph)
+        name = _acylamino_amido_prefix(mol, start_idx, exclude_atoms, upstream_atom)
+        if name is None:
+            name = name_heteroatom_subgraph(mol, start_idx, exclude_atoms, upstream_atom, name_subgraph)
         if name is not None:
             if decision_trace is not None:
                 trace_decision(

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -818,13 +818,6 @@ def _number_saturated_n_ring_for_spiro(
     return min(candidates)[3]
 
 
-def _spiro_subgraph_name(mol: Molecule, c_idx: int, sub_comp: set[int]) -> str:
-    """Compatibility marker for older assembly callers."""
-
-    spiro = _spiro_subgraph_assembly(mol, c_idx, sub_comp)
-    return f"[SPIRO]-{spiro.side_locant}-{spiro.side_parent_name}"
-
-
 def _collect_subgraph_substituents(
     mol: Molecule,
     candidate_path: list[int],

--- a/src/openclatura/naming_context.py
+++ b/src/openclatura/naming_context.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from .assembly_parts import RetainedParentMetadata
-from .molecule import DecisionTrace, Molecule
 from .parent_selection import ParentSelection
 from .perception import PerceivedGroup
 
@@ -45,78 +44,6 @@ class NamingIntent:
 
 
 @dataclass
-class NamingContext:
-    """Shared context for a naming run or recursive naming branch."""
-
-    mol: Molecule
-    mode: NamingMode
-    component_atoms: set[int] = field(default_factory=set)
-    root_atom: int | None = None
-    upstream_atom: int | None = None
-    blocked_atoms: set[int] = field(default_factory=set)
-    trace: DecisionTrace | None = None
-    perceived_groups: list[PerceivedGroup] = field(default_factory=list)
-    cyclic_atoms: set[int] = field(default_factory=set)
-
-
-@dataclass
-class SubgraphBoundary:
-    """Explicit graph boundary for recursive branch naming."""
-
-    root_atom: int
-    upstream_atom: int | None
-    blocked_atoms: set[int]
-    component_atoms: set[int] = field(default_factory=set)
-    parent_atoms: set[int] = field(default_factory=set)
-    consumed_atoms: set[int] = field(default_factory=set)
-
-
-@dataclass
-class PrincipalGroupSelection:
-    """Selected principal group key plus all matching group objects."""
-
-    key: str | None
-    groups: list[PerceivedGroup] = field(default_factory=list)
-    prefix_groups: list[PerceivedGroup] = field(default_factory=list)
-
-    @property
-    def attachment_atoms(self) -> list[int]:
-        return [group.attachment_carbon for group in self.groups]
-
-    @property
-    def involved_atoms(self) -> set[int]:
-        atoms: set[int] = set()
-        for group in self.groups:
-            atoms.add(group.attachment_carbon)
-            atoms.update(group.atoms_involved)
-        return atoms
-
-
-@dataclass
-class ParentPlan:
-    """Selected parent plus retained-name and principal-group metadata."""
-
-    selection: ParentSelection
-    retained_name: str | None = None
-    locant_maps: list[dict[int, str]] | None = None
-    retained_parent_metadata: RetainedParentMetadata | None = None
-    principal: PrincipalGroupSelection | None = None
-
-
-@dataclass
-class NumberedParent:
-    """Numbered parent path and locant lookup."""
-
-    path: list[int]
-    locant_map: dict[int, str] | None = None
-
-    def locant_for(self, atom_idx: int) -> str | int:
-        if self.locant_map:
-            return self.locant_map[atom_idx]
-        return self.path.index(atom_idx) + 1
-
-
-@dataclass
 class ParentAssemblyPlan:
     """Numbered parent plus assembly parts for the selected naming intent."""
 
@@ -124,16 +51,6 @@ class ParentAssemblyPlan:
     locant_map: dict[int, str] | None
     get_loc: Callable
     parts: object
-
-
-@dataclass
-class FragmentNamingResult:
-    """Name plus graph and trace metadata for a named fragment."""
-
-    name: str
-    trace_segments: list[dict] = field(default_factory=list)
-    atom_ids: set[int] = field(default_factory=set)
-    bond_ids: set[int] = field(default_factory=set)
 
 
 @dataclass

--- a/src/openclatura/oxoacid_templates.py
+++ b/src/openclatura/oxoacid_templates.py
@@ -143,12 +143,3 @@ def oxoacid_role_template(mol: Molecule, role: CentralOxoRole) -> OxoacidRoleTem
         if template.matches(mol, role):
             return template
     return None
-
-
-def unsupported_oxoacid_role_template(mol: Molecule, role: CentralOxoRole) -> OxoacidRoleTemplate | None:
-    """Return an unsupported template certificate for high-risk oxo roles."""
-
-    template = oxoacid_role_template(mol, role)
-    if template is not None and template.kind == OxoacidTemplateKind.UNSUPPORTED:
-        return template
-    return None

--- a/src/openclatura/rules/elision.py
+++ b/src/openclatura/rules/elision.py
@@ -116,8 +116,3 @@ def join_with_elision(*fragments: str, rule: str = "e") -> str:
 def is_vowel_start(s: str) -> bool:
     """Return True if `s` begins with a vowel (a, e, i, o, u, y)."""
     return bool(s) and s[0].lower() in VOWELS
-
-
-def is_vowel_end(s: str) -> bool:
-    """Return True if `s` ends with a vowel."""
-    return bool(s) and s[-1].lower() in VOWELS

--- a/src/openclatura/small_ring_stereo.py
+++ b/src/openclatura/small_ring_stereo.py
@@ -19,14 +19,8 @@ def scoped_small_ring_stereo_features(
     lower-case descriptors.
     """
 
-    # OPSIN currently treats mixed local R/S + lower-case r/s descriptor groups
-    # inside substituent scopes as ordinary absolute stereochemistry and often
-    # cannot attach the locants to the named fragment. Until a grammar-backed
-    # relative-stereo renderer exists for these scopes, prefer the generic
-    # cis/trans fallback in parent_pipeline._add_relative_ring_stereo.
-    if parts.is_substituent:
-        return []
-
+    # Emit local descriptors for substituent small-ring scopes; simpler rings
+    # still use the cis/trans fallback in parent_pipeline._add_relative_ring_stereo.
     if not parts.is_substituent or not parts.is_ring or parts.is_bicycle or parts.is_spiro or parts.is_polycycle:
         return []
     if not 3 <= len(numbered_path) <= 7:
@@ -37,6 +31,13 @@ def scoped_small_ring_stereo_features(
         if mol.atoms[atom_idx].raw_stereo in {"CW", "CCW"} and not mol.atoms[atom_idx].stereo
     ]
     if len(raw_atoms) != 2:
+        return []
+    parent_set = set(numbered_path)
+    if all(
+        sum(1 for neighbor_idx in mol.get_neighbors(atom_idx) if neighbor_idx not in parent_set) == 1
+        for atom_idx in raw_atoms
+    ):
+        # Mono-substituted centers: defer to the cis/trans fallback.
         return []
     locants = {atom_idx: str(get_loc(atom_idx)) for atom_idx in numbered_path}
     if any(not locants[atom_idx].isdigit() for atom_idx in numbered_path):

--- a/src/openclatura/special_cases.py
+++ b/src/openclatura/special_cases.py
@@ -2118,5 +2118,3 @@ def try_name_anhydride_component_result(
         )
         return AnhydrideComponentName(name=name, bindings=half_bindings + (core_binding,))
     return None
-
-

--- a/src/openclatura/special_cases.py
+++ b/src/openclatura/special_cases.py
@@ -436,17 +436,6 @@ def simple_azine_parent_name(
     return ""
 
 
-def phosphane_borane_zwitterion_name(
-    mol: Molecule,
-    component_atoms: set[int],
-    branch_namer: RecursiveSubgraphNamer | None = None,
-) -> str:
-    """Name graph-proven B(-)(H)3-P(+) zwitterions as boranuide parents."""
-
-    result = phosphane_borane_zwitterion_result(mol, component_atoms, branch_namer)
-    return result.name if result is not None else ""
-
-
 def phosphane_borane_zwitterion_result(
     mol: Molecule,
     component_atoms: set[int],
@@ -1022,17 +1011,6 @@ def _linear_alkyl_carbanion_parent_name(mol: Molecule, carbon_atoms: set[int], r
     return len(carbon_atoms)
 
 
-def hydroxyurea_parent_name(
-    mol: Molecule,
-    component_atoms: set[int],
-    branch_namer: RecursiveSubgraphNamer | None = None,
-) -> str:
-    """Name graph-proven N-hydroxyureas without carbamic-acid fallback wording."""
-
-    result = hydroxyurea_parent_result(mol, component_atoms, branch_namer)
-    return result.name if result is not None else ""
-
-
 def hydroxyurea_parent_result(
     mol: Molecule,
     component_atoms: set[int],
@@ -1222,13 +1200,6 @@ def _component_atoms_until_blocked(
     return atoms
 
 
-def oxoacid_parent_name(mol: Molecule, component_atoms: set[int]) -> str:
-    """Match functional parent hydrides by central atom and oxygen ligand counts."""
-
-    result = oxoacid_parent_result(mol, component_atoms)
-    return result.name if result is not None else ""
-
-
 def oxoacid_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialComponentName | None:
     """Match functional parent hydrides with central-oxo role bindings."""
 
@@ -1249,17 +1220,6 @@ def oxoacid_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialCo
         name = spec["name"]
     bindings = _central_oxo_role_bindings(mol, role, name, "oxoacid_parent")
     return _component_name_result(mol, component_atoms, name, "oxoacid_parent", bindings=bindings)
-
-
-def oxoacid_ester_name(
-    mol: Molecule,
-    component_atoms: set[int],
-    branch_namer: RecursiveSubgraphNamer | None = None,
-) -> str:
-    """Name organic esters of data-backed oxoacid parent hydrides."""
-
-    result = oxoacid_ester_result(mol, component_atoms, branch_namer)
-    return result.name if result is not None else ""
 
 
 def oxoacid_ester_result(
@@ -1321,17 +1281,6 @@ def oxoacid_ester_result(
         )
         matches.append(_component_name_result(mol, component_atoms, name, "oxoacid_ester", bindings=bindings))
     return matches[0] if len(matches) == 1 else None
-
-
-def _peroxy_oxoacid_ester_name(
-    mol: Molecule,
-    component_atoms: set[int],
-    role: CentralOxoRole,
-    suffix: str,
-    branch_namer: RecursiveSubgraphNamer | None,
-) -> str:
-    result = _peroxy_oxoacid_ester_result(mol, component_atoms, role, suffix, branch_namer)
-    return result.name if result is not None else ""
 
 
 def _peroxy_oxoacid_ester_result(
@@ -1489,32 +1438,6 @@ def _ester_modifier_name(
     return _alkyl_ligand_name(mol, component_atoms, root, ester_oxygen)
 
 
-def _oxoacid_oxygen_counts(mol: Molecule, central: int, oxygen_neighbors: list[int]) -> tuple[int, int]:
-    role = central_oxo_roles(mol, {central, *oxygen_neighbors})
-    if len(role) == 1:
-        return role[0].spec_counts()
-    return 0, 0
-
-
-def _is_charge_normalized_halogen_oxo_ligand(
-    mol: Molecule,
-    central_symbol: str,
-    central: int,
-    oxygen: int,
-) -> bool:
-    """Return true for RDKit-normalized X(+)-O(-) oxo ligands on halogen oxoacids."""
-
-    if central_symbol not in {"Cl", "Br", "I"}:
-        return False
-    bond = mol.get_bond(central, oxygen)
-    return (
-        bond is not None
-        and bond.order == 1
-        and mol.atoms[oxygen].charge < 0
-        and sum(1 for _ in mol.get_neighbors(oxygen)) == 1
-    )
-
-
 def _matching_oxoacid_spec(central_symbol: str, single_o: int, double_o: int, charge: int) -> dict | None:
     for spec in RULES.components.replacement_parent_oxoacid_specs:
         if spec["central"] != central_symbol:
@@ -1530,13 +1453,6 @@ def _matching_oxoacid_spec(central_symbol: str, single_o: int, double_o: int, ch
 def _matching_oxoacid_spec_for_role(mol: Molecule, role: CentralOxoRole) -> dict | None:
     single_o, double_o = role.spec_counts()
     return _matching_oxoacid_spec(role.central_symbol, single_o, double_o, mol.atoms[role.central].charge)
-
-
-def organophosphinic_acid_name(mol: Molecule, component_atoms: set[int]) -> str:
-    """Name simple R-P(=O)(OH)H phosphinic acid parents."""
-
-    result = organophosphinic_acid_result(mol, component_atoms)
-    return result.name if result is not None else ""
 
 
 def organophosphinic_acid_result(mol: Molecule, component_atoms: set[int]) -> SpecialComponentName | None:
@@ -1589,13 +1505,6 @@ def organophosphinic_acid_result(mol: Molecule, component_atoms: set[int]) -> Sp
         ),
     )
     return _component_name_result(mol, component_atoms, name, "organophosphinic_acid", bindings=bindings)
-
-
-def sulfoxide_parent_name(mol: Molecule, component_atoms: set[int]) -> str:
-    """Name simple dialkyl sulfoxides from a charged or neutral S-O graph."""
-
-    result = sulfoxide_parent_result(mol, component_atoms)
-    return result.name if result is not None else ""
 
 
 def sulfoxide_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialComponentName | None:
@@ -1809,15 +1718,6 @@ def _alkyl_branch_prefixes(
     return "".join(parts)
 
 
-def _carbon_degree(mol: Molecule, carbon_atoms: set[int], atom_idx: int) -> int:
-    return sum(1 for neighbor in mol.get_neighbors(atom_idx) if neighbor in carbon_atoms)
-
-
-def homonuclear_chain_parent_name(mol: Molecule, component_atoms: set[int]) -> str:
-    result = homonuclear_chain_parent_result(mol, component_atoms)
-    return result.name if result is not None else ""
-
-
 def homonuclear_chain_parent_result(mol: Molecule, component_atoms: set[int]) -> SpecialComponentName | None:
     """Name acyclic same-element parent hydride chains and simple ligands."""
 
@@ -1880,11 +1780,6 @@ def homonuclear_chain_parent_result(mol: Molecule, component_atoms: set[int]) ->
         "homonuclear_chain_parent",
         bindings=(parent_binding, *ligand_bindings),
     )
-
-
-def simple_central_parent_hydride_name(mol: Molecule, component_atoms: set[int]) -> str:
-    result = simple_central_parent_hydride_result(mol, component_atoms)
-    return result.name if result is not None else ""
 
 
 def simple_central_parent_hydride_result(mol: Molecule, component_atoms: set[int]) -> SpecialComponentName | None:
@@ -2225,13 +2120,3 @@ def try_name_anhydride_component_result(
     return None
 
 
-def try_name_anhydride_component(
-    mol: Molecule,
-    perceived_groups: list[PerceivedGroup],
-    principal_key: str | None,
-    component_namer: ComponentNamer,
-) -> str:
-    """Return an anhydride component name when the component is an anhydride."""
-
-    result = try_name_anhydride_component_result(mol, perceived_groups, principal_key, component_namer)
-    return result.name if result is not None else ""

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -801,32 +801,21 @@ def test_heteroatom_shortcut_leaf_tokens_and_tree_are_graph_local():
 
 
 def test_carbonylamino_heteroatom_shortcut_tree_does_not_invent_hydroxy_children():
+    # Acylamino substituents render as substitutive <acid>amido names; the acid is named
+    # on a temporary hydroxyl-capped fragment that must not leak a hydroxy node into the tree.
     analysis = analyze_smiles("CC(C)C[C@@H](C(=O)N[C@@H](CC(C)C)C(=O)N[C@@H](CC(C)C)C(=O)O)N")
-    component = analysis.substituent_tree[0]
-    peptide_branch = next(
-        item
-        for item in component["substituents"]
-        if item["name"] == "(1S)-1-((1S)-1-amino-3-methylbutylcarbonylamino)-3-methylbutylcarbonylamino"
+    assert analysis.name == (
+        "(2S)-2-((2S)-2-((2S)-2-amino-4-methylpentanamido)-4-methylpentanamido)-4-methylpentanoic acid"
     )
-    branch_children = peptide_branch["substituents"][0]["substituents"]
-    child_names = [child["name"] for child in branch_children]
 
-    assert "hydroxy" not in child_names
-    assert "carbonyl" in child_names
-    carbonyl = next(child for child in branch_children if child["name"] == "carbonyl")
-    assert carbonyl["atoms"] == [13, 14]
-    assert carbonyl["bonds"] == [14]
-    side = next(child for child in branch_children if child["name"].endswith("methylbutyl)"))
-    assert side["parent"]["parent_length"] == 4
-    assert any(child["name"] == "methyl" for child in side["substituents"])
-    carbonylamino = next(child for child in side["substituents"] if child["name"].endswith("carbonylamino"))
-    assert carbonylamino["atoms"] == [0, 1, 2, 3, 4, 5, 6, 7, 24]
-    inner_carbonyl = carbonylamino["substituents"][0]
-    inner_side = next(child for child in inner_carbonyl["substituents"] if child["name"].endswith("methylbutyl)"))
-    amino = next(child for child in inner_side["substituents"] if child["name"] == "amino")
-    assert amino["locants"] == ["1"]
-    core = next(child for child in inner_carbonyl["substituents"] if child["name"] == "carbonyl")
-    assert core["atoms"] == [5, 6]
+    def walk(node):
+        yield node
+        for child in node.get("substituents", []):
+            yield from walk(child)
+
+    component = analysis.substituent_tree[0]
+    names = [node["name"] for sub in component["substituents"] for node in walk(sub)]
+    assert not any("hydroxy" in (name or "") for name in names)
 
 
 def test_postprocessing_rewrites_keep_token_metadata_auditable():
@@ -4355,13 +4344,21 @@ def test_locanted_ez_stereo_token_binds_to_double_bond_scope():
     assert z_token["bonds"]
 
 
-def test_scoped_small_ring_stereo_does_not_emit_unsupported_relative_locant_descriptors():
+def test_scoped_small_ring_stereo_emits_pseudoasymmetric_descriptors_for_gem_disubstituted_center():
+    # Gem-disubstituted ring center: emit local (1R,3s) and the unambiguous acetamido form.
     name = name_smiles("CN1CCC[C@](O)(CC(=O)N[C@]2(C)C[C@H](NC(=O)CCC3CC3)C2)C1")
 
     assert name == (
-        "3-cyclopropyl-N-(3-(((3S)-3-hydroxy-1-methylpiperidin-3-yl)methylcarbonylamino)-3-methylcyclobutyl)propanamide"
+        "3-cyclopropyl-N-((1R,3s)-3-(2-((3S)-3-hydroxy-1-methylpiperidin-3-yl)acetamido)-3-methylcyclobutyl)propanamide"
     )
-    assert "1R,3s" not in name
+    assert "1R,3s" in name
+    assert "methylcarbonylamino" not in name
+
+
+def test_scoped_small_ring_stereo_defers_to_cis_trans_for_mono_substituted_centers():
+    # Mono-substituted ring centers keep the cis/trans form.
+    assert name_smiles("CC(=O)N[C@H]1CC[C@@H](C)CC1") == "N-(cis-4-methylcyclohexyl)acetamide"
+    assert name_smiles("CC(=O)N[C@H]1CC[C@H](C)CC1") == "N-(trans-4-methylcyclohexyl)acetamide"
 
 
 def test_dense_polycyclic_cage_fails_closed_without_von_baeyer_path_explosion():
@@ -4484,8 +4481,8 @@ def test_pyopsin_regression_names_use_parseable_spiro_and_formamido_forms():
         "CN1CC11C2C3CC2C13": "1'-methylspiro[tricyclo[2.2.0.0^{2,5}]hexane-6,2'-aziridine]",
         "CC1CC11CC2CCC12": "2'-methylspiro[bicyclo[2.2.0]hexane-2,1'-cyclopropane]",
         "CC1NC11CC2OC12C": "1-methyl-3'-methylspiro[5-oxabicyclo[2.1.0]pentane-2,2'-aziridine]",
-        "COC(=O)CCNC=O": "methyl 3-(formamido)propanoate",
-        "N=COC(=O)CNC=O": "iminomethyl 2-(formamido)acetate",
+        "COC(=O)CCNC=O": "methyl 3-formamidopropanoate",
+        "N=COC(=O)CNC=O": "iminomethyl 2-formamidoacetate",
     }
 
     for smiles, expected in cases.items():

--- a/src/openclatura/von_baeyer.py
+++ b/src/openclatura/von_baeyer.py
@@ -85,15 +85,6 @@ def find_von_baeyer_candidates(
     return tuple(sorted(deduped, key=lambda candidate: candidate.rank))
 
 
-def best_von_baeyer_candidate(
-    mol: Molecule,
-    atoms: set[int] | frozenset[int],
-    edges: set[tuple[int, int]] | frozenset[tuple[int, int]],
-) -> VonBaeyerCandidate | None:
-    candidates = find_von_baeyer_candidates(mol, atoms, edges)
-    return candidates[0] if candidates else None
-
-
 def _is_von_baeyer_scope(mol: Molecule, atoms: frozenset[int], edges: frozenset[tuple[int, int]]) -> bool:
     if len(edges) - len(atoms) + 1 < 3:
         return False
@@ -401,15 +392,6 @@ def _component_path(
                     seen.add(neighbor)
                     queue.append((neighbor, path + (neighbor,)))
     return ()
-
-
-def _is_unbranched_component(component: set[int], edge_set: frozenset[tuple[int, int]], attachments: set[int]) -> bool:
-    allowed = component | attachments
-    for atom in component:
-        degree = sum(1 for neighbor in _neighbors(atom, edge_set) if neighbor in allowed)
-        if degree > 2:
-            return False
-    return True
 
 
 def _connected_components(atoms: set[int], edge_set: frozenset[tuple[int, int]]) -> list[set[int]]:

--- a/tests/integration/test_describer.py
+++ b/tests/integration/test_describer.py
@@ -189,9 +189,11 @@ def test_describe_renders_heteroatom_shortcut_ligand_tree():
 
 
 def test_describe_carbonylamino_shortcut_does_not_render_carbonyl_oxygen_as_hydroxy():
-    text = str(describe("CC(C)C[C@@H](C(=O)N[C@@H](CC(C)C)C(=O)N[C@@H](CC(C)C)C(=O)O)N"))
+    d = describe("CC(C)C[C@@H](C(=O)N[C@@H](CC(C)C)C(=O)N[C@@H](CC(C)C)C(=O)O)N")
+    text = str(d)
 
-    assert "Substituent: carbonyl covers 2 atoms and 1 bond" in text
-    assert "Substituent at 1: (1S)-1-amino-3-methylbutylcarbonylamino covers 9 atoms and 8 bonds" in text
-    assert "Substituent: (1S)-1-amino-3-methylbutylcarbonyl covers 8 atoms and 7 bonds" in text
-    assert "Substituent: hydroxy covers 1 atom and 1 bond" not in text
+    # The acyl-amino chain is named as amido linkages, not the old carbonylamino shortcut.
+    assert d.name == "(2S)-2-((2S)-2-((2S)-2-amino-4-methylpentanamido)-4-methylpentanamido)-4-methylpentanoic acid"
+    assert "carbonylamino" not in text
+    # The carbonyl oxygen is part of the amido linkage, never rendered as a hydroxy substituent.
+    assert "Substituent: hydroxy" not in text


### PR DESCRIPTION
## Summary by Sourcery

Improve naming and stereochemical treatment of acylamino substituents and small-ring stereochemistry while fixing graph-related edge cases in name postprocessing and analysis.

New Features:
- Support substitutive acylamido prefixes for carboxamide nitrogens, including N-locanted amide N-substituents rendered as N- prefixed names.
- Emit pseudoasymmetric local R/S descriptors for gem-disubstituted small-ring centers within substituent scopes while deferring mono-substituted centers to cis/trans descriptors.

Bug Fixes:
- Prevent temporary hydroxyl-capped fragments used for acylamido naming from leaking spurious hydroxy nodes into the substituent analysis tree.
- Fix oxo group plus methyl contractions to carbonyl using parenthesis-aware parsing to avoid corrupting names with nested methyl groups such as heteroaryl-methyl substituents.
- Correct formamide-related names to use substitutive formamido forms instead of functional-class parenthesized spellings.
- Ensure substituent small-ring stereochemistry no longer suppresses valid local pseudoasymmetric descriptors that should be emitted.

Enhancements:
- Refine heteroatom subgraph naming by preferring acylamido-based substituent names over generic carbonylamino renderings when appropriate.

Tests:
- Update and extend analysis and naming tests to cover acylamido substitution, avoidance of hydroxy graph artifacts, improved oxo-to-carbonyl contractions, and new small-ring stereochemistry behaviors.