### PR TITLE
feat: unique-locant-elision

### DIFF
--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 
+from .locant_sources import LocantMapSource
 from .name_operations import HydroOperation
 from .spiro_assembly import SpiroAssembly
 
@@ -156,7 +157,7 @@ class AssemblyParts:
     parent_atom_charges_by_locant: dict[str, int] = field(default_factory=dict)
     parent_bond_orders_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
     parent_bond_ids_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
-    locant_map_source: str = "generated"
+    locant_map_source: LocantMapSource = LocantMapSource.GENERATED
     name_atom_bindings: list[NameAtomBinding] = field(default_factory=list)
     name_token_spans: list[dict] = field(default_factory=list)
     name_rewrite_history: list[dict] = field(default_factory=list)

--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -156,6 +156,7 @@ class AssemblyParts:
     parent_atom_charges_by_locant: dict[str, int] = field(default_factory=dict)
     parent_bond_orders_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
     parent_bond_ids_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
+    locant_map_source: str = "generated"
     name_atom_bindings: list[NameAtomBinding] = field(default_factory=list)
     name_token_spans: list[dict] = field(default_factory=list)
     name_rewrite_history: list[dict] = field(default_factory=list)

--- a/src/openclatura/assembly_prefixes.py
+++ b/src/openclatura/assembly_prefixes.py
@@ -1,12 +1,12 @@
 """Prefix formatting for assembled names."""
 
 import re
-from itertools import combinations
 
 from .assembly_charge import inferred_ionic_retained_parent, single_charged_replacement_locants
 from .assembly_parts import AssemblyParts, SubstituentItem
 from .assembly_utils import is_fully_enclosed, needs_hyphen, parse_locant
 from .formatting import is_complex_prefix
+from .locant_elision import retained_parent_attachment_is_ambiguous, substituent_locant_set_is_unique
 from .nomenclature import RULES
 from .retained_specs import retained_parent_spec
 from .rules import multipliers
