### PR TITLE
feat: restore large backbone stems with reverse lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 Built on top of RDKit, the package walks the molecular graph, detects functional groups and ring systems, selects the principal parent, assigns locants, and constructs the corresponding substitutive IUPAC name. Every step is recorded in an inspectable
 decision trace so the *why* of a name is recoverable, not just the *what*.
 
+Systematic backbone stems are supported for chains and rings containing from 1
+through 1000 skeletal atoms, following IUPAC Blue Book P-14.2.1.
+
 > **Status:** beta. The naming engine handles a broad slice of organic
 > structures (alkanes/alkenes/alkynes, common functional groups, simple
 > heterocycles, fused/spiro/bridged systems, retained names from the Blue

--- a/src/openclatura/chains.py
+++ b/src/openclatura/chains.py
@@ -462,19 +462,24 @@ def find_all_carbon_paths(mol: Molecule, exclude_atoms: set[int] = None) -> list
 
     all_paths = []
 
-    def dfs(current: int, path: list[int], visited: set[int]):
-        neighbors = [n for n in mol.get_neighbors(current) if n in valid_nodes and n not in visited]
-        if not neighbors:
-            all_paths.append(path)
-            return
-        for n in neighbors:
-            dfs(n, path + [n], visited | {n})
+    def collect_paths(start: int) -> None:
+        # Long unbranched backbones can exceed Python's recursion limit. Keep
+        # the existing depth-first order without using the interpreter stack.
+        stack = [(start, [start], {start})]
+        while stack:
+            current, path, visited = stack.pop()
+            neighbors = [n for n in mol.get_neighbors(current) if n in valid_nodes and n not in visited]
+            if not neighbors:
+                all_paths.append(path)
+                continue
+            for neighbor in reversed(neighbors):
+                stack.append((neighbor, path + [neighbor], visited | {neighbor}))
 
     endpoints = [n for n in valid_nodes if sum(1 for x in mol.get_neighbors(n) if x in valid_nodes) <= 1]
     start_nodes = endpoints if endpoints else valid_nodes
 
     for start in start_nodes:
-        dfs(start, [start], {start})
+        collect_paths(start)
 
     unique_paths = []
     seen = set()

--- a/src/openclatura/formatting.py
+++ b/src/openclatura/formatting.py
@@ -98,13 +98,13 @@ def substituted_alkoxy_prefix(branch: str) -> str | None:
 
     if "hydroxy" not in branch:
         return None
-    for stem in stems.STEMS.values():
-        terminal = f"{stem.stem}yl"
-        replacement = f"{stem.stem}oxy"
-        if branch.endswith(terminal):
-            prefix = branch[: -len(terminal)]
-            return f"({prefix}{replacement})" if prefix else replacement
-    return None
+    stem = stems.terminal_stem(branch)
+    if stem is None:
+        return None
+    terminal = f"{stem.stem}yl"
+    replacement = f"{stem.stem}oxy"
+    prefix = branch[: -len(terminal)]
+    return f"({prefix}{replacement})" if prefix else replacement
 
 
 def format_element_substituent(stereo_prefix: str, branch: str, suffix: str, is_double: bool = False) -> str:

--- a/src/openclatura/ring_renderer.py
+++ b/src/openclatura/ring_renderer.py
@@ -36,10 +36,7 @@ def von_baeyer_cycle_count(descriptor: str | None) -> int | None:
     for count, multiplier in multipliers.MULTIPLIERS.items():
         if prefix == multiplier.basic:
             return count
-    for count, stem in stems.STEMS.items():
-        if prefix == _basic_cycle_prefix(count):
-            return count
-    return None
+    return stems.length_for_basic_prefix(prefix)
 
 
 def is_von_baeyer_descriptor(descriptor: str | None) -> bool:

--- a/src/openclatura/rules/stems.py
+++ b/src/openclatura/rules/stems.py
@@ -9,6 +9,7 @@ References:
 """
 
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import lru_cache
 from re import Pattern
@@ -162,25 +163,25 @@ def stem_for(length: int) -> str:
     return get(length).stem
 
 
-@lru_cache(maxsize=1)
-def _supported_stems() -> tuple[Stem, ...]:
-    """Return every supported stem, constructing generated values only once."""
+def _iter_supported_stems() -> Iterator[Stem]:
+    """Yield supported stems without retaining a second full collection."""
 
-    return tuple(get(length) for length in range(MIN_STEM_LENGTH, MAX_STEM_LENGTH + 1))
+    for length in range(MIN_STEM_LENGTH, MAX_STEM_LENGTH + 1):
+        yield get(length)
 
 
 @lru_cache(maxsize=1)
 def _alkyl_suffix_index() -> dict[str, Stem]:
-    """Map supported terminal alkyl text to its stem."""
+    """Lazily map supported terminal alkyl text to its stem."""
 
-    return {f"{stem.stem}yl": stem for stem in _supported_stems()}
+    return {f"{stem.stem}yl": stem for stem in _iter_supported_stems()}
 
 
 @lru_cache(maxsize=1)
 def _basic_prefix_index() -> dict[str, int]:
-    """Map supported basic numerical prefixes to skeletal-atom counts."""
+    """Lazily map supported basic numerical prefixes to atom counts."""
 
-    return {f"{stem.stem}a": stem.length for stem in _supported_stems()}
+    return {f"{stem.stem}a": stem.length for stem in _iter_supported_stems()}
 
 
 @lru_cache(maxsize=1)
@@ -192,9 +193,16 @@ def _terminal_alkyl_pattern() -> Pattern[str]:
 
 
 def terminal_stem(name: str) -> Stem | None:
-    """Return the stem represented by the longest terminal alkyl suffix."""
+    """Return the stem represented by the longest terminal alkyl suffix.
 
-    if not isinstance(name, str) or not name:
+    Reverse-search data is constructed only on the first call. An empty or
+    unrecognized string returns ``None``; a non-string input raises
+    ``ValueError`` because it cannot represent nomenclature text.
+    """
+
+    if not isinstance(name, str):
+        raise ValueError("Terminal stem name must be a string")
+    if not name:
         return None
     match = _terminal_alkyl_pattern().search(name)
     if match is None:
@@ -203,8 +211,15 @@ def terminal_stem(name: str) -> Stem | None:
 
 
 def length_for_basic_prefix(prefix: str) -> int | None:
-    """Return the skeletal-atom count represented by a basic numerical prefix."""
+    """Return the atom count represented by a basic numerical prefix.
 
-    if not isinstance(prefix, str) or not prefix:
+    Reverse-search data is constructed only on the first call. An empty or
+    unrecognized string returns ``None``; a non-string input raises
+    ``ValueError`` because it cannot represent nomenclature text.
+    """
+
+    if not isinstance(prefix, str):
+        raise ValueError("Basic numerical prefix must be a string")
+    if not prefix:
         return None
     return _basic_prefix_index().get(prefix)

--- a/src/openclatura/rules/stems.py
+++ b/src/openclatura/rules/stems.py
@@ -8,7 +8,10 @@ References:
 - IUPAC 2013 Recommendations, P-23.2.1 (chain length names)
 """
 
+import re
 from dataclasses import dataclass
+from functools import lru_cache
+from re import Pattern
 
 
 @dataclass(frozen=True)
@@ -20,7 +23,8 @@ class Stem:
 
 # Stems 1-4 are retained (non-systematic) names.
 # Stems 5+ are derived from Greek/Latin numerical roots.
-# Coverage up to 30; extend as needed (IUPAC defines stems well beyond this).
+# Retained and established spellings through 30. Larger stems are generated
+# from the basic numerical terms in Blue Book P-14.2.1.
 STEMS: dict[int, Stem] = {
     1: Stem(1, "meth", retained=True),
     2: Stem(2, "eth", retained=True),
@@ -54,12 +58,153 @@ STEMS: dict[int, Stem] = {
     30: Stem(30, "triacont", retained=False),
 }
 
+MIN_STEM_LENGTH = 1
+MAX_STEM_LENGTH = 1000
+
+_UNITS = {
+    1: "hen",
+    2: "do",
+    3: "tri",
+    4: "tetra",
+    5: "penta",
+    6: "hexa",
+    7: "hepta",
+    8: "octa",
+    9: "nona",
+}
+
+_TENS = {
+    1: "deca",
+    2: "icosa",
+    3: "triaconta",
+    4: "tetraconta",
+    5: "pentaconta",
+    6: "hexaconta",
+    7: "heptaconta",
+    8: "octaconta",
+    9: "nonaconta",
+}
+
+_HUNDREDS = {
+    1: "hecta",
+    2: "dicta",
+    3: "tricta",
+    4: "tetracta",
+    5: "pentacta",
+    6: "hexacta",
+    7: "heptacta",
+    8: "octacta",
+    9: "nonacta",
+}
+
+
+def _validate_length(length: int) -> None:
+    if isinstance(length, bool) or not isinstance(length, int):
+        raise ValueError("Stem length must be an integer from 1 through 1000")
+    if not MIN_STEM_LENGTH <= length <= MAX_STEM_LENGTH:
+        raise ValueError("Stem length must be from 1 through 1000")
+
+
+def _under_one_hundred(value: int) -> str:
+    """Return the basic numerical term for a value from 1 through 99."""
+
+    if value == 11:
+        return "undeca"
+
+    units = value % 10
+    tens = value // 10
+    unit_term = _UNITS.get(units, "")
+    tens_term = _TENS.get(tens, "")
+
+    # The initial i of icosa is elided after a vowel (P-14.2.1.2), e.g.
+    # do + icosa -> docosa, but hen + icosa -> henicosa.
+    if unit_term and tens == 2 and unit_term[-1] in "aeiou":
+        tens_term = tens_term[1:]
+    return unit_term + tens_term
+
+
+def _numerical_term(length: int) -> str:
+    """Build the P-14.2.1 basic numerical term for ``length``."""
+
+    _validate_length(length)
+    if length == 1000:
+        return "kilia"
+
+    hundreds, remainder = divmod(length, 100)
+    parts = []
+    if remainder:
+        parts.append(_under_one_hundred(remainder))
+    if hundreds:
+        parts.append(_HUNDREDS[hundreds])
+    return "".join(parts)
+
 
 def get(length: int) -> Stem:
-    """Look up a stem by chain length. Raises KeyError if out of range."""
-    return STEMS[length]
+    """Return the chain stem for a supported skeletal-atom count."""
+
+    _validate_length(length)
+    return _get_cached(length)
+
+
+@lru_cache(maxsize=MAX_STEM_LENGTH)
+def _get_cached(length: int) -> Stem:
+    """Return a validated stem while caching generated values."""
+
+    if length in STEMS:
+        return STEMS[length]
+    numerical_term = _numerical_term(length)
+    return Stem(length, numerical_term.removesuffix("a"), retained=False)
 
 
 def stem_for(length: int) -> str:
-    """Return just the stem string for a given chain length."""
-    return STEMS[length].stem
+    """Return just the stem string for a supported chain length."""
+
+    return get(length).stem
+
+
+@lru_cache(maxsize=1)
+def _supported_stems() -> tuple[Stem, ...]:
+    """Return every supported stem, constructing generated values only once."""
+
+    return tuple(get(length) for length in range(MIN_STEM_LENGTH, MAX_STEM_LENGTH + 1))
+
+
+@lru_cache(maxsize=1)
+def _alkyl_suffix_index() -> dict[str, Stem]:
+    """Map supported terminal alkyl text to its stem."""
+
+    return {f"{stem.stem}yl": stem for stem in _supported_stems()}
+
+
+@lru_cache(maxsize=1)
+def _basic_prefix_index() -> dict[str, int]:
+    """Map supported basic numerical prefixes to skeletal-atom counts."""
+
+    return {f"{stem.stem}a": stem.length for stem in _supported_stems()}
+
+
+@lru_cache(maxsize=1)
+def _terminal_alkyl_pattern() -> Pattern[str]:
+    """Compile a longest-first matcher for supported terminal alkyl text."""
+
+    alternatives = sorted((re.escape(suffix) for suffix in _alkyl_suffix_index()), key=len, reverse=True)
+    return re.compile(f"({'|'.join(alternatives)})$")
+
+
+def terminal_stem(name: str) -> Stem | None:
+    """Return the stem represented by the longest terminal alkyl suffix."""
+
+    if not isinstance(name, str) or not name:
+        return None
+    match = _terminal_alkyl_pattern().search(name)
+    if match is None:
+        return None
+    return _alkyl_suffix_index()[match.group(1)]
+
+
+def length_for_basic_prefix(prefix: str) -> int | None:
+    """Return the skeletal-atom count represented by a basic numerical prefix."""
+
+    if not isinstance(prefix, str) or not prefix:
+        return None
+    return _basic_prefix_index().get(prefix)

--- a/src/openclatura/tests/test_stems.py
+++ b/src/openclatura/tests/test_stems.py
@@ -82,6 +82,18 @@ def test_generated_stems_are_unique():
     assert len(generated) == len(set(generated)) == 1000
 
 
+def test_forward_lookup_does_not_build_reverse_indexes():
+    stems._alkyl_suffix_index.cache_clear()
+    stems._basic_prefix_index.cache_clear()
+    stems._terminal_alkyl_pattern.cache_clear()
+
+    stems.stem_for(486)
+
+    assert stems._alkyl_suffix_index.cache_info().currsize == 0
+    assert stems._basic_prefix_index.cache_info().currsize == 0
+    assert stems._terminal_alkyl_pattern.cache_info().currsize == 0
+
+
 @pytest.mark.parametrize("length", range(1, 1001))
 def test_terminal_stem_round_trip(length):
     stem = stems.get(length)
@@ -93,10 +105,18 @@ def test_basic_prefix_round_trip(length):
     assert stems.length_for_basic_prefix(f"{stems.stem_for(length)}a") == length
 
 
-@pytest.mark.parametrize("value", [None, "", 31, "not-a-stem", "ethylated"])
-def test_reverse_stem_lookups_reject_unknown_values(value):
+@pytest.mark.parametrize("value", ["", "not-a-stem", "ethylated"])
+def test_reverse_stem_lookups_return_none_for_unknown_text(value):
     assert stems.terminal_stem(value) is None
     assert stems.length_for_basic_prefix(value) is None
+
+
+@pytest.mark.parametrize("value", [None, 31, 1.0, [], {}, True])
+def test_reverse_stem_lookups_raise_value_error_for_non_strings(value):
+    with pytest.raises(ValueError, match="must be a string"):
+        stems.terminal_stem(value)
+    with pytest.raises(ValueError, match="must be a string"):
+        stems.length_for_basic_prefix(value)
 
 
 @pytest.mark.parametrize(

--- a/src/openclatura/tests/test_stems.py
+++ b/src/openclatura/tests/test_stems.py
@@ -1,0 +1,140 @@
+"""Regression tests for systematic chain-length stems."""
+
+import pytest
+
+from openclatura import name
+from openclatura.formatting import substituted_alkoxy_prefix
+from openclatura.ring_renderer import von_baeyer_cycle_count
+from openclatura.rules import stems
+
+LEGACY_STEMS = (
+    "meth",
+    "eth",
+    "prop",
+    "but",
+    "pent",
+    "hex",
+    "hept",
+    "oct",
+    "non",
+    "dec",
+    "undec",
+    "dodec",
+    "tridec",
+    "tetradec",
+    "pentadec",
+    "hexadec",
+    "heptadec",
+    "octadec",
+    "nonadec",
+    "icos",
+    "henicos",
+    "docos",
+    "tricos",
+    "tetracos",
+    "pentacos",
+    "hexacos",
+    "heptacos",
+    "octacos",
+    "nonacos",
+    "triacont",
+)
+
+
+@pytest.mark.parametrize("length, expected", enumerate(LEGACY_STEMS, start=1))
+def test_legacy_stems_are_unchanged(length, expected):
+    assert stems.stem_for(length) == expected
+
+
+@pytest.mark.parametrize(
+    "length, expected",
+    [
+        (31, "hentriacont"),
+        (39, "nonatriacont"),
+        (40, "tetracont"),
+        (41, "hentetracont"),
+        (52, "dopentacont"),
+        (99, "nonanonacont"),
+        (100, "hect"),
+        (101, "henhect"),
+        (111, "undecahect"),
+        (199, "nonanonacontahect"),
+        (200, "dict"),
+        (363, "trihexacontatrict"),
+        (486, "hexaoctacontatetract"),
+        (999, "nonanonacontanonact"),
+        (1000, "kili"),
+    ],
+)
+def test_systematic_stem_examples(length, expected):
+    assert stems.stem_for(length) == expected
+    assert stems.get(length) == stems.Stem(length, expected, retained=False)
+
+
+@pytest.mark.parametrize("length", [None, 1.0, "31", [], {}, True, False, 0, -1, 1001])
+def test_invalid_stem_lengths_raise_value_error(length):
+    with pytest.raises(ValueError, match="1 through 1000"):
+        stems.stem_for(length)
+
+
+def test_generated_stems_are_unique():
+    generated = [stems.stem_for(length) for length in range(1, 1001)]
+    assert len(generated) == len(set(generated)) == 1000
+
+
+@pytest.mark.parametrize("length", range(1, 1001))
+def test_terminal_stem_round_trip(length):
+    stem = stems.get(length)
+    assert stems.terminal_stem(f"2-hydroxy{stem.stem}yl") == stem
+
+
+@pytest.mark.parametrize("length", range(1, 1001))
+def test_basic_prefix_round_trip(length):
+    assert stems.length_for_basic_prefix(f"{stems.stem_for(length)}a") == length
+
+
+@pytest.mark.parametrize("value", [None, "", 31, "not-a-stem", "ethylated"])
+def test_reverse_stem_lookups_reject_unknown_values(value):
+    assert stems.terminal_stem(value) is None
+    assert stems.length_for_basic_prefix(value) is None
+
+
+@pytest.mark.parametrize(
+    "branch, expected",
+    [
+        ("2-hydroxyethyl", "(2-hydroxyethoxy)"),
+        ("2-hydroxyhentriacontyl", "(2-hydroxyhentriacontoxy)"),
+        ("2-hydroxyhexaoctacontatetractyl", "(2-hydroxyhexaoctacontatetractoxy)"),
+        ("2-hydroxykiliyl", "(2-hydroxykilioxy)"),
+    ],
+)
+def test_substituted_alkoxy_prefix_uses_longest_generated_terminal_stem(branch, expected):
+    assert substituted_alkoxy_prefix(branch) == expected
+
+
+@pytest.mark.parametrize("branch", ["ethyl", "2-hydroxyalkyl", "hydroxyethylated"])
+def test_substituted_alkoxy_prefix_rejects_unrelated_branches(branch):
+    assert substituted_alkoxy_prefix(branch) is None
+
+
+@pytest.mark.parametrize(
+    "count",
+    [3, 10, 31, 100, 486, 1000],
+)
+def test_von_baeyer_cycle_count_recognizes_generated_prefixes(count):
+    prefix = f"{stems.stem_for(count)}a"
+    assert von_baeyer_cycle_count(f"{prefix}cyclo[1.1.1]") == count
+
+
+@pytest.mark.parametrize("descriptor", [None, "", "notacyclo[1.1.1]", "hentriacont[1.1.1]"])
+def test_von_baeyer_cycle_count_rejects_unknown_prefixes(descriptor):
+    assert von_baeyer_cycle_count(descriptor) is None
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("length", range(1, 1001))
+def test_linear_alkanes_from_one_through_one_thousand(length):
+    result = name("C" * length)
+    expected = stems.stem_for(length) + "ane"
+    assert result.error is None, f"C{length}: {result.error}"
+    assert result.name == expected


### PR DESCRIPTION
## Summary

Restores support for systematic backbone stems from 1 through 1,000 after the revert of #58.

This revision addresses the reverse-recognition performance concerns raised in #58 by separating forward stem generation from reverse lookup.

Closes #52.

## Changes

- Preserve the explicit `STEMS` table for established stems from 1–30.
- Generate and cache systematic stems from 31–1,000.
- Add dedicated lazy reverse-lookup APIs:
  - `terminal_stem()`
  - `length_for_basic_prefix()`
- Use longest-first terminal matching for alkoxy formatting.
- Use exact reverse lookup for Von Baeyer numerical prefixes.
- Use iterative carbon-path traversal to avoid recursion errors for long chains.
- Document support through 1,000 skeletal atoms.

## Tests

- 2,078 focused stem and reverse-lookup tests passed.
- 1,000 exhaustive linear-alkane tests passed.
- 2,945 repository-wide fast tests passed.
- 2 golden regression tests passed.
- Ruff lint and format checks passed.

This replaces the implementation reverted in #61 and incorporates the review feedback from #58.

## Summary by Sourcery

Restore and extend systematic backbone stem support up to chains and rings of length 1–1000, with performant reverse lookup for naming and ring descriptors.

New Features:
- Generate and cache systematic backbone stems for skeletal-atom counts beyond 30 up to 1000.
- Provide reverse-lookup APIs to resolve terminal alkyl stems and basic numerical prefixes from name fragments.
- Support Von Baeyer descriptors and substituted alkoxy prefixes using the extended stem set.
- Document systematic backbone stem coverage through 1–1000 skeletal atoms in the README.

Bug Fixes:
- Prevent recursion-limit failures when enumerating long carbon paths by switching to an explicit depth-first stack traversal.

Enhancements:
- Keep legacy stems 1–30 stable while deriving larger stems from IUPAC basic numerical terms.
- Ensure stem generation validates input lengths and produces unique stems across the supported range.

Tests:
- Add comprehensive regression tests for legacy and generated stems, reverse lookup behavior, alkoxy formatting, Von Baeyer cycle counts, and linear alkanes from C1 to C1000.