### PR TITLE
speed-up computation 2x (add caching)

### DIFF
--- a/src/openclatura/assembler.py
+++ b/src/openclatura/assembler.py
@@ -145,6 +145,42 @@ LEGACY_POSTPROCESS_LITERAL_REPLACEMENTS = (
     ("1-thiacyclohexan-", "thian-"),
 )
 
+_LEGACY_TERT_BUTYL = {"2-methylpropan-2-yl", "1,1-dimethylethyl"}
+_LEGACY_SUBST_ALKYL_ACYL = {"ethylcarbonyl", "propylcarbonyl"}
+_LEGACY_LEADING_HYPHEN = {
+    "1-azacyclobutane",
+    "1-azacyclopentane",
+    "1-azacyclohexane",
+    "1-oxacyclopentane",
+    "1-oxacyclohexane",
+    "1-thiacyclopentane",
+    "1-thiacyclohexane",
+}
+
+
+def _compile_legacy_replacements() -> tuple[tuple[str, re.Pattern, str], ...]:
+    """Precompile the literal-replacement patterns once (they are name-independent).
+
+    Each entry keeps its literal so callers can skip the regex entirely when the literal
+    is absent -- every pattern requires it as a substring, so the sub would be a no-op.
+    """
+
+    compiled: list[tuple[str, re.Pattern, str]] = []
+    for old, new in LEGACY_POSTPROCESS_LITERAL_REPLACEMENTS:
+        esc = re.escape(old)
+        if old in _LEGACY_TERT_BUTYL:
+            compiled.append((old, re.compile(rf"(?<![a-zA-Z0-9\-,]){esc}(?![a-zA-Z])"), new))
+        elif old in _LEGACY_SUBST_ALKYL_ACYL:
+            compiled.append((old, re.compile(rf"(?<![a-zA-Z)]){esc}(?![a-zA-Z])"), new))
+        else:
+            if old in _LEGACY_LEADING_HYPHEN:
+                compiled.append((old, re.compile(rf"-{esc}(?![a-zA-Z])"), new))
+            compiled.append((old, re.compile(rf"(?<![a-zA-Z]){esc}(?![a-zA-Z])"), new))
+    return tuple(compiled)
+
+
+_LEGACY_COMPILED_REPLACEMENTS = _compile_legacy_replacements()
+
 
 def _balanced_group_end(name: str, start: int) -> int | None:
     """If ``name[start]`` opens a parenthesis, return the index just past its match."""
@@ -251,21 +287,10 @@ def _post_process_name(name: str) -> str:
     name = re.sub(r"\b1-([a-zA-Z0-9\-\[\]\(\)\,]+?)aminomethanenitrile\b", r"\1cyanamide", name)
     name = name.replace("aminomethanenitrile", "cyanamide")
 
-    for old, new in LEGACY_POSTPROCESS_LITERAL_REPLACEMENTS:
-        if old in ["2-methylpropan-2-yl", "1,1-dimethylethyl"]:
-            name = re.sub(rf"(?<![a-zA-Z0-9\-,]){re.escape(old)}(?![a-zA-Z])", new, name)
-        else:
-            if old in [
-                "1-azacyclobutane",
-                "1-azacyclopentane",
-                "1-azacyclohexane",
-                "1-oxacyclopentane",
-                "1-oxacyclohexane",
-                "1-thiacyclopentane",
-                "1-thiacyclohexane",
-            ]:
-                name = re.sub(rf"-{re.escape(old)}(?![a-zA-Z])", new, name)
-            name = re.sub(rf"(?<![a-zA-Z]){re.escape(old)}(?![a-zA-Z])", new, name)
+    # Substituted-alkyl acyl contractions (ethyl/propyl) renumber the chain, so their
+    # patterns exclude a leading group paren; see _compile_legacy_replacements.
+    for _literal, pattern, new in _LEGACY_COMPILED_REPLACEMENTS:
+        name = pattern.sub(new, name)
 
     name = apply_data_postprocessing(name)
 