@@ -45,7 +45,7 @@ def substituent_locant_string(parts: AssemblyParts, locs: list[str], grouped_cou
     must_print_retained_locant = bool(
         retained_spec
         and retained_spec.attachment_policy.use_parent_attachment_equivalence
-        and _retained_parent_attachment_is_ambiguous(parts, locs)
+        and retained_parent_attachment_is_ambiguous(parts, locs)
     )
     simple_one_locant = (
         len(locs) == 1
@@ -62,234 +62,9 @@ def substituent_locant_string(parts: AssemblyParts, locs: list[str], grouped_cou
         and not spiro_subs
         and not must_print_retained_locant
     )
-    if simple_one_locant or _substituent_locant_set_is_unique(parts, locs, grouped_count, spiro_subs):
+    if simple_one_locant or substituent_locant_set_is_unique(parts, locs, grouped_count, spiro_subs):
         return ""
     return ",".join(map(str, locs))
-
-
-def _substituent_locant_set_is_unique(
-    parts: AssemblyParts,
-    locs: list[str],
-    grouped_count: int,
-    spiro_subs,
-) -> bool:
-    """Return whether locants add no information for this substituent set.
-
-    The check is graph-based: selected locants may be omitted only when every
-    same-sized placement on parent atoms with the same local labels is related
-    by a parent automorphism. This keeps locants for ordinary isomeric cases
-    such as dimethylbenzene and tetramethylbenzene, while allowing fully
-    determined cases such as hexamethylbenzene.
-    """
-
-    if (
-        not locs
-        or parts.locant_map_source != "generated"
-        or grouped_count != 1
-        or parts.is_substituent
-        or parts.is_bicycle
-        or parts.is_spiro
-        or parts.is_polycycle
-        or spiro_subs
-        or parts.principal_group
-        or parts.unsaturations
-        or parts.a_prefixes
-    ):
-        return False
-    selected = tuple(str(loc) for loc in locs)
-    if len(set(selected)) != len(selected):
-        return False
-    if len(selected) == 1 and not parts.is_ring:
-        return False
-    if len(selected) == 1 and _retained_parent_attachment_is_ambiguous(parts, list(selected)):
-        return False
-    if not all(loc.isdigit() for loc in selected):
-        return False
-    if not parts.parent_atom_symbols_by_locant or not parts.parent_bond_orders_by_locants:
-        return False
-
-    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
-    selected_labels = {_parent_locant_label(parts, loc) for loc in selected}
-    if None in selected_labels or len(selected_labels) != 1:
-        return False
-    selected_label = next(iter(selected_labels))
-    candidates = [loc for loc in locants if _parent_locant_label(parts, loc) == selected_label]
-    if not set(selected).issubset(candidates):
-        return False
-    if len(selected) > len(candidates):
-        return False
-    return _all_same_sized_substituent_sets_are_equivalent(parts, set(selected), candidates)
-
-
-def _parent_locant_label(parts: AssemblyParts, locant: str) -> tuple[str, int, bool] | None:
-    symbol = parts.parent_atom_symbols_by_locant.get(locant)
-    if symbol is None:
-        return None
-    return (
-        symbol,
-        parts.parent_atom_charges_by_locant.get(locant, 0),
-        locant in {str(hydrogen) for hydrogen in parts.indicated_hydrogens},
-    )
-
-
-def _all_same_sized_substituent_sets_are_equivalent(
-    parts: AssemblyParts,
-    selected: set[str],
-    candidates: list[str],
-) -> bool:
-    k = len(selected)
-    n = len(candidates)
-    if k == n:
-        return True
-    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
-    labels = _parent_automorphism_labels(parts, locants)
-    adjacency = _parent_automorphism_adjacency(parts, locants)
-    if k == 1:
-        source = next(iter(selected))
-        return len(_parent_attachment_orbit(parts, source, candidates)) == len(candidates)
-    if k == n - 1:
-        omitted = next(loc for loc in candidates if loc not in selected)
-        return len(_parent_attachment_orbit(parts, omitted, candidates)) == len(candidates)
-    if n > 12:
-        return False
-    for target in combinations(candidates, k):
-        if not _has_parent_set_automorphism_mapping(selected, set(target), locants, labels, adjacency):
-            return False
-    return True
-
-
-def _parent_automorphism_labels(parts: AssemblyParts, locants: list[str]) -> dict[str, tuple[str | None, int, bool]]:
-    indicated_hydrogens = {str(hydrogen) for hydrogen in parts.indicated_hydrogens}
-    return {
-        loc: (
-            parts.parent_atom_symbols_by_locant.get(loc),
-            parts.parent_atom_charges_by_locant.get(loc, 0),
-            loc in indicated_hydrogens,
-        )
-        for loc in locants
-    }
-
-
-def _parent_automorphism_adjacency(parts: AssemblyParts, locants: list[str]) -> dict[str, dict[str, int]]:
-    return {
-        loc: {
-            other: parts.parent_bond_orders_by_locants.get(tuple(sorted((loc, other))), 0)
-            for other in locants
-            if other != loc
-        }
-        for loc in locants
-    }
-
-
-def _has_parent_set_automorphism_mapping(
-    source_set: set[str],
-    target_set: set[str],
-    locants: list[str],
-    labels: dict,
-    adjacency: dict,
-) -> bool:
-    if len(source_set) != len(target_set):
-        return False
-    mapping: dict[str, str] = {}
-    used: set[str] = set()
-
-    def compatible(src: str, dst: str) -> bool:
-        if labels[src] != labels[dst]:
-            return False
-        if (src in source_set) != (dst in target_set):
-            return False
-        for assigned_src, assigned_dst in mapping.items():
-            if adjacency[src].get(assigned_src, 0) != adjacency[dst].get(assigned_dst, 0):
-                return False
-        return True
-
-    def search() -> bool:
-        if len(mapping) == len(locants):
-            return True
-        src = min(
-            (loc for loc in locants if loc not in mapping),
-            key=lambda loc: (
-                loc not in source_set,
-                -sum(1 for assigned in mapping if adjacency[loc].get(assigned, 0)),
-                parse_locant(loc),
-            ),
-        )
-        candidate_targets = [loc for loc in locants if loc not in used and (src in source_set) == (loc in target_set)]
-        for dst in candidate_targets:
-            if not compatible(src, dst):
-                continue
-            mapping[src] = dst
-            used.add(dst)
-            if search():
-                return True
-            used.remove(dst)
-            del mapping[src]
-        return False
-
-    return search()
-
-
-def _retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str]) -> bool:
-    """Return whether locant omission would hide a non-equivalent attachment."""
-
-    if not parts.retained_name or not parts.is_ring or parts.is_bicycle or parts.is_spiro or parts.is_polycycle:
-        return False
-    if len(locs) != 1:
-        return False
-    locant = str(locs[0])
-    if locant not in parts.parent_atom_symbols_by_locant:
-        return True
-    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
-    if len(locants) <= 1:
-        return False
-    orbit = _parent_attachment_orbit(parts, locant, locants)
-    return len(orbit) < len(locants)
-
-
-def _parent_attachment_orbit(parts: AssemblyParts, source: str, locants: list[str]) -> set[str]:
-    labels = _parent_automorphism_labels(parts, locants)
-    adjacency = _parent_automorphism_adjacency(parts, locants)
-    return {
-        target
-        for target in locants
-        if labels[target] == labels[source]
-        and _has_parent_automorphism_mapping(source, target, locants, labels, adjacency)
-    }
-
-
-def _has_parent_automorphism_mapping(
-    source: str, target: str, locants: list[str], labels: dict, adjacency: dict
-) -> bool:
-    mapping = {source: target}
-    used = {target}
-
-    def compatible(src: str, dst: str) -> bool:
-        if labels[src] != labels[dst]:
-            return False
-        for assigned_src, assigned_dst in mapping.items():
-            if adjacency[src].get(assigned_src, 0) != adjacency[dst].get(assigned_dst, 0):
-                return False
-        return True
-
-    def search() -> bool:
-        if len(mapping) == len(locants):
-            return True
-        src = min(
-            (loc for loc in locants if loc not in mapping),
-            key=lambda loc: sum(1 for assigned in mapping if adjacency[loc].get(assigned, 0)),
-        )
-        for dst in locants:
-            if dst in used or not compatible(src, dst):
-                continue
-            mapping[src] = dst
-            used.add(dst)
-            if search():
-                return True
-            used.remove(dst)
-            del mapping[src]
-        return False
-
-    return search()
 
 
 def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:

--- a/src/openclatura/assembly_prefixes.py
+++ b/src/openclatura/assembly_prefixes.py
@@ -1,6 +1,7 @@
 """Prefix formatting for assembled names."""
 
 import re
+from itertools import combinations
 
 from .assembly_charge import inferred_ionic_retained_parent, single_charged_replacement_locants
 from .assembly_parts import AssemblyParts, SubstituentItem
@@ -61,7 +62,171 @@ def substituent_locant_string(parts: AssemblyParts, locs: list[str], grouped_cou
         and not spiro_subs
         and not must_print_retained_locant
     )
