### PR TITLE
Update DOI and URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ If you use Openclatura in your research, please cite the Openclatura preprint:
   year    = {2026},
   month   = jul,
   day     = {15},
-  doi     = {10.26434/chemrxiv.15006114/v1},
-  url     = {https://doi.org/10.26434/chemrxiv.15006114/v1},
+  doi     = {10.26434/chemrxiv.15006114/v2},
+  url     = {https://doi.org/10.26434/chemrxiv.15006114/v2},
   note    = {Preprint}
 }
 ```


### PR DESCRIPTION
Updated DOI and URL for the ChemRxiv reference.

## Summary by Sourcery

Documentation:
- Refresh ChemRxiv DOI and URL in the README to point to version v2 of the preprint.