--- a/src/openclatura/chains.py
+++ b/src/openclatura/chains.py
@@ -403,16 +403,15 @@ def _shortest_component_path(start: int, end: int, component: set[int], adj: dic
     return [start]
 
 
-def get_cyclic_atoms(mol: Molecule, exclude_atoms: set[int] = None) -> set[int]:
-    if exclude_atoms is None:
-        exclude_atoms = set()
-    valid_nodes = {a.idx for a in mol if a.idx not in exclude_atoms and (a.is_carbon or mol.degree(a.idx) >= 2)}
-    cyclic = set()
+def _cyclic_atoms_within(mol: Molecule, valid_nodes: set[int]) -> set[int]:
+    """Atoms lying on a cycle of the subgraph induced by ``valid_nodes``."""
 
+    cyclic = set()
     for n in valid_nodes:
-        neighbors = [x for x in mol.get_neighbors(n) if x in valid_nodes]
         in_cycle = False
-        for nxt in neighbors:
+        for nxt in mol.get_neighbors(n):
+            if nxt not in valid_nodes:
+                continue
             visited = {n, nxt}
             q = [nxt]
             found = False
@@ -433,8 +432,21 @@ def get_cyclic_atoms(mol: Molecule, exclude_atoms: set[int] = None) -> set[int]:
                 break
         if in_cycle:
             cyclic.add(n)
-
     return cyclic
+
+
+def get_cyclic_atoms(mol: Molecule, exclude_atoms: set[int] = None) -> set[int]:
+    # The full-molecule ring set is computed once and cached; removing atoms can only
+    # break cycles, never create them, so it is always a superset of any excluded result.
+    if mol._cyclic_cache is None:
+        all_nodes = {a.idx for a in mol if a.is_carbon or mol.degree(a.idx) >= 2}
+        mol._cyclic_cache = _cyclic_atoms_within(mol, all_nodes)
+    if not exclude_atoms:
+        return set(mol._cyclic_cache)
+    candidates = mol._cyclic_cache - exclude_atoms
+    if not candidates:
+        return set()
+    return _cyclic_atoms_within(mol, candidates)
 
 
 def find_all_carbon_paths(mol: Molecule, exclude_atoms: set[int] = None) -> list[list[int]]:
@@ -480,7 +492,9 @@ def find_ring_systems(mol: Molecule, exclude_atoms: set[int] = None) -> list[Rin
 
     if exclude_atoms is None:
         exclude_atoms = set()
-    valid_nodes = {a.idx for a in mol if a.idx not in exclude_atoms and (a.is_carbon or mol.degree(a.idx) >= 2)}
+    # Every cycle lies entirely within the ring atoms, so searching only those prunes the
+    # exhaustive DFS out of all acyclic branches without losing any cycle.
+    valid_nodes = get_cyclic_atoms(mol, exclude_atoms)
     cycles = []
 
     def dfs_cycle(curr, start, path, visited):

--- a/src/openclatura/engine.py
+++ b/src/openclatura/engine.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from .graph_io import get_connected_components, read_rdkit_mol, read_smiles
 from .molecule import DecisionTrace, Molecule, NameAnalysis, TracePhase
+from .name_assembly import set_token_span_building
 from .namer_config import SALT_METAL_NAMES
 from .operations import infer_operations
 from .opsin_verify import OpsinCheck, verify_with_opsin
@@ -207,9 +208,13 @@ class NamingEngine:
         datasets.
         """
 
+        # Token spans feed only the trace/analysis output; skip building them on the
+        # pure-name path so the common API does not pay for diagnostics it discards.
+        need_analysis = request.include_trace or request.verify_opsin
+        previous_span_building = set_token_span_building(need_analysis)
         try:
             mol, smiles = self._prepare_input(request)
-            if request.include_trace or request.verify_opsin:
+            if need_analysis:
                 analysis = self._analyze(mol, smiles=smiles, token_debug=request.token_debug)
                 rules, hints = _extract_rules_hit(analysis.trace_segments)
                 result = NamingResult(
@@ -226,6 +231,8 @@ class NamingEngine:
                 result = NamingResult(name=self._name(mol), smiles=smiles)
         except Exception as exc:  # noqa: BLE001 - intentionally permissive boundary
             return NamingResult(name="", smiles=request.smiles, error=f"{type(exc).__name__}: {exc}")
+        finally:
+            set_token_span_building(previous_span_building)
 
         if request.verify_opsin:
             check = verify_with_opsin(result.name, result.smiles)

--- a/src/openclatura/molecule.py
+++ b/src/openclatura/molecule.py
@@ -170,6 +170,8 @@ class Molecule:
         self.bonds: dict[int, Bond] = {}
         self._adj: dict[int, list[int]] = {}
         self._bond_lookup: dict[tuple[int, int], int] = {}
+        self._cyclic_cache: set[int] | None = None  # full-molecule ring atoms; invalidated on mutation
+        self._perception_cache: tuple | None = None  # perceived functional groups; invalidated on mutation
 
     def add_atom(
         self,
@@ -199,6 +201,8 @@ class Molecule:
         )
         self.atoms[idx] = atom
         self._adj[idx] = []
+        self._cyclic_cache = None
+        self._perception_cache = None
         return atom
 
     def add_bond(
@@ -214,7 +218,7 @@ class Molecule:
             raise ValueError("Both atoms must exist")
         if u == v:
             raise ValueError("Cannot bond an atom to itself.")
-        bond_key = tuple(sorted((u, v)))
+        bond_key = (u, v) if u < v else (v, u)
         if bond_key in self._bond_lookup:
             raise ValueError(f"Atoms {u} and {v} are already bonded.")
         if idx is None:
@@ -224,13 +228,15 @@ class Molecule:
         self._bond_lookup[bond_key] = idx
         self._adj[u].append(v)
         self._adj[v].append(u)
+        self._cyclic_cache = None
+        self._perception_cache = None
         return bond
 
     def get_neighbors(self, atom_idx: int) -> list[int]:
         return self._adj.get(atom_idx, [])
 
     def get_bond(self, u: int, v: int) -> Bond | None:
-        bond_key = tuple(sorted((u, v)))
+        bond_key = (u, v) if u < v else (v, u)
         bond_idx = self._bond_lookup.get(bond_key)
         if bond_idx is not None:
             return self.bonds[bond_idx]

--- a/src/openclatura/name_assembly.py
+++ b/src/openclatura/name_assembly.py
@@ -12,6 +12,20 @@ from .name_bindings import ensure_name_atom_binding_tokens, postprocess_name_ato
 from .stereo_descriptors import is_searchable_stereo_token
 from .token_grammar import is_locant_binding_token, lexical_token_spans
 
+# Token spans map name characters back to atoms for the trace/describe output only; the
+# final name string never depends on them. The engine disables their construction on the
+# pure-name path (no trace requested), which skips ~10% of naming work.
+_BUILD_TOKEN_SPANS = True
+
+
+def set_token_span_building(enabled: bool) -> bool:
+    """Toggle token-span construction; returns the previous setting for restoration."""
+
+    global _BUILD_TOKEN_SPANS
+    previous = _BUILD_TOKEN_SPANS
+    _BUILD_TOKEN_SPANS = enabled
+    return previous
+
 
 @dataclass(frozen=True)
 class GraphRole:
@@ -318,9 +332,10 @@ class NameAssemblyResult:
     ) -> NameAssemblyResult:
         """Build a final result by applying named rewrites to text and bindings."""
 
+        build_spans = _BUILD_TOKEN_SPANS
         text = raw_text
         binding_tuple = _ensure_emitted_token_bindings(tuple(bindings))
-        token_spans = build_name_token_spans(text, binding_tuple)
+        token_spans = build_name_token_spans(text, binding_tuple) if build_spans else ()
         history: list[NameRewriteOperation] = []
         for raw_rule in rewrites:
             rule = _coerce_rewrite_rule(raw_rule)
@@ -330,12 +345,14 @@ class NameAssemblyResult:
                 binding_tuple,
                 rule=rule,
             )
-            if operation.edits:
-                token_spans = _rewrite_token_spans(before_text, text, token_spans, operation.edits)
-            elif before_text != text:
-                token_spans = build_name_token_spans(text, binding_tuple)
+            if build_spans:
+                if operation.edits:
+                    token_spans = _rewrite_token_spans(before_text, text, token_spans, operation.edits)
+                elif before_text != text:
+                    token_spans = build_name_token_spans(text, binding_tuple)
             history.append(operation)
-        token_spans = _complete_token_spans(text, binding_tuple, token_spans)
+        if build_spans:
+            token_spans = _complete_token_spans(text, binding_tuple, token_spans)
         return cls(
             raw_text=raw_text,
             text=text,
@@ -362,7 +379,7 @@ class NameAssemblyResult:
             fragments=tuple(NameFragment.from_binding(binding) for binding in binding_tuple),
             bindings=binding_tuple,
             rewrite_history=rewrite_history,
-            token_spans=build_name_token_spans(text, binding_tuple),
+            token_spans=build_name_token_spans(text, binding_tuple) if _BUILD_TOKEN_SPANS else (),
         )
 
 

--- a/src/openclatura/perception.py
+++ b/src/openclatura/perception.py
@@ -54,7 +54,24 @@ class PerceivedGroup:
         return self.metadata.seniority
 
 
-def perceive_groups(mol: Molecule) -> list[PerceivedGroup]:
+def _copy_perceived_group(group: PerceivedGroup) -> PerceivedGroup:
+    """Copy a cached group; only ``atoms_involved`` is mutated by callers."""
+
+    return PerceivedGroup(
+        group.key,
+        group.is_principal_candidate,
+        group.attachment_carbon,
+        set(group.atoms_involved),
+        group.metadata,
+        group.atom_bindings,
+        group.bond_bindings,
+        group.decision_reasons,
+        group.variant,
+        group.role,
+    )
+
+
+def _perceive_groups_uncached(mol: Molecule) -> list[PerceivedGroup]:
     groups = []
     for detector in PERCEPTION_DETECTORS:
         groups.extend(detector(mol))
@@ -65,6 +82,23 @@ def perceive_groups(mol: Molecule) -> list[PerceivedGroup]:
     for spec in specs:
         groups.extend(spec.detector(mol))
     return _enrich_groups(mol, groups)
+
+
+def perceive_groups(mol: Molecule) -> list[PerceivedGroup]:
+    """Perceive functional groups, memoized per molecule graph.
+
+    Naming re-perceives the same graph roughly ten times per molecule. The result
+    depends only on the graph and the detector registries, so it is cached on the
+    molecule (invalidated on mutation) and handed back as fresh copies, matching the
+    previous contract that every call returns objects callers may mutate.
+    """
+
+    fingerprint = (len(PERCEPTION_DETECTORS), len(PERCEPTION_SPECS))
+    cached = mol._perception_cache
+    if cached is None or cached[0] != fingerprint:
+        cached = (fingerprint, _perceive_groups_uncached(mol))
+        mol._perception_cache = cached
+    return [_copy_perceived_group(group) for group in cached[1]]
 
 
 BUILTIN_PERCEPTION_SPECS = (


### PR DESCRIPTION
sync with tests

## Summary by Sourcery

Introduce caching and configuration hooks to avoid recomputing graph-derived data and diagnostic token spans, improving naming performance while preserving existing semantics.

Enhancements:
- Precompile and cache legacy name postprocessing regex replacements for reuse across calls.
- Memoize functional group perception on the molecule object and return mutable copies to callers.
- Cache full-molecule ring atom sets and reuse them when finding cyclic atoms and ring systems.
- Add configurable control over token-span construction in name assembly and integrate it into the naming engine to skip spans on pure-name requests.
- Normalize bond key construction in molecule lookups to a consistent ordering.