-    return "" if simple_one_locant else ",".join(map(str, locs))
+    if simple_one_locant or _substituent_locant_set_is_unique(parts, locs, grouped_count, spiro_subs):
+        return ""
+    return ",".join(map(str, locs))
+
+
+def _substituent_locant_set_is_unique(
+    parts: AssemblyParts,
+    locs: list[str],
+    grouped_count: int,
+    spiro_subs,
+) -> bool:
+    """Return whether locants add no information for this substituent set.
+
+    The check is graph-based: selected locants may be omitted only when every
+    same-sized placement on parent atoms with the same local labels is related
+    by a parent automorphism. This keeps locants for ordinary isomeric cases
+    such as dimethylbenzene and tetramethylbenzene, while allowing fully
+    determined cases such as hexamethylbenzene.
+    """
+
+    if (
+        not locs
+        or parts.locant_map_source != "generated"
+        or grouped_count != 1
+        or parts.is_substituent
+        or parts.is_bicycle
+        or parts.is_spiro
+        or parts.is_polycycle
+        or spiro_subs
+        or parts.principal_group
+        or parts.unsaturations
+        or parts.a_prefixes
+    ):
+        return False
+    selected = tuple(str(loc) for loc in locs)
+    if len(set(selected)) != len(selected):
+        return False
+    if len(selected) == 1 and not parts.is_ring:
+        return False
+    if len(selected) == 1 and _retained_parent_attachment_is_ambiguous(parts, list(selected)):
+        return False
+    if not all(loc.isdigit() for loc in selected):
+        return False
+    if not parts.parent_atom_symbols_by_locant or not parts.parent_bond_orders_by_locants:
+        return False
+
+    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
+    selected_labels = {_parent_locant_label(parts, loc) for loc in selected}
+    if None in selected_labels or len(selected_labels) != 1:
+        return False
+    selected_label = next(iter(selected_labels))
+    candidates = [loc for loc in locants if _parent_locant_label(parts, loc) == selected_label]
+    if not set(selected).issubset(candidates):
+        return False
+    if len(selected) > len(candidates):
+        return False
+    return _all_same_sized_substituent_sets_are_equivalent(parts, set(selected), candidates)
+
+
+def _parent_locant_label(parts: AssemblyParts, locant: str) -> tuple[str, int, bool] | None:
+    symbol = parts.parent_atom_symbols_by_locant.get(locant)
+    if symbol is None:
+        return None
+    return (
+        symbol,
+        parts.parent_atom_charges_by_locant.get(locant, 0),
+        locant in {str(hydrogen) for hydrogen in parts.indicated_hydrogens},
+    )
+
+
+def _all_same_sized_substituent_sets_are_equivalent(
+    parts: AssemblyParts,
+    selected: set[str],
+    candidates: list[str],
+) -> bool:
+    k = len(selected)
+    n = len(candidates)
+    if k == n:
+        return True
+    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
+    labels = _parent_automorphism_labels(parts, locants)
+    adjacency = _parent_automorphism_adjacency(parts, locants)
+    if k == 1:
+        source = next(iter(selected))
+        return len(_parent_attachment_orbit(parts, source, candidates)) == len(candidates)
+    if k == n - 1:
+        omitted = next(loc for loc in candidates if loc not in selected)
+        return len(_parent_attachment_orbit(parts, omitted, candidates)) == len(candidates)
+    if n > 12:
+        return False
+    for target in combinations(candidates, k):
+        if not _has_parent_set_automorphism_mapping(selected, set(target), locants, labels, adjacency):
+            return False
+    return True
+
+
+def _parent_automorphism_labels(parts: AssemblyParts, locants: list[str]) -> dict[str, tuple[str | None, int, bool]]:
+    indicated_hydrogens = {str(hydrogen) for hydrogen in parts.indicated_hydrogens}
+    return {
+        loc: (
+            parts.parent_atom_symbols_by_locant.get(loc),
+            parts.parent_atom_charges_by_locant.get(loc, 0),
+            loc in indicated_hydrogens,
+        )
+        for loc in locants
+    }
+
+
+def _parent_automorphism_adjacency(parts: AssemblyParts, locants: list[str]) -> dict[str, dict[str, int]]:
+    return {
+        loc: {
+            other: parts.parent_bond_orders_by_locants.get(tuple(sorted((loc, other))), 0)
+            for other in locants
+            if other != loc
+        }
+        for loc in locants
+    }
+
+
+def _has_parent_set_automorphism_mapping(
+    source_set: set[str],
+    target_set: set[str],
+    locants: list[str],
+    labels: dict,
+    adjacency: dict,
+) -> bool:
+    if len(source_set) != len(target_set):
+        return False
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+
+    def compatible(src: str, dst: str) -> bool:
+        if labels[src] != labels[dst]:
+            return False
+        if (src in source_set) != (dst in target_set):
+            return False
+        for assigned_src, assigned_dst in mapping.items():
+            if adjacency[src].get(assigned_src, 0) != adjacency[dst].get(assigned_dst, 0):
+                return False
+        return True
+
+    def search() -> bool:
+        if len(mapping) == len(locants):
+            return True
+        src = min(
+            (loc for loc in locants if loc not in mapping),
+            key=lambda loc: (
+                loc not in source_set,
+                -sum(1 for assigned in mapping if adjacency[loc].get(assigned, 0)),
+                parse_locant(loc),
+            ),
+        )
+        candidate_targets = [loc for loc in locants if loc not in used and (src in source_set) == (loc in target_set)]
+        for dst in candidate_targets:
+            if not compatible(src, dst):
+                continue
+            mapping[src] = dst
+            used.add(dst)
+            if search():
+                return True
+            used.remove(dst)
+            del mapping[src]
+        return False
+
+    return search()
 
 
 def _retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str]) -> bool:
@@ -82,22 +247,8 @@ def _retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[st
 
 
 def _parent_attachment_orbit(parts: AssemblyParts, source: str, locants: list[str]) -> set[str]:
-    labels = {
-        loc: (
-            parts.parent_atom_symbols_by_locant.get(loc),
-            parts.parent_atom_charges_by_locant.get(loc, 0),
-            loc in {str(h) for h in parts.indicated_hydrogens},
-        )
-        for loc in locants
-    }
-    adjacency = {
-        loc: {
-            other: parts.parent_bond_orders_by_locants.get(tuple(sorted((loc, other))), 0)
-            for other in locants
-            if other != loc
-        }
-        for loc in locants
-    }
+    labels = _parent_automorphism_labels(parts, locants)
+    adjacency = _parent_automorphism_adjacency(parts, locants)
     return {
         target
         for target in locants

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -1,0 +1,229 @@
+"""Graph-based decisions for optional substituent locant elision."""
+
+from itertools import combinations
+
+from .assembly_parts import AssemblyParts
+from .assembly_utils import parse_locant
+from .locant_sources import LocantMapSource
+
+# Optional locant omission is a presentation improvement. Above this candidate
+# count the search refuses to run and leaves explicit locants in place.
+MAX_AUTOMORPHISM_CANDIDATES = 12
+
+ParentLocantLabel = tuple[str, int, bool]
+
+
+def substituent_locant_set_is_unique(
+    parts: AssemblyParts,
+    locs: list[str],
+    grouped_count: int,
+    spiro_subs,
+) -> bool:
+    """Return whether parent symmetry makes these substituent locants redundant."""
+
+    if (
+        not locs
+        or parts.locant_map_source != LocantMapSource.GENERATED
+        or grouped_count != 1
+        or parts.is_substituent
+        or parts.is_bicycle
+        or parts.is_spiro
+        or parts.is_polycycle
+        or spiro_subs
+        or parts.principal_group
+        or parts.unsaturations
+        or parts.a_prefixes
+    ):
+        return False
+    selected = tuple(str(loc) for loc in locs)
+    if len(set(selected)) != len(selected):
+        return False
+    if len(selected) == 1 and not parts.is_ring:
+        return False
+    if len(selected) == 1 and retained_parent_attachment_is_ambiguous(parts, list(selected)):
+        return False
+    if not all(loc.isdigit() for loc in selected):
+        return False
+    if not parts.parent_atom_symbols_by_locant or not parts.parent_bond_orders_by_locants:
+        return False
+
+    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
+    selected_labels = {parent_locant_label(parts, loc) for loc in selected}
+    if None in selected_labels or len(selected_labels) != 1:
+        return False
+    selected_label = next(iter(selected_labels))
+    candidates = [loc for loc in locants if parent_locant_label(parts, loc) == selected_label]
+    if not set(selected).issubset(candidates):
+        return False
+    if len(selected) > len(candidates):
+        return False
+    return _all_same_sized_substituent_sets_are_equivalent(parts, set(selected), candidates)
+
+
+def retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str]) -> bool:
+    """Return whether locant omission would hide a non-equivalent retained-parent attachment."""
+
+    if not parts.retained_name or not parts.is_ring or parts.is_bicycle or parts.is_spiro or parts.is_polycycle:
+        return False
+    if len(locs) != 1:
+        return False
+    locant = str(locs[0])
+    if locant not in parts.parent_atom_symbols_by_locant:
+        return True
+    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
+    if len(locants) <= 1:
+        return False
+    orbit = _parent_attachment_orbit(parts, locant, locants)
+    return len(orbit) < len(locants)
+
+
+def parent_locant_label(parts: AssemblyParts, locant: str) -> ParentLocantLabel | None:
+    """Return the graph label used for parent-locant symmetry comparisons."""
+
+    symbol = parts.parent_atom_symbols_by_locant.get(locant)
+    if symbol is None:
+        return None
+    return (
+        symbol,
+        parts.parent_atom_charges_by_locant.get(locant, 0),
+        locant in {str(hydrogen) for hydrogen in parts.indicated_hydrogens},
+    )
+
+
+def _all_same_sized_substituent_sets_are_equivalent(
+    parts: AssemblyParts,
+    selected: set[str],
+    candidates: list[str],
+) -> bool:
+    k = len(selected)
+    n = len(candidates)
+    if k == n:
+        return True
+    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
+    labels = _parent_automorphism_labels(parts, locants)
+    adjacency = _parent_automorphism_adjacency(parts, locants)
+    if k == 1:
+        source = next(iter(selected))
+        return len(_parent_attachment_orbit(parts, source, candidates)) == len(candidates)
+    if k == n - 1:
+        omitted = next(loc for loc in candidates if loc not in selected)
+        return len(_parent_attachment_orbit(parts, omitted, candidates)) == len(candidates)
+    if n > MAX_AUTOMORPHISM_CANDIDATES:
+        return False
+    for target in combinations(candidates, k):
+        if not _has_parent_set_automorphism_mapping(selected, set(target), locants, labels, adjacency):
+            return False
+    return True
+
+
+def _parent_automorphism_labels(parts: AssemblyParts, locants: list[str]) -> dict[str, ParentLocantLabel | None]:
+    return {loc: parent_locant_label(parts, loc) for loc in locants}
+
+
+def _parent_automorphism_adjacency(parts: AssemblyParts, locants: list[str]) -> dict[str, dict[str, int]]:
+    return {
+        loc: {
+            other: parts.parent_bond_orders_by_locants.get(tuple(sorted((loc, other))), 0)
+            for other in locants
+            if other != loc
+        }
+        for loc in locants
+    }
+
+
+def _has_parent_set_automorphism_mapping(
+    source_set: set[str],
+    target_set: set[str],
+    locants: list[str],
+    labels: dict,
+    adjacency: dict,
+) -> bool:
+    if len(source_set) != len(target_set):
+        return False
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+
+    def compatible(src: str, dst: str) -> bool:
+        if labels[src] != labels[dst]:
+            return False
+        if (src in source_set) != (dst in target_set):
+            return False
+        for assigned_src, assigned_dst in mapping.items():
+            if adjacency[src].get(assigned_src, 0) != adjacency[dst].get(assigned_dst, 0):
+                return False
+        return True
+
+    def search() -> bool:
+        if len(mapping) == len(locants):
+            return True
+        src = min(
+            (loc for loc in locants if loc not in mapping),
+            key=lambda loc: (
+                loc not in source_set,
+                -sum(1 for assigned in mapping if adjacency[loc].get(assigned, 0)),
+                parse_locant(loc),
+            ),
+        )
+        candidate_targets = [loc for loc in locants if loc not in used and (src in source_set) == (loc in target_set)]
+        for dst in candidate_targets:
+            if not compatible(src, dst):
+                continue
+            mapping[src] = dst
+            used.add(dst)
+            if search():
+                return True
+            used.remove(dst)
+            del mapping[src]
+        return False
+
+    return search()
+
+
+def _parent_attachment_orbit(parts: AssemblyParts, source: str, locants: list[str]) -> set[str]:
+    labels = _parent_automorphism_labels(parts, locants)
+    adjacency = _parent_automorphism_adjacency(parts, locants)
+    return {
+        target
+        for target in locants
+        if labels[target] == labels[source]
+        and _has_parent_automorphism_mapping(source, target, locants, labels, adjacency)
+    }
+
+
+def _has_parent_automorphism_mapping(
+    source: str,
+    target: str,
+    locants: list[str],
+    labels: dict,
+    adjacency: dict,
+) -> bool:
+    mapping = {source: target}
+    used = {target}
+
+    def compatible(src: str, dst: str) -> bool:
+        if labels[src] != labels[dst]:
+            return False
+        for assigned_src, assigned_dst in mapping.items():
+            if adjacency[src].get(assigned_src, 0) != adjacency[dst].get(assigned_dst, 0):
+                return False
+        return True
+
+    def search() -> bool:
+        if len(mapping) == len(locants):
+            return True
+        src = min(
+            (loc for loc in locants if loc not in mapping),
+            key=lambda loc: sum(1 for assigned in mapping if adjacency[loc].get(assigned, 0)),
+        )
+        for dst in locants:
+            if dst in used or not compatible(src, dst):
+                continue
+            mapping[src] = dst
+            used.add(dst)
+            if search():
+                return True
+            used.remove(dst)
+            del mapping[src]
+        return False
+
+    return search()

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -1,5 +1,6 @@
 """Graph-based decisions for optional substituent locant elision."""
 
+from dataclasses import dataclass
 from itertools import combinations
 
 from .assembly_parts import AssemblyParts
@@ -11,6 +12,16 @@ from .locant_sources import LocantMapSource
 MAX_AUTOMORPHISM_CANDIDATES = 12
 
 ParentLocantLabel = tuple[str, int, bool]
+
+
+@dataclass(frozen=True)
+class ParentSymmetryContext:
+    """Parent graph data reused during one optional locant-elision decision."""
+
+    locants: tuple[str, ...]
+    indicated_hydrogens: frozenset[str]
+    labels: dict[str, ParentLocantLabel | None]
+    adjacency: dict[str, dict[str, int]]
 
 
 def substituent_locant_set_is_unique(
@@ -47,17 +58,19 @@ def substituent_locant_set_is_unique(
     if not parts.parent_atom_symbols_by_locant or not parts.parent_bond_orders_by_locants:
         return False
 
-    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
-    selected_labels = {parent_locant_label(parts, loc) for loc in selected}
+    context = _parent_symmetry_context(parts)
+    selected_labels = {parent_locant_label(parts, loc, context.indicated_hydrogens) for loc in selected}
     if None in selected_labels or len(selected_labels) != 1:
         return False
     selected_label = next(iter(selected_labels))
-    candidates = [loc for loc in locants if parent_locant_label(parts, loc) == selected_label]
+    candidates = [loc for loc in context.locants if context.labels[loc] == selected_label]
     if not set(selected).issubset(candidates):
         return False
     if len(selected) > len(candidates):
         return False
-    return _all_same_sized_substituent_sets_are_equivalent(parts, set(selected), candidates)
+    if not _candidate_positions_are_single_attachment_sites(context, candidates):
+        return False
+    return _all_same_sized_substituent_sets_are_equivalent(context, set(selected), candidates)
 
 
 def retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str]) -> bool:
@@ -70,58 +83,40 @@ def retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str
     locant = str(locs[0])
     if locant not in parts.parent_atom_symbols_by_locant:
         return True
-    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
-    if len(locants) <= 1:
+    context = _parent_symmetry_context(parts)
+    if len(context.locants) <= 1:
         return False
-    orbit = _parent_attachment_orbit(parts, locant, locants)
-    return len(orbit) < len(locants)
+    orbit = _parent_attachment_orbit(context, locant, context.locants)
+    return len(orbit) < len(context.locants)
 
 
-def parent_locant_label(parts: AssemblyParts, locant: str) -> ParentLocantLabel | None:
+def parent_locant_label(
+    parts: AssemblyParts,
+    locant: str,
+    indicated_hydrogens: frozenset[str] | None = None,
+) -> ParentLocantLabel | None:
     """Return the graph label used for parent-locant symmetry comparisons."""
 
     symbol = parts.parent_atom_symbols_by_locant.get(locant)
     if symbol is None:
         return None
+    if indicated_hydrogens is None:
+        indicated_hydrogens = frozenset(str(hydrogen) for hydrogen in parts.indicated_hydrogens)
     return (
         symbol,
         parts.parent_atom_charges_by_locant.get(locant, 0),
-        locant in {str(hydrogen) for hydrogen in parts.indicated_hydrogens},
+        locant in indicated_hydrogens,
     )
 
 
-def _all_same_sized_substituent_sets_are_equivalent(
-    parts: AssemblyParts,
-    selected: set[str],
-    candidates: list[str],
-) -> bool:
-    k = len(selected)
-    n = len(candidates)
-    if k == n:
-        return True
-    locants = sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant)
-    labels = _parent_automorphism_labels(parts, locants)
-    adjacency = _parent_automorphism_adjacency(parts, locants)
-    if k == 1:
-        source = next(iter(selected))
-        return len(_parent_attachment_orbit(parts, source, candidates)) == len(candidates)
-    if k == n - 1:
-        omitted = next(loc for loc in candidates if loc not in selected)
-        return len(_parent_attachment_orbit(parts, omitted, candidates)) == len(candidates)
-    if n > MAX_AUTOMORPHISM_CANDIDATES:
-        return False
-    for target in combinations(candidates, k):
-        if not _has_parent_set_automorphism_mapping(selected, set(target), locants, labels, adjacency):
-            return False
-    return True
-
-
-def _parent_automorphism_labels(parts: AssemblyParts, locants: list[str]) -> dict[str, ParentLocantLabel | None]:
-    return {loc: parent_locant_label(parts, loc) for loc in locants}
-
-
-def _parent_automorphism_adjacency(parts: AssemblyParts, locants: list[str]) -> dict[str, dict[str, int]]:
-    return {
+def _parent_symmetry_context(parts: AssemblyParts) -> ParentSymmetryContext:
+    locants = tuple(sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant))
+    indicated_hydrogens = frozenset(str(hydrogen) for hydrogen in parts.indicated_hydrogens)
+    labels = {
+        loc: parent_locant_label(parts, loc, indicated_hydrogens)
+        for loc in locants
+    }
+    adjacency = {
         loc: {
             other: parts.parent_bond_orders_by_locants.get(tuple(sorted((loc, other))), 0)
             for other in locants
@@ -129,14 +124,57 @@ def _parent_automorphism_adjacency(parts: AssemblyParts, locants: list[str]) -> 
         }
         for loc in locants
     }
+    return ParentSymmetryContext(
+        locants=locants,
+        indicated_hydrogens=indicated_hydrogens,
+        labels=labels,
+        adjacency=adjacency,
+    )
+
+
+def _all_same_sized_substituent_sets_are_equivalent(
+    context: ParentSymmetryContext,
+    selected: set[str],
+    candidates: list[str],
+) -> bool:
+    k = len(selected)
+    n = len(candidates)
+    if k == n:
+        return True
+    if k == 1:
+        source = next(iter(selected))
+        return len(_parent_attachment_orbit(context, source, candidates)) == len(candidates)
+    if k == n - 1:
+        omitted = next(loc for loc in candidates if loc not in selected)
+        return len(_parent_attachment_orbit(context, omitted, candidates)) == len(candidates)
+    if n > MAX_AUTOMORPHISM_CANDIDATES:
+        return False
+    for target in combinations(candidates, k):
+        if not _has_parent_set_automorphism_mapping(selected, set(target), context):
+            return False
+    return True
+
+
+def _candidate_positions_are_single_attachment_sites(
+    context: ParentSymmetryContext,
+    candidates: list[str],
+) -> bool:
+    """Return whether omitted locants cannot hide geminal alternatives.
+
+    Optional locant omission is safe only when each equivalent parent position
+    can host at most one rendered substituent of this group. Unsaturated/aromatic
+    parent atoms satisfy this through their parent bond-order valence; saturated
+    small-ring atoms such as cyclopropane carbons do not, so names like
+    dimethylcyclopropane keep locants to distinguish 1,1- from 1,2-patterns.
+    """
+
+    return all(sum(context.adjacency[loc].values()) >= 3 for loc in candidates)
 
 
 def _has_parent_set_automorphism_mapping(
     source_set: set[str],
     target_set: set[str],
-    locants: list[str],
-    labels: dict,
-    adjacency: dict,
+    context: ParentSymmetryContext,
 ) -> bool:
     if len(source_set) != len(target_set):
         return False
@@ -144,27 +182,29 @@ def _has_parent_set_automorphism_mapping(
     used: set[str] = set()
 
     def compatible(src: str, dst: str) -> bool:
-        if labels[src] != labels[dst]:
+        if context.labels[src] != context.labels[dst]:
             return False
         if (src in source_set) != (dst in target_set):
             return False
         for assigned_src, assigned_dst in mapping.items():
-            if adjacency[src].get(assigned_src, 0) != adjacency[dst].get(assigned_dst, 0):
+            if context.adjacency[src].get(assigned_src, 0) != context.adjacency[dst].get(assigned_dst, 0):
                 return False
         return True
 
     def search() -> bool:
-        if len(mapping) == len(locants):
+        if len(mapping) == len(context.locants):
             return True
         src = min(
-            (loc for loc in locants if loc not in mapping),
+            (loc for loc in context.locants if loc not in mapping),
             key=lambda loc: (
                 loc not in source_set,
-                -sum(1 for assigned in mapping if adjacency[loc].get(assigned, 0)),
+                -sum(1 for assigned in mapping if context.adjacency[loc].get(assigned, 0)),
                 parse_locant(loc),
             ),
         )
-        candidate_targets = [loc for loc in locants if loc not in used and (src in source_set) == (loc in target_set)]
+        candidate_targets = [
+            loc for loc in context.locants if loc not in used and (src in source_set) == (loc in target_set)
+        ]
         for dst in candidate_targets:
             if not compatible(src, dst):
                 continue
@@ -179,43 +219,39 @@ def _has_parent_set_automorphism_mapping(
     return search()
 
 
-def _parent_attachment_orbit(parts: AssemblyParts, source: str, locants: list[str]) -> set[str]:
-    labels = _parent_automorphism_labels(parts, locants)
-    adjacency = _parent_automorphism_adjacency(parts, locants)
+def _parent_attachment_orbit(context: ParentSymmetryContext, source: str, locants: tuple[str, ...] | list[str]) -> set[str]:
     return {
         target
         for target in locants
-        if labels[target] == labels[source]
-        and _has_parent_automorphism_mapping(source, target, locants, labels, adjacency)
+        if context.labels[target] == context.labels[source]
+        and _has_parent_automorphism_mapping(source, target, context)
     }
 
 
 def _has_parent_automorphism_mapping(
     source: str,
     target: str,
-    locants: list[str],
-    labels: dict,
-    adjacency: dict,
+    context: ParentSymmetryContext,
 ) -> bool:
     mapping = {source: target}
     used = {target}
 
     def compatible(src: str, dst: str) -> bool:
-        if labels[src] != labels[dst]:
+        if context.labels[src] != context.labels[dst]:
             return False
         for assigned_src, assigned_dst in mapping.items():
-            if adjacency[src].get(assigned_src, 0) != adjacency[dst].get(assigned_dst, 0):
+            if context.adjacency[src].get(assigned_src, 0) != context.adjacency[dst].get(assigned_dst, 0):
                 return False
         return True
 
     def search() -> bool:
-        if len(mapping) == len(locants):
+        if len(mapping) == len(context.locants):
             return True
         src = min(
-            (loc for loc in locants if loc not in mapping),
-            key=lambda loc: sum(1 for assigned in mapping if adjacency[loc].get(assigned, 0)),
+            (loc for loc in context.locants if loc not in mapping),
+            key=lambda loc: sum(1 for assigned in mapping if context.adjacency[loc].get(assigned, 0)),
         )
-        for dst in locants:
+        for dst in context.locants:
             if dst in used or not compatible(src, dst):
                 continue
             mapping[src] = dst

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -112,10 +112,7 @@ def parent_locant_label(
 def _parent_symmetry_context(parts: AssemblyParts) -> ParentSymmetryContext:
     locants = tuple(sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant))
     indicated_hydrogens = frozenset(str(hydrogen) for hydrogen in parts.indicated_hydrogens)
-    labels = {
-        loc: parent_locant_label(parts, loc, indicated_hydrogens)
-        for loc in locants
-    }
+    labels = {loc: parent_locant_label(parts, loc, indicated_hydrogens) for loc in locants}
     adjacency = {
         loc: {
             other: parts.parent_bond_orders_by_locants.get(tuple(sorted((loc, other))), 0)
@@ -219,7 +216,9 @@ def _has_parent_set_automorphism_mapping(
     return search()
 
 
-def _parent_attachment_orbit(context: ParentSymmetryContext, source: str, locants: tuple[str, ...] | list[str]) -> set[str]:
+def _parent_attachment_orbit(
+    context: ParentSymmetryContext, source: str, locants: tuple[str, ...] | list[str]
+) -> set[str]:
     return {
         target
         for target in locants

--- a/src/openclatura/locant_sources.py
+++ b/src/openclatura/locant_sources.py
@@ -1,0 +1,11 @@
+"""Provenance labels for parent locant maps."""
+
+from enum import StrEnum
+
+
+class LocantMapSource(StrEnum):
+    """Where the parent atom-to-locant map came from."""
+
+    GENERATED = "generated"
+    SUPPLIED = "supplied"
+    PROOF = "proof"

--- a/src/openclatura/naming_context.py
+++ b/src/openclatura/naming_context.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from .assembly_parts import RetainedParentMetadata
+from .locant_sources import LocantMapSource
 from .parent_selection import ParentSelection
 from .perception import PerceivedGroup
 
@@ -49,7 +50,7 @@ class ParentAssemblyPlan:
 
     numbered_path: list[int]
     locant_map: dict[int, str] | None
-    locant_map_source: str
+    locant_map_source: LocantMapSource
     get_loc: Callable
     parts: object
 

--- a/src/openclatura/naming_context.py
+++ b/src/openclatura/naming_context.py
@@ -49,6 +49,7 @@ class ParentAssemblyPlan:
 
     numbered_path: list[int]
     locant_map: dict[int, str] | None
+    locant_map_source: str
     get_loc: Callable
     parts: object
 

--- a/src/openclatura/parent_pipeline.py
+++ b/src/openclatura/parent_pipeline.py
@@ -44,6 +44,7 @@ def build_parent_assembly_plan(
 ) -> ParentAssemblyPlan:
     """Number a selected parent and create base assembly parts."""
 
+    locant_map_source = "supplied" if locant_maps else "generated"
     if (
         locant_maps is None
         and selection.ring_parent is not None
@@ -54,6 +55,8 @@ def build_parent_assembly_plan(
             numbering.locant_map for numbering in selection.ring_parent.numbering_candidates if numbering.audit_ok
         ]
         locant_maps = audited_maps or None
+        if locant_maps:
+            locant_map_source = "proof"
     numbered_path, locant_map = choose_parent_numbering(
         mol,
         selection.paths,
@@ -76,8 +79,15 @@ def build_parent_assembly_plan(
         selection,
         intent,
         retained_parent_metadata,
+        locant_map_source=locant_map_source,
     )
-    return ParentAssemblyPlan(numbered_path=numbered_path, locant_map=locant_map, get_loc=get_loc, parts=parts)
+    return ParentAssemblyPlan(
+        numbered_path=numbered_path,
+        locant_map=locant_map,
+        locant_map_source=locant_map_source,
+        get_loc=get_loc,
+        parts=parts,
+    )
 
 
 def _is_von_baeyer_descriptor(descriptor: str | None) -> bool:
@@ -92,6 +102,8 @@ def build_parent_parts(
     selection: ParentSelection,
     intent: NamingIntent,
     retained_parent_metadata: RetainedParentMetadata | None = None,
+    *,
+    locant_map_source: str = "generated",
 ) -> AssemblyParts:
     """Create shared parent assembly parts for a naming intent."""
 
@@ -122,6 +134,7 @@ def build_parent_parts(
         polycycle_descriptor=selection.polycycle_descriptor,
         retained_name=retained_name,
         retained_parent_metadata=retained_parent_metadata,
+        locant_map_source=locant_map_source,
         parent_atom_ids=set(numbered_path),
         parent_bond_ids=bond_ids_within(mol, set(numbered_path)),
         **assembly_overrides,

--- a/src/openclatura/parent_pipeline.py
+++ b/src/openclatura/parent_pipeline.py
@@ -1,6 +1,7 @@
 """Shared parent planning steps for component and subgraph naming."""
 
 from .assembly_parts import AssemblyParts, NameAtomBinding, ParentChargeItem, RetainedParentMetadata
+from .locant_sources import LocantMapSource
 from .molecule import Molecule
 from .name_bindings import ensure_name_atom_binding_tokens
 from .namer_config import RETAINED_RING_ELEMENTS
@@ -44,7 +45,7 @@ def build_parent_assembly_plan(
 ) -> ParentAssemblyPlan:
     """Number a selected parent and create base assembly parts."""
 
-    locant_map_source = "supplied" if locant_maps else "generated"
+    locant_map_source = LocantMapSource.SUPPLIED if locant_maps else LocantMapSource.GENERATED
     if (
         locant_maps is None
         and selection.ring_parent is not None
@@ -56,7 +57,7 @@ def build_parent_assembly_plan(
         ]
         locant_maps = audited_maps or None
         if locant_maps:
-            locant_map_source = "proof"
+            locant_map_source = LocantMapSource.PROOF
     numbered_path, locant_map = choose_parent_numbering(
         mol,
         selection.paths,
@@ -103,7 +104,7 @@ def build_parent_parts(
     intent: NamingIntent,
     retained_parent_metadata: RetainedParentMetadata | None = None,
     *,
-    locant_map_source: str = "generated",
+    locant_map_source: LocantMapSource = LocantMapSource.GENERATED,
 ) -> AssemblyParts:
     """Create shared parent assembly parts for a naming intent."""
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -3811,6 +3811,17 @@ def test_retained_heteroaromatic_parent_locants_follow_attachment_equivalence():
     assert name_smiles("CN1C=CC=C1") == "1-methyl-1H-pyrrole"
 
 
+def test_substituent_locants_are_omitted_when_parent_symmetry_makes_configuration_unique():
+    assert name_smiles("Cc1c(C)c(C)c(C)c(C)c1C") == "hexamethylbenzene"
+    assert name_smiles("Cc1c(C)c(C)c(C)c(C)c1") == "pentamethylbenzene"
+    assert name_smiles("Clc1c(Cl)c(Cl)c(Cl)c(Cl)c1Cl") == "hexachlorobenzene"
+
+
+def test_substituent_locants_are_kept_when_same_count_has_multiple_configurations():
+    assert name_smiles("Cc1cc(C)cc(C)c1") == "1,3,5-trimethylbenzene"
+    assert name_smiles("Cc1c(C)c(C)c(C)cc1") == "1,2,3,4-tetramethylbenzene"
+
+
 def test_analyze_smiles_exposes_decision_trace():
     analysis = analyze_smiles("CCO")
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -3820,6 +3820,7 @@ def test_substituent_locants_are_omitted_when_parent_symmetry_makes_configuratio
 def test_substituent_locants_are_kept_when_same_count_has_multiple_configurations():
     assert name_smiles("Cc1cc(C)cc(C)c1") == "1,3,5-trimethylbenzene"
     assert name_smiles("Cc1c(C)c(C)c(C)cc1") == "1,2,3,4-tetramethylbenzene"
+    assert name_smiles("CC1CC1C") == "1,2-dimethylcyclopropane"
 
 
 def test_analyze_smiles_exposes_decision_trace():


### PR DESCRIPTION
## Summary by Sourcery

Implement symmetry-aware elision of substituent locants for simple generated-parent cases while tracking locant map provenance.

New Features:
- Add graph-based logic to omit substituent locants when parent symmetry makes a single configuration uniquely determined.
- Introduce locant map provenance tracking via a LocantMapSource enum and propagate it through parent assembly planning.

Bug Fixes:
- Preserve locants for retained parents or cases where attachment or configuration would be ambiguous, preventing incorrect locant omission.

Enhancements:
- Refactor retained parent attachment ambiguity checks into a shared locant_elision module reused by substituent locant formatting.
- Tighten substituent locant string generation to consider uniqueness of locant sets instead of only simple single-locant cases.

Tests:
- Add analysis tests covering locant omission for symmetric polysubstituted benzenes and locant retention when multiple configurations or geminal alternatives exist.