### PR TITLE
feat: elide redundant constitutional locants

### DIFF
--- a/src/openclatura/__init__.py
+++ b/src/openclatura/__init__.py
@@ -38,6 +38,7 @@ def name(
     verify_opsin: bool = False,
     verify_self: bool = False,
     token_debug: bool = False,
+    omit_redundant_locants: bool = True,
 ) -> NamingResult:
     """One-shot naming with the default engine. Returns a typed ``NamingResult``.
 
@@ -56,6 +57,7 @@ def name(
             verify_opsin=verify_opsin,
             verify_self=verify_self,
             token_debug=token_debug,
+            omit_redundant_locants=omit_redundant_locants,
         )
     )
 
@@ -67,6 +69,7 @@ def name_mol(
     verify_opsin: bool = False,
     verify_self: bool = False,
     token_debug: bool = False,
+    omit_redundant_locants: bool = True,
 ) -> NamingResult:
     """One-shot naming of an existing RDKit molecule. Returns a ``NamingResult``.
 
@@ -83,6 +86,7 @@ def name_mol(
             verify_opsin=verify_opsin,
             verify_self=verify_self,
             token_debug=token_debug,
+            omit_redundant_locants=omit_redundant_locants,
         )
     )
 
@@ -94,6 +98,7 @@ def name_many(
     verify_opsin: bool = False,
     verify_self: bool = False,
     token_debug: bool = False,
+    omit_redundant_locants: bool = True,
     processes: int | None | str = 1,
     chunksize: int = 64,
 ) -> list[NamingResult]:
@@ -111,6 +116,7 @@ def name_many(
         verify_opsin=verify_opsin,
         verify_self=verify_self,
         token_debug=token_debug,
+        omit_redundant_locants=omit_redundant_locants,
         processes=processes,
         chunksize=chunksize,
     )

--- a/src/openclatura/assembly_parent.py
+++ b/src/openclatura/assembly_parent.py
@@ -515,7 +515,11 @@ def format_unsaturations(parts: AssemblyParts, stem_str: str, *, omit_locants: b
             stem_str += "a"
     base_infixes = [(unsaturation, infix) for unsaturation, _count, infix in base_infixes]
     for unsaturation, base_infix in base_infixes:
-        if unsaturation.locants and not omit_locants:
+        if (
+            unsaturation.locants
+            and not omit_locants
+            and unsaturation.bond_key not in parts.elided_unsaturation_locants
+        ):
             loc_str = ",".join(sorted(unsaturation.locants, key=parse_locant))
             unsat_parts.append(f"-{loc_str}-{base_infix}")
         else:
@@ -661,6 +665,8 @@ def format_principal_suffix(parts: AssemblyParts, terminal_e: str, spiro_subs) -
 
     if elision.is_vowel_start(suffix_text):
         terminal_e = ""
+    if parts.elide_principal_group_locants:
+        omit_locant = True
     if group.suffix_with_locant and locs and not omit_locant:
         return terminal_e, f"-{','.join(map(str, locs))}-{suffix_text}"
     return terminal_e, suffix_text

--- a/src/openclatura/assembly_parent.py
+++ b/src/openclatura/assembly_parent.py
@@ -515,11 +515,7 @@ def format_unsaturations(parts: AssemblyParts, stem_str: str, *, omit_locants: b
             stem_str += "a"
     base_infixes = [(unsaturation, infix) for unsaturation, _count, infix in base_infixes]
     for unsaturation, base_infix in base_infixes:
-        if (
-            unsaturation.locants
-            and not omit_locants
-            and unsaturation.bond_key not in parts.elided_unsaturation_locants
-        ):
+        if unsaturation.locants and not omit_locants and unsaturation.bond_key not in parts.elided_unsaturation_locants:
             loc_str = ",".join(sorted(unsaturation.locants, key=parse_locant))
             unsat_parts.append(f"-{loc_str}-{base_infix}")
         else:

--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -163,6 +163,7 @@ class AssemblyParts:
     parent_atom_ids_by_locant: dict[str, int] = field(default_factory=dict)
     parent_atom_symbols_by_locant: dict[str, str] = field(default_factory=dict)
     parent_atom_charges_by_locant: dict[str, int] = field(default_factory=dict)
+    parent_atom_isotopes_by_locant: dict[str, int | None] = field(default_factory=dict)
     parent_bond_orders_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
     parent_bond_ids_by_locants: dict[tuple[str, str], int] = field(default_factory=dict)
     locant_map_source: LocantMapSource = LocantMapSource.GENERATED
@@ -170,3 +171,8 @@ class AssemblyParts:
     name_token_spans: list[dict] = field(default_factory=list)
     name_rewrite_history: list[dict] = field(default_factory=list)
     stereo_audit_issues: list[str] = field(default_factory=list)
+    omit_redundant_locants: bool = False
+    elided_substituent_locants: set[str] = field(default_factory=set)
+    elided_unsaturation_locants: set[str] = field(default_factory=set)
+    elide_principal_group_locants: bool = False
+    locant_elision_decisions: list[dict] = field(default_factory=list)

--- a/src/openclatura/assembly_parts.py
+++ b/src/openclatura/assembly_parts.py
@@ -171,7 +171,7 @@ class AssemblyParts:
     name_token_spans: list[dict] = field(default_factory=list)
     name_rewrite_history: list[dict] = field(default_factory=list)
     stereo_audit_issues: list[str] = field(default_factory=list)
-    omit_redundant_locants: bool = False
+    omit_redundant_locants: bool = True
     elided_substituent_locants: set[str] = field(default_factory=set)
     elided_unsaturation_locants: set[str] = field(default_factory=set)
     elide_principal_group_locants: bool = False

--- a/src/openclatura/assembly_prefixes.py
+++ b/src/openclatura/assembly_prefixes.py
@@ -47,7 +47,9 @@ def group_substituents(substituents: list[SubstituentItem]) -> dict[str, list[Su
     return grouped
 
 
-def substituent_locant_string(parts: AssemblyParts, locs: list[str], grouped_count: int, spiro_subs) -> str:
+def substituent_locant_string(parts: AssemblyParts, name: str, locs: list[str], grouped_count: int, spiro_subs) -> str:
+    if name in parts.elided_substituent_locants:
+        return ""
     imino_beside_another_prefix = grouped_count > 1 and any(sub.name == "imino" for sub in parts.substituents)
     if (
         parts.parent_length == 1
@@ -112,7 +114,7 @@ def format_substituent_prefixes(parts: AssemblyParts, spiro_subs) -> str:
         count = max(1, count_raw // attachments_per_group)
         is_complex = is_complex_prefix(name)
         mult = (multipliers.complex_(count) if is_complex else multipliers.basic(count)) if count > 1 else ""
-        loc_str = substituent_locant_string(parts, locs, len(grouped), spiro_subs)
+        loc_str = substituent_locant_string(parts, name, locs, len(grouped), spiro_subs)
 
         name_to_use = _omit_optional_outer_parentheses(
             parts,

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -275,7 +275,7 @@ def name_component(
     name_spiro_subgraph: SpiroSubgraphNamer,
     assemble_parent_name: ParentAssembler,
     token_debug: bool = False,
-    omit_redundant_locants: bool = False,
+    omit_redundant_locants: bool = True,
 ):
     """Name one connected component or recursive component of a molecule."""
 

--- a/src/openclatura/component_namer.py
+++ b/src/openclatura/component_namer.py
@@ -18,6 +18,7 @@ from .component_group_rules import (
 )
 from .component_modifiers import add_component_front_modifiers, add_component_n_substituents
 from .functional_prefixes import collect_component_prefix_substituents
+from .locant_elision import apply_redundant_locant_elision
 from .molecule import DecisionTrace, Molecule, TracePhase, bond_ids_within, charged_atoms
 from .name_assembly import NameAssemblyResult, assert_final_name_assembly, token_span_trace_data
 from .name_bindings import binding_trace_data, refresh_name_atom_bindings
@@ -274,6 +275,7 @@ def name_component(
     name_spiro_subgraph: SpiroSubgraphNamer,
     assemble_parent_name: ParentAssembler,
     token_debug: bool = False,
+    omit_redundant_locants: bool = False,
 ):
     """Name one connected component or recursive component of a molecule."""
 
@@ -320,6 +322,7 @@ def name_component(
             name_spiro_subgraph=name_spiro_subgraph,
             assemble_parent_name=assemble_parent_name,
             token_debug=token_debug,
+            omit_redundant_locants=omit_redundant_locants,
         )
 
     structural_parent_result = structural_replacement_parent_result(mol, component_atoms, name_subgraph)
@@ -542,7 +545,10 @@ def name_component(
     parent_plan = build_parent_assembly_plan(
         mol,
         state.parent_selection,
-        NamingIntent.component(state.principal_carbons),
+        NamingIntent.component(
+            state.principal_carbons,
+            omit_redundant_locants=omit_redundant_locants,
+        ),
         subst_mapping,
         state.locant_maps,
         state.retained_name,
@@ -600,6 +606,8 @@ def name_component(
     add_indicated_hydrogens(mol, parts, numbered_path, get_loc)
     add_component_substituents(parts, subst_mapping, numbered_path, get_loc)
 
+    apply_redundant_locant_elision(parts)
+
     refresh_name_atom_bindings(parts)
     parts.stereo_audit_issues = list(audit_stereochemistry(mol, parts).issues)
     if COMPONENT_AUDIT_HOOK is not None:
@@ -630,6 +638,7 @@ def name_component(
             "name_atom_bindings": binding_trace_data(parts.name_atom_bindings, include_emitted_tokens=token_debug),
             "name_token_spans": parts.name_token_spans if token_debug else [],
             "name_rewrite_history": parts.name_rewrite_history,
+            "locant_elisions": parts.locant_elision_decisions,
         },
     )
     trace_segments = assembly_trace_segments(parts) if return_trace or return_tree else []

--- a/src/openclatura/engine.py
+++ b/src/openclatura/engine.py
@@ -63,6 +63,10 @@ class NamingRequest:
     SMILES to the input.  Verification is graceful when py2opsin or Java
     are missing (see :class:`openclatura.opsin_verify.OpsinCheck`).
 
+    ``omit_redundant_locants`` is an experimental, opt-in symmetry proof for
+    constitutional locants on simple chain and monocyclic parents. The default
+    is deliberately false to preserve the existing naming contract.
+
     Structures arrive either as ``smiles`` or as an already-parsed
     ``rdkit_mol`` (``rdkit.Chem.rdchem.Mol``); when a molecule is given, a
     SMILES is only generated if something downstream actually needs one, so
@@ -74,6 +78,7 @@ class NamingRequest:
     verify_opsin: bool = False
     verify_self: bool = False
     token_debug: bool = False
+    omit_redundant_locants: bool = False
     rdkit_mol: Any | None = None
 
 
@@ -238,7 +243,12 @@ class NamingEngine:
             with audit_cm as component_audits:
                 mol, smiles = self._prepare_input(request)
                 if need_analysis:
-                    analysis = self._analyze(mol, smiles=smiles, token_debug=request.token_debug)
+                    analysis = self._analyze(
+                        mol,
+                        smiles=smiles,
+                        token_debug=request.token_debug,
+                        omit_redundant_locants=request.omit_redundant_locants,
+                    )
                     rules, hints = _extract_rules_hit(analysis.trace_segments)
                     result = NamingResult(
                         name=analysis.name,
@@ -251,7 +261,10 @@ class NamingEngine:
                         rule_hints=hints,
                     )
                 else:
-                    result = NamingResult(name=self._name(mol), smiles=smiles)
+                    result = NamingResult(
+                        name=self._name(mol, omit_redundant_locants=request.omit_redundant_locants),
+                        smiles=smiles,
+                    )
         except Exception as exc:  # noqa: BLE001 - intentionally permissive boundary
             return NamingResult(name="", smiles=request.smiles, error=f"{type(exc).__name__}: {exc}")
         finally:
@@ -334,19 +347,30 @@ class NamingEngine:
             smiles = Chem.MolToSmiles(request.rdkit_mol)
         return read_rdkit_mol(request.rdkit_mol), smiles
 
-    def _name(self, mol: Molecule) -> str:
+    def _name(self, mol: Molecule, *, omit_redundant_locants: bool = False) -> str:
         if not mol.atoms:
             return ""
 
         names = []
         for component in get_connected_components(mol):
-            component_name = self._name_component(mol, component)
+            component_name = self._name_component(
+                mol,
+                component,
+                omit_redundant_locants=omit_redundant_locants,
+            )
             if component_name:
                 names.append((component_name, _component_charge(mol, component)))
         names.sort(key=lambda item: self._component_sort_key(*item))
         return " ".join(_multiply_identical_ions(names))
 
-    def _analyze(self, mol: Molecule, *, smiles: str = "", token_debug: bool = False) -> NameAnalysis:
+    def _analyze(
+        self,
+        mol: Molecule,
+        *,
+        smiles: str = "",
+        token_debug: bool = False,
+        omit_redundant_locants: bool = False,
+    ) -> NameAnalysis:
         decisions = DecisionTrace()
         trace_decision(
             decisions,
@@ -379,6 +403,7 @@ class NamingEngine:
                 return_tree=True,
                 decision_trace=decisions,
                 token_debug=token_debug,
+                omit_redundant_locants=omit_redundant_locants,
             )
             if component_name:
                 named_components.append((component_name, trace, tree, _component_charge(mol, component)))

--- a/src/openclatura/engine.py
+++ b/src/openclatura/engine.py
@@ -63,9 +63,10 @@ class NamingRequest:
     SMILES to the input.  Verification is graceful when py2opsin or Java
     are missing (see :class:`openclatura.opsin_verify.OpsinCheck`).
 
-    ``omit_redundant_locants`` is an experimental, opt-in symmetry proof for
-    constitutional locants on simple chain and monocyclic parents. The default
-    is deliberately false to preserve the existing naming contract.
+    ``omit_redundant_locants`` controls an experimental symmetry proof for
+    constitutional locants on simple chain and monocyclic parents. It defaults
+    to true because a provably unique locant configuration gives the better
+    name, while callers can explicitly disable it for compatibility.
 
     Structures arrive either as ``smiles`` or as an already-parsed
     ``rdkit_mol`` (``rdkit.Chem.rdchem.Mol``); when a molecule is given, a
@@ -78,7 +79,7 @@ class NamingRequest:
     verify_opsin: bool = False
     verify_self: bool = False
     token_debug: bool = False
-    omit_redundant_locants: bool = False
+    omit_redundant_locants: bool = True
     rdkit_mol: Any | None = None
 
 
@@ -289,6 +290,7 @@ class NamingEngine:
         verify_opsin: bool = False,
         verify_self: bool = False,
         token_debug: bool = False,
+        omit_redundant_locants: bool = True,
         processes: int | None | str = 1,
         chunksize: int = 64,
     ) -> list[NamingResult]:
@@ -313,6 +315,7 @@ class NamingEngine:
                         verify_opsin=verify_opsin,
                         verify_self=verify_self,
                         token_debug=token_debug,
+                        omit_redundant_locants=omit_redundant_locants,
                     )
                 )
                 for item in smiles_list
@@ -325,6 +328,7 @@ class NamingEngine:
             verify_opsin=verify_opsin,
             verify_self=verify_self,
             token_debug=token_debug,
+            omit_redundant_locants=omit_redundant_locants,
             processes=worker_count,
             chunksize=chunksize,
         )
@@ -347,7 +351,7 @@ class NamingEngine:
             smiles = Chem.MolToSmiles(request.rdkit_mol)
         return read_rdkit_mol(request.rdkit_mol), smiles
 
-    def _name(self, mol: Molecule, *, omit_redundant_locants: bool = False) -> str:
+    def _name(self, mol: Molecule, *, omit_redundant_locants: bool = True) -> str:
         if not mol.atoms:
             return ""
 
@@ -369,7 +373,7 @@ class NamingEngine:
         *,
         smiles: str = "",
         token_debug: bool = False,
-        omit_redundant_locants: bool = False,
+        omit_redundant_locants: bool = True,
     ) -> NameAnalysis:
         decisions = DecisionTrace()
         trace_decision(
@@ -460,6 +464,7 @@ def _request_for(
     verify_opsin: bool,
     verify_self: bool = False,
     token_debug: bool,
+    omit_redundant_locants: bool = True,
 ) -> NamingRequest:
     """Build a request from a batch item, which may be a SMILES or an RDKit molecule."""
 
@@ -469,12 +474,13 @@ def _request_for(
         verify_opsin=verify_opsin,
         verify_self=verify_self,
         token_debug=token_debug,
+        omit_redundant_locants=omit_redundant_locants,
         **kwargs,
     )
 
 
-def _name_one_for_worker(args: tuple[str | Any, bool, bool, bool, bool]) -> NamingResult:
-    item, include_trace, verify_opsin, verify_self, token_debug = args
+def _name_one_for_worker(args: tuple[str | Any, bool, bool, bool, bool, bool]) -> NamingResult:
+    item, include_trace, verify_opsin, verify_self, token_debug, omit_redundant_locants = args
     return DEFAULT_NAMING_ENGINE.run(
         _request_for(
             item,
@@ -482,6 +488,7 @@ def _name_one_for_worker(args: tuple[str | Any, bool, bool, bool, bool]) -> Nami
             verify_opsin=verify_opsin,
             verify_self=verify_self,
             token_debug=token_debug,
+            omit_redundant_locants=omit_redundant_locants,
         )
     )
 
@@ -493,13 +500,14 @@ def _run_parallel(
     verify_opsin: bool,
     verify_self: bool = False,
     token_debug: bool,
+    omit_redundant_locants: bool = True,
     processes: int,
     chunksize: int,
 ) -> list[NamingResult]:
     # Imported lazily so the simple `import openclatura` path stays light.
     from concurrent.futures import ProcessPoolExecutor
 
-    payload = [(s, include_trace, verify_opsin, verify_self, token_debug) for s in smiles_list]
+    payload = [(s, include_trace, verify_opsin, verify_self, token_debug, omit_redundant_locants) for s in smiles_list]
     with ProcessPoolExecutor(max_workers=processes) as ex:
         return list(ex.map(_name_one_for_worker, payload, chunksize=chunksize))
 

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -379,7 +379,9 @@ def _elision_is_safe(
     base_edges = {edge: (1 if edge in normalized_unsaturation_edges else parent_edge_orders[edge]) for edge in edges}
     actual_nodes, actual_edges = _decorated_labels(base_nodes, base_edges, (*fixed, *omitted))
 
-    placement_options = [_candidate_positions(group, locants, edges, base_nodes, base_edges, budget) for group in omitted]
+    placement_options = [
+        _candidate_positions(group, locants, edges, base_nodes, base_edges, budget) for group in omitted
+    ]
     if any(not options for options in placement_options):
         return False
     candidate_count = prod(len(options) for options in placement_options)

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass
 from itertools import combinations, product
-from math import comb, prod
+from math import prod
 
 from .assembly_parts import AssemblyParts
 from .assembly_utils import parse_locant
@@ -14,6 +14,20 @@ from .locant_sources import LocantMapSource
 MAX_CANDIDATE_PLACEMENTS = 10_000
 MAX_AUTOMORPHISM_CANDIDATES = 12
 ParentLocantLabel = tuple[str, int, bool]
+
+
+class _SearchLimitExceeded(Exception):
+    """Signal that an exact proof exhausted its per-invocation work budget."""
+
+
+@dataclass
+class _SearchBudget:
+    remaining: int
+
+    def consume(self) -> None:
+        if self.remaining <= 0:
+            raise _SearchLimitExceeded
+        self.remaining -= 1
 
 
 def _within_search_limit(size: int) -> bool:
@@ -208,7 +222,11 @@ def _parent_attachment_orbit(
     }
 
 
-def apply_redundant_locant_elision(parts: AssemblyParts) -> None:
+def apply_redundant_locant_elision(
+    parts: AssemblyParts,
+    *,
+    max_candidate_placements: int = MAX_CANDIDATE_PLACEMENTS,
+) -> None:
     """Mark constitutional locant groups that are redundant by exact symmetry.
 
     The proof is deliberately conservative. Candidate placements are drawn from
@@ -223,7 +241,19 @@ def apply_redundant_locant_elision(parts: AssemblyParts) -> None:
     if not groups:
         return
 
-    selected = _maximum_safe_elision(parts, groups)
+    budget = _SearchBudget(max(0, max_candidate_placements))
+    try:
+        selected = _maximum_safe_elision(parts, groups, budget)
+    except _SearchLimitExceeded:
+        parts.locant_elision_decisions.append(
+            {
+                "category": "search",
+                "key": "candidate-placement-limit",
+                "locants": [],
+                "reason": "exact symmetry search limit exceeded; locants retained",
+            }
+        )
+        return
     for group in selected:
         if group.category == "substituent":
             parts.elided_substituent_locants.add(group.key)
@@ -310,18 +340,19 @@ def _feature_groups(parts: AssemblyParts) -> list[_FeatureGroup]:
     return groups
 
 
-def _maximum_safe_elision(parts: AssemblyParts, groups: list[_FeatureGroup]) -> tuple[_FeatureGroup, ...]:
+def _maximum_safe_elision(
+    parts: AssemblyParts,
+    groups: list[_FeatureGroup],
+    budget: _SearchBudget,
+) -> tuple[_FeatureGroup, ...]:
     ordered = sorted(
         (group for group in groups if group.category != "substituent"),
         key=lambda group: (group.priority, group.category, group.key),
     )
-    checked = 0
     for size in range(len(ordered), 0, -1):
         for subset in combinations(ordered, size):
-            checked += 1
-            if not _within_search_limit(checked):
-                return ()
-            if _elision_is_safe(parts, groups, subset):
+            budget.consume()
+            if _elision_is_safe(parts, groups, subset, budget):
                 return subset
     return ()
 
@@ -330,6 +361,7 @@ def _elision_is_safe(
     parts: AssemblyParts,
     all_groups: list[_FeatureGroup],
     omitted: tuple[_FeatureGroup, ...],
+    budget: _SearchBudget,
 ) -> bool:
     locants = tuple(sorted(parts.parent_atom_symbols_by_locant, key=parse_locant))
     edges = tuple(sorted((_edge(pair) for pair in parts.parent_bond_orders_by_locants), key=_edge_sort_key))
@@ -347,39 +379,37 @@ def _elision_is_safe(
     base_edges = {edge: (1 if edge in normalized_unsaturation_edges else parent_edge_orders[edge]) for edge in edges}
     actual_nodes, actual_edges = _decorated_labels(base_nodes, base_edges, (*fixed, *omitted))
 
-    placement_options = [_candidate_positions(group, locants, edges, base_nodes, base_edges) for group in omitted]
+    placement_options = [_candidate_positions(group, locants, edges, base_nodes, base_edges, budget) for group in omitted]
     if any(not options for options in placement_options):
         return False
     candidate_count = prod(len(options) for options in placement_options)
     if not _within_search_limit(candidate_count):
         return False
 
-    checked = 0
     for placements in product(*placement_options):
-        checked += 1
-        if not _within_search_limit(checked):
-            return False
+        budget.consume()
         candidate_groups = tuple(
             _FeatureGroup(group.category, group.key, tuple(positions))
             for group, positions in zip(omitted, placements, strict=True)
         )
         candidate_nodes, candidate_edges = _decorated_labels(base_nodes, base_edges, (*fixed, *candidate_groups))
-        if not _isomorphic(locants, edges, actual_nodes, actual_edges, candidate_nodes, candidate_edges):
+        if not _isomorphic(locants, edges, actual_nodes, actual_edges, candidate_nodes, candidate_edges, budget):
             return False
     return True
 
 
-def _candidate_positions(group, locants, edges, base_nodes, base_edges):
+def _candidate_positions(group, locants, edges, base_nodes, base_edges, budget: _SearchBudget):
     count = len(group.positions)
     universe = locants if group.category != "unsaturation" else edges
-    if count > len(universe) or not _within_search_limit(comb(len(universe), count)):
+    if count > len(universe):
         return ()
     actual_signature = Counter(_position_signature(position, base_nodes, base_edges) for position in group.positions)
-    return tuple(
-        candidate
-        for candidate in combinations(universe, count)
-        if Counter(_position_signature(position, base_nodes, base_edges) for position in candidate) == actual_signature
-    )
+    candidates = []
+    for candidate in combinations(universe, count):
+        budget.consume()
+        if Counter(_position_signature(position, base_nodes, base_edges) for position in candidate) == actual_signature:
+            candidates.append(candidate)
+    return tuple(candidates)
 
 
 def _position_signature(position, node_labels, edge_labels):
@@ -452,7 +482,7 @@ def _decorated_labels(base_nodes, base_edges, groups):
     return nodes, edges
 
 
-def _isomorphic(locants, edges, source_nodes, source_edges, target_nodes, target_edges) -> bool:
+def _isomorphic(locants, edges, source_nodes, source_edges, target_nodes, target_edges, budget: _SearchBudget) -> bool:
     source_adj = _labeled_adjacency(locants, edges, source_edges)
     target_adj = _labeled_adjacency(locants, edges, target_edges)
     mapping: dict[str, str] = {}
@@ -473,6 +503,7 @@ def _isomorphic(locants, edges, source_nodes, source_edges, target_nodes, target
             key=lambda locant: sum(source_adj[locant].get(other) is not None for other in mapping),
         )
         for target in locants:
+            budget.consume()
             if target in used or not compatible(source, target):
                 continue
             mapping[source] = target

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -12,6 +12,8 @@ from .assembly_utils import parse_locant
 from .locant_sources import LocantMapSource
 
 MAX_CANDIDATE_PLACEMENTS = 10_000
+MAX_AUTOMORPHISM_CANDIDATES = 12
+ParentLocantLabel = tuple[str, int, bool]
 
 
 def _within_search_limit(size: int) -> bool:
@@ -37,8 +39,18 @@ class _FeatureGroup:
         return {"substituent": 0, "unsaturation": 1, "suffix": 2}[self.category]
 
 
+@dataclass(frozen=True)
+class ParentSymmetryContext:
+    """Parent graph data reused during one default locant-elision decision."""
+
+    locants: tuple[str, ...]
+    indicated_hydrogens: frozenset[str]
+    labels: dict[str, ParentLocantLabel | None]
+    adjacency: dict[str, dict[str, int]]
+
+
 def substituent_locant_set_is_unique(parts: AssemblyParts, locs: list[str], grouped_count: int, spiro_subs) -> bool:
-    """Preserve the target branch's conventional simple-prefix omission proof."""
+    """Return whether parent symmetry makes these substituent locants redundant."""
 
     if (
         not locs
@@ -55,18 +67,27 @@ def substituent_locant_set_is_unique(parts: AssemblyParts, locs: list[str], grou
     ):
         return False
     selected = tuple(str(locant) for locant in locs)
-    if len(set(selected)) != len(selected) or not all(locant.isdigit() for locant in selected):
+    if len(set(selected)) != len(selected):
         return False
     if len(selected) == 1 and not parts.is_ring:
         return False
     if len(selected) == 1 and retained_parent_attachment_is_ambiguous(parts, list(selected)):
         return False
-    group = _FeatureGroup("substituent", "__simple_prefix__", selected)
-    return (
-        _supported_simple_parent(parts)
-        and _single_attachment_positions(parts, selected)
-        and _elision_is_safe(parts, [group], (group,))
-    )
+    if not all(locant.isdigit() for locant in selected):
+        return False
+    if not parts.parent_atom_symbols_by_locant or not parts.parent_bond_orders_by_locants:
+        return False
+    context = _parent_symmetry_context(parts)
+    selected_labels = {parent_locant_label(parts, locant, context.indicated_hydrogens) for locant in selected}
+    if None in selected_labels or len(selected_labels) != 1:
+        return False
+    selected_label = next(iter(selected_labels))
+    candidates = [locant for locant in context.locants if context.labels[locant] == selected_label]
+    if not set(selected).issubset(candidates) or len(selected) > len(candidates):
+        return False
+    if not _candidate_positions_are_single_attachment_sites(context, candidates):
+        return False
+    return _all_same_sized_substituent_sets_are_equivalent(context, set(selected), candidates)
 
 
 def retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str]) -> bool:
@@ -76,29 +97,115 @@ def retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str
         return False
     if len(locs) != 1:
         return False
-    source = str(locs[0])
-    locants = tuple(sorted(parts.parent_atom_symbols_by_locant, key=parse_locant))
-    if source not in locants:
+    locant = str(locs[0])
+    if locant not in parts.parent_atom_symbols_by_locant:
         return True
-    edges = tuple(sorted((_edge(pair) for pair in parts.parent_bond_orders_by_locants), key=_edge_sort_key))
-    base_nodes = _base_node_labels(parts, locants)
-    base_edges = {_edge(edge): order for edge, order in parts.parent_bond_orders_by_locants.items()}
-    source_group = _FeatureGroup("substituent", "__attachment__", (source,))
-    source_nodes, source_edges = _decorated_labels(base_nodes, base_edges, (source_group,))
-    for target in locants:
-        target_group = _FeatureGroup("substituent", "__attachment__", (target,))
-        target_nodes, target_edges = _decorated_labels(base_nodes, base_edges, (target_group,))
-        if not _isomorphic(locants, edges, source_nodes, source_edges, target_nodes, target_edges):
+    context = _parent_symmetry_context(parts)
+    if len(context.locants) <= 1:
+        return False
+    return len(_parent_attachment_orbit(context, locant, context.locants)) < len(context.locants)
+
+
+def parent_locant_label(
+    parts: AssemblyParts, locant: str, indicated_hydrogens: frozenset[str] | None = None
+) -> ParentLocantLabel | None:
+    symbol = parts.parent_atom_symbols_by_locant.get(locant)
+    if symbol is None:
+        return None
+    if indicated_hydrogens is None:
+        indicated_hydrogens = frozenset(str(hydrogen) for hydrogen in parts.indicated_hydrogens)
+    return (symbol, parts.parent_atom_charges_by_locant.get(locant, 0), locant in indicated_hydrogens)
+
+
+def _parent_symmetry_context(parts: AssemblyParts) -> ParentSymmetryContext:
+    locants = tuple(sorted(parts.parent_atom_symbols_by_locant, key=parse_locant))
+    indicated_hydrogens = frozenset(str(hydrogen) for hydrogen in parts.indicated_hydrogens)
+    labels = {locant: parent_locant_label(parts, locant, indicated_hydrogens) for locant in locants}
+    adjacency = {
+        locant: {
+            other: parts.parent_bond_orders_by_locants.get(tuple(sorted((locant, other))), 0)
+            for other in locants
+            if other != locant
+        }
+        for locant in locants
+    }
+    return ParentSymmetryContext(locants, indicated_hydrogens, labels, adjacency)
+
+
+def _all_same_sized_substituent_sets_are_equivalent(
+    context: ParentSymmetryContext, selected: set[str], candidates: list[str]
+) -> bool:
+    k, n = len(selected), len(candidates)
+    if k == n:
+        return True
+    if k == 1:
+        return len(_parent_attachment_orbit(context, next(iter(selected)), candidates)) == n
+    if k == n - 1:
+        omitted = next(locant for locant in candidates if locant not in selected)
+        return len(_parent_attachment_orbit(context, omitted, candidates)) == n
+    if n > MAX_AUTOMORPHISM_CANDIDATES:
+        return False
+    return all(
+        _has_parent_set_automorphism_mapping(selected, set(target), context) for target in combinations(candidates, k)
+    )
+
+
+def _candidate_positions_are_single_attachment_sites(context: ParentSymmetryContext, candidates: list[str]) -> bool:
+    return all(sum(context.adjacency[locant].values()) >= 3 for locant in candidates)
+
+
+def _has_parent_set_automorphism_mapping(
+    source_set: set[str], target_set: set[str], context: ParentSymmetryContext
+) -> bool:
+    if len(source_set) != len(target_set):
+        return False
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+
+    def compatible(source: str, target: str) -> bool:
+        return (
+            context.labels[source] == context.labels[target]
+            and (source in source_set) == (target in target_set)
+            and all(
+                context.adjacency[source].get(other, 0) == context.adjacency[target].get(mapped, 0)
+                for other, mapped in mapping.items()
+            )
+        )
+
+    def search() -> bool:
+        if len(mapping) == len(context.locants):
             return True
-    return False
+        source = min(
+            (locant for locant in context.locants if locant not in mapping),
+            key=lambda locant: (
+                locant not in source_set,
+                -sum(1 for assigned in mapping if context.adjacency[locant].get(assigned, 0)),
+                parse_locant(locant),
+            ),
+        )
+        for target in context.locants:
+            if target in used or not compatible(source, target):
+                continue
+            mapping[source] = target
+            used.add(target)
+            if search():
+                return True
+            used.remove(target)
+            del mapping[source]
+        return False
+
+    return search()
 
 
-def _single_attachment_positions(parts: AssemblyParts, locants: tuple[str, ...]) -> bool:
-    """Reject omission where geminal and distributed placements could collide."""
-
-    adjacency = _adjacency(parts, set(parts.parent_atom_symbols_by_locant))
-    edge_orders = {_edge(edge): order for edge, order in parts.parent_bond_orders_by_locants.items()}
-    return all(sum(edge_orders[_edge((locant, other))] for other in adjacency[locant]) >= 3 for locant in locants)
+def _parent_attachment_orbit(
+    context: ParentSymmetryContext, source: str, locants: tuple[str, ...] | list[str]
+) -> set[str]:
+    return {
+        target
+        for target in locants
+        if context.labels[target] == context.labels[source]
+        and _has_parent_set_automorphism_mapping({source}, {target}, context)
+    }
 
 
 def apply_redundant_locant_elision(parts: AssemblyParts) -> None:

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -242,7 +242,21 @@ def apply_redundant_locant_elision(parts: AssemblyParts) -> None:
 
 
 def _supported_simple_parent(parts: AssemblyParts) -> bool:
-    if parts.is_bicycle or parts.is_spiro or parts.is_polycycle:
+    if (
+        parts.is_substituent
+        or parts.is_bicycle
+        or parts.is_spiro
+        or parts.is_polycycle
+        or parts.stereo_features
+        or parts.relative_stereo_prefixes
+        or parts.indicated_hydrogens
+        or parts.parent_charges
+        or parts.a_prefixes
+        or parts.front_modifier_locants
+        or parts.principal_suffix_modifiers
+        or parts.hydro_operations
+        or any(parts.parent_atom_charges_by_locant.values())
+    ):
         return False
     locants = set(parts.parent_atom_symbols_by_locant)
     if not locants or any(not _is_numeric_locant(locant) for locant in locants):
@@ -265,10 +279,18 @@ def _feature_groups(parts: AssemblyParts) -> list[_FeatureGroup]:
         if locants and all(locant in parts.parent_atom_symbols_by_locant for locant in locants):
             groups.append(_FeatureGroup("substituent", name, tuple(sorted(locants, key=parse_locant))))
 
-    if parts.principal_group and parts.principal_group.locants:
+    if (
+        parts.principal_group
+        and len(parts.principal_group.locants) == 1
+        and not parts.substituents
+        and set(parts.parent_atom_symbols_by_locant.values()) == {"C"}
+    ):
         locants = tuple(str(locant) for locant in parts.principal_group.locants)
         if all(locant in parts.parent_atom_symbols_by_locant for locant in locants):
             groups.append(_FeatureGroup("suffix", parts.principal_group.key, tuple(sorted(locants, key=parse_locant))))
+
+    if parts.principal_group:
+        return groups
 
     bond_locants = {bond_id: _edge(pair) for pair, bond_id in parts.parent_bond_ids_by_locants.items()}
     by_bond_key: dict[str, list[tuple[str, str]]] = {}
@@ -289,7 +311,10 @@ def _feature_groups(parts: AssemblyParts) -> list[_FeatureGroup]:
 
 
 def _maximum_safe_elision(parts: AssemblyParts, groups: list[_FeatureGroup]) -> tuple[_FeatureGroup, ...]:
-    ordered = sorted(groups, key=lambda group: (group.priority, group.category, group.key))
+    ordered = sorted(
+        (group for group in groups if group.category != "substituent"),
+        key=lambda group: (group.priority, group.category, group.key),
+    )
     checked = 0
     for size in range(len(ordered), 0, -1):
         for subset in combinations(ordered, size):

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -14,6 +14,17 @@ from .locant_sources import LocantMapSource
 MAX_CANDIDATE_PLACEMENTS = 10_000
 
 
+def _within_search_limit(size: int) -> bool:
+    """Return whether an exact search may proceed without exceeding its cap.
+
+    Every combinatorial search space and its realized iteration count use this
+    same inclusive limit.  Returning ``False`` always fails closed: the caller
+    retains the original locants instead of approximating symmetry.
+    """
+
+    return size <= MAX_CANDIDATE_PLACEMENTS
+
+
 @dataclass(frozen=True)
 class _FeatureGroup:
     category: str
@@ -51,8 +62,10 @@ def substituent_locant_set_is_unique(parts: AssemblyParts, locs: list[str], grou
     if len(selected) == 1 and retained_parent_attachment_is_ambiguous(parts, list(selected)):
         return False
     group = _FeatureGroup("substituent", "__simple_prefix__", selected)
-    return _supported_simple_parent(parts) and _single_attachment_positions(parts, selected) and _elision_is_safe(
-        parts, [group], (group,)
+    return (
+        _supported_simple_parent(parts)
+        and _single_attachment_positions(parts, selected)
+        and _elision_is_safe(parts, [group], (group,))
     )
 
 
@@ -174,7 +187,7 @@ def _maximum_safe_elision(parts: AssemblyParts, groups: list[_FeatureGroup]) -> 
     for size in range(len(ordered), 0, -1):
         for subset in combinations(ordered, size):
             checked += 1
-            if checked > MAX_CANDIDATE_PLACEMENTS:
+            if not _within_search_limit(checked):
                 return ()
             if _elision_is_safe(parts, groups, subset):
                 return subset
@@ -206,13 +219,13 @@ def _elision_is_safe(
     if any(not options for options in placement_options):
         return False
     candidate_count = prod(len(options) for options in placement_options)
-    if candidate_count > MAX_CANDIDATE_PLACEMENTS:
+    if not _within_search_limit(candidate_count):
         return False
 
     checked = 0
     for placements in product(*placement_options):
         checked += 1
-        if checked > MAX_CANDIDATE_PLACEMENTS:
+        if not _within_search_limit(checked):
             return False
         candidate_groups = tuple(
             _FeatureGroup(group.category, group.key, tuple(positions))
@@ -227,7 +240,7 @@ def _elision_is_safe(
 def _candidate_positions(group, locants, edges, base_nodes, base_edges):
     count = len(group.positions)
     universe = locants if group.category != "unsaturation" else edges
-    if count > len(universe) or comb(len(universe), count) > MAX_CANDIDATE_PLACEMENTS:
+    if count > len(universe) or not _within_search_limit(comb(len(universe), count)):
         return ()
     actual_signature = Counter(_position_signature(position, base_nodes, base_edges) for position in group.positions)
     return tuple(

--- a/src/openclatura/locant_elision.py
+++ b/src/openclatura/locant_elision.py
@@ -1,36 +1,33 @@
-"""Graph-based decisions for optional substituent locant elision."""
+"""Conservative graph proofs for optional constitutional-locant elision."""
 
+from __future__ import annotations
+
+from collections import Counter
 from dataclasses import dataclass
-from itertools import combinations
+from itertools import combinations, product
+from math import comb, prod
 
 from .assembly_parts import AssemblyParts
 from .assembly_utils import parse_locant
 from .locant_sources import LocantMapSource
 
-# Optional locant omission is a presentation improvement. Above this candidate
-# count the search refuses to run and leaves explicit locants in place.
-MAX_AUTOMORPHISM_CANDIDATES = 12
-
-ParentLocantLabel = tuple[str, int, bool]
+MAX_CANDIDATE_PLACEMENTS = 10_000
 
 
 @dataclass(frozen=True)
-class ParentSymmetryContext:
-    """Parent graph data reused during one optional locant-elision decision."""
+class _FeatureGroup:
+    category: str
+    key: str
+    positions: tuple[str | tuple[str, str], ...]
 
-    locants: tuple[str, ...]
-    indicated_hydrogens: frozenset[str]
-    labels: dict[str, ParentLocantLabel | None]
-    adjacency: dict[str, dict[str, int]]
+    @property
+    def priority(self) -> int:
+        # Lower-seniority information is preferred for omission.
+        return {"substituent": 0, "unsaturation": 1, "suffix": 2}[self.category]
 
 
-def substituent_locant_set_is_unique(
-    parts: AssemblyParts,
-    locs: list[str],
-    grouped_count: int,
-    spiro_subs,
-) -> bool:
-    """Return whether parent symmetry makes these substituent locants redundant."""
+def substituent_locant_set_is_unique(parts: AssemblyParts, locs: list[str], grouped_count: int, spiro_subs) -> bool:
+    """Preserve the target branch's conventional simple-prefix omission proof."""
 
     if (
         not locs
@@ -46,219 +43,344 @@ def substituent_locant_set_is_unique(
         or parts.a_prefixes
     ):
         return False
-    selected = tuple(str(loc) for loc in locs)
-    if len(set(selected)) != len(selected):
+    selected = tuple(str(locant) for locant in locs)
+    if len(set(selected)) != len(selected) or not all(locant.isdigit() for locant in selected):
         return False
     if len(selected) == 1 and not parts.is_ring:
         return False
     if len(selected) == 1 and retained_parent_attachment_is_ambiguous(parts, list(selected)):
         return False
-    if not all(loc.isdigit() for loc in selected):
-        return False
-    if not parts.parent_atom_symbols_by_locant or not parts.parent_bond_orders_by_locants:
-        return False
-
-    context = _parent_symmetry_context(parts)
-    selected_labels = {parent_locant_label(parts, loc, context.indicated_hydrogens) for loc in selected}
-    if None in selected_labels or len(selected_labels) != 1:
-        return False
-    selected_label = next(iter(selected_labels))
-    candidates = [loc for loc in context.locants if context.labels[loc] == selected_label]
-    if not set(selected).issubset(candidates):
-        return False
-    if len(selected) > len(candidates):
-        return False
-    if not _candidate_positions_are_single_attachment_sites(context, candidates):
-        return False
-    return _all_same_sized_substituent_sets_are_equivalent(context, set(selected), candidates)
+    group = _FeatureGroup("substituent", "__simple_prefix__", selected)
+    return _supported_simple_parent(parts) and _single_attachment_positions(parts, selected) and _elision_is_safe(
+        parts, [group], (group,)
+    )
 
 
 def retained_parent_attachment_is_ambiguous(parts: AssemblyParts, locs: list[str]) -> bool:
-    """Return whether locant omission would hide a non-equivalent retained-parent attachment."""
+    """Return whether omitting one retained-parent attachment locant is ambiguous."""
 
     if not parts.retained_name or not parts.is_ring or parts.is_bicycle or parts.is_spiro or parts.is_polycycle:
         return False
     if len(locs) != 1:
         return False
-    locant = str(locs[0])
-    if locant not in parts.parent_atom_symbols_by_locant:
+    source = str(locs[0])
+    locants = tuple(sorted(parts.parent_atom_symbols_by_locant, key=parse_locant))
+    if source not in locants:
         return True
-    context = _parent_symmetry_context(parts)
-    if len(context.locants) <= 1:
+    edges = tuple(sorted((_edge(pair) for pair in parts.parent_bond_orders_by_locants), key=_edge_sort_key))
+    base_nodes = _base_node_labels(parts, locants)
+    base_edges = {_edge(edge): order for edge, order in parts.parent_bond_orders_by_locants.items()}
+    source_group = _FeatureGroup("substituent", "__attachment__", (source,))
+    source_nodes, source_edges = _decorated_labels(base_nodes, base_edges, (source_group,))
+    for target in locants:
+        target_group = _FeatureGroup("substituent", "__attachment__", (target,))
+        target_nodes, target_edges = _decorated_labels(base_nodes, base_edges, (target_group,))
+        if not _isomorphic(locants, edges, source_nodes, source_edges, target_nodes, target_edges):
+            return True
+    return False
+
+
+def _single_attachment_positions(parts: AssemblyParts, locants: tuple[str, ...]) -> bool:
+    """Reject omission where geminal and distributed placements could collide."""
+
+    adjacency = _adjacency(parts, set(parts.parent_atom_symbols_by_locant))
+    edge_orders = {_edge(edge): order for edge, order in parts.parent_bond_orders_by_locants.items()}
+    return all(sum(edge_orders[_edge((locant, other))] for other in adjacency[locant]) >= 3 for locant in locants)
+
+
+def apply_redundant_locant_elision(parts: AssemblyParts) -> None:
+    """Mark constitutional locant groups that are redundant by exact symmetry.
+
+    The proof is deliberately conservative. Candidate placements are drawn from
+    the complete compatible parent vertex/edge set; if any candidate is not
+    graph-equivalent to the observed decoration, its locants remain printed.
+    """
+
+    if not parts.omit_redundant_locants or not _supported_simple_parent(parts):
+        return
+
+    groups = _feature_groups(parts)
+    if not groups:
+        return
+
+    selected = _maximum_safe_elision(parts, groups)
+    for group in selected:
+        if group.category == "substituent":
+            parts.elided_substituent_locants.add(group.key)
+        elif group.category == "unsaturation":
+            parts.elided_unsaturation_locants.add(group.key)
+        else:
+            parts.elide_principal_group_locants = True
+        parts.locant_elision_decisions.append(
+            {
+                "category": group.category,
+                "key": group.key,
+                "locants": [_display_position(position) for position in group.positions],
+                "reason": "placement is unique under exact parent-graph symmetry",
+            }
+        )
+
+
+def _supported_simple_parent(parts: AssemblyParts) -> bool:
+    if parts.is_bicycle or parts.is_spiro or parts.is_polycycle:
         return False
-    orbit = _parent_attachment_orbit(context, locant, context.locants)
-    return len(orbit) < len(context.locants)
+    locants = set(parts.parent_atom_symbols_by_locant)
+    if not locants or any(not _is_numeric_locant(locant) for locant in locants):
+        return False
+    adjacency = _adjacency(parts, locants)
+    if not _connected(adjacency):
+        return False
+    degrees = [len(neighbors) for neighbors in adjacency.values()]
+    if parts.is_ring:
+        return len(locants) >= 3 and all(degree == 2 for degree in degrees)
+    return sum(degree == 1 for degree in degrees) == 2 and all(degree <= 2 for degree in degrees)
 
 
-def parent_locant_label(
+def _feature_groups(parts: AssemblyParts) -> list[_FeatureGroup]:
+    groups: list[_FeatureGroup] = []
+    by_name: dict[str, list[str]] = {}
+    for item in parts.substituents:
+        by_name.setdefault(item.name, []).extend(str(locant) for locant in item.locants)
+    for name, locants in sorted(by_name.items()):
+        if locants and all(locant in parts.parent_atom_symbols_by_locant for locant in locants):
+            groups.append(_FeatureGroup("substituent", name, tuple(sorted(locants, key=parse_locant))))
+
+    if parts.principal_group and parts.principal_group.locants:
+        locants = tuple(str(locant) for locant in parts.principal_group.locants)
+        if all(locant in parts.parent_atom_symbols_by_locant for locant in locants):
+            groups.append(_FeatureGroup("suffix", parts.principal_group.key, tuple(sorted(locants, key=parse_locant))))
+
+    bond_locants = {bond_id: _edge(pair) for pair, bond_id in parts.parent_bond_ids_by_locants.items()}
+    by_bond_key: dict[str, list[tuple[str, str]]] = {}
+    for item in parts.unsaturations:
+        positions = [bond_locants[bond_id] for bond_id in item.bond_ids if bond_id in bond_locants]
+        if len(positions) != len(item.locants):
+            continue
+        by_bond_key.setdefault(item.bond_key, []).extend(positions)
+    for bond_key, positions in sorted(by_bond_key.items()):
+        groups.append(
+            _FeatureGroup(
+                "unsaturation",
+                bond_key,
+                tuple(sorted((_edge(position) for position in positions), key=_edge_sort_key)),
+            )
+        )
+    return groups
+
+
+def _maximum_safe_elision(parts: AssemblyParts, groups: list[_FeatureGroup]) -> tuple[_FeatureGroup, ...]:
+    ordered = sorted(groups, key=lambda group: (group.priority, group.category, group.key))
+    checked = 0
+    for size in range(len(ordered), 0, -1):
+        for subset in combinations(ordered, size):
+            checked += 1
+            if checked > MAX_CANDIDATE_PLACEMENTS:
+                return ()
+            if _elision_is_safe(parts, groups, subset):
+                return subset
+    return ()
+
+
+def _elision_is_safe(
     parts: AssemblyParts,
-    locant: str,
-    indicated_hydrogens: frozenset[str] | None = None,
-) -> ParentLocantLabel | None:
-    """Return the graph label used for parent-locant symmetry comparisons."""
-
-    symbol = parts.parent_atom_symbols_by_locant.get(locant)
-    if symbol is None:
-        return None
-    if indicated_hydrogens is None:
-        indicated_hydrogens = frozenset(str(hydrogen) for hydrogen in parts.indicated_hydrogens)
-    return (
-        symbol,
-        parts.parent_atom_charges_by_locant.get(locant, 0),
-        locant in indicated_hydrogens,
-    )
-
-
-def _parent_symmetry_context(parts: AssemblyParts) -> ParentSymmetryContext:
-    locants = tuple(sorted(parts.parent_atom_symbols_by_locant.keys(), key=parse_locant))
-    indicated_hydrogens = frozenset(str(hydrogen) for hydrogen in parts.indicated_hydrogens)
-    labels = {loc: parent_locant_label(parts, loc, indicated_hydrogens) for loc in locants}
-    adjacency = {
-        loc: {
-            other: parts.parent_bond_orders_by_locants.get(tuple(sorted((loc, other))), 0)
-            for other in locants
-            if other != loc
-        }
-        for loc in locants
-    }
-    return ParentSymmetryContext(
-        locants=locants,
-        indicated_hydrogens=indicated_hydrogens,
-        labels=labels,
-        adjacency=adjacency,
-    )
-
-
-def _all_same_sized_substituent_sets_are_equivalent(
-    context: ParentSymmetryContext,
-    selected: set[str],
-    candidates: list[str],
+    all_groups: list[_FeatureGroup],
+    omitted: tuple[_FeatureGroup, ...],
 ) -> bool:
-    k = len(selected)
-    n = len(candidates)
-    if k == n:
-        return True
-    if k == 1:
-        source = next(iter(selected))
-        return len(_parent_attachment_orbit(context, source, candidates)) == len(candidates)
-    if k == n - 1:
-        omitted = next(loc for loc in candidates if loc not in selected)
-        return len(_parent_attachment_orbit(context, omitted, candidates)) == len(candidates)
-    if n > MAX_AUTOMORPHISM_CANDIDATES:
+    locants = tuple(sorted(parts.parent_atom_symbols_by_locant, key=parse_locant))
+    edges = tuple(sorted((_edge(pair) for pair in parts.parent_bond_orders_by_locants), key=_edge_sort_key))
+    omitted_set = set(omitted)
+    fixed = tuple(group for group in all_groups if group not in omitted_set)
+    base_nodes = _base_node_labels(parts, locants)
+    normalized_unsaturation_edges = {
+        position
+        for group in all_groups
+        if group.category == "unsaturation"
+        for position in group.positions
+        if isinstance(position, tuple)
+    }
+    parent_edge_orders = {_edge(edge): order for edge, order in parts.parent_bond_orders_by_locants.items()}
+    base_edges = {edge: (1 if edge in normalized_unsaturation_edges else parent_edge_orders[edge]) for edge in edges}
+    actual_nodes, actual_edges = _decorated_labels(base_nodes, base_edges, (*fixed, *omitted))
+
+    placement_options = [_candidate_positions(group, locants, edges, base_nodes, base_edges) for group in omitted]
+    if any(not options for options in placement_options):
         return False
-    for target in combinations(candidates, k):
-        if not _has_parent_set_automorphism_mapping(selected, set(target), context):
+    candidate_count = prod(len(options) for options in placement_options)
+    if candidate_count > MAX_CANDIDATE_PLACEMENTS:
+        return False
+
+    checked = 0
+    for placements in product(*placement_options):
+        checked += 1
+        if checked > MAX_CANDIDATE_PLACEMENTS:
+            return False
+        candidate_groups = tuple(
+            _FeatureGroup(group.category, group.key, tuple(positions))
+            for group, positions in zip(omitted, placements, strict=True)
+        )
+        candidate_nodes, candidate_edges = _decorated_labels(base_nodes, base_edges, (*fixed, *candidate_groups))
+        if not _isomorphic(locants, edges, actual_nodes, actual_edges, candidate_nodes, candidate_edges):
             return False
     return True
 
 
-def _candidate_positions_are_single_attachment_sites(
-    context: ParentSymmetryContext,
-    candidates: list[str],
-) -> bool:
-    """Return whether omitted locants cannot hide geminal alternatives.
-
-    Optional locant omission is safe only when each equivalent parent position
-    can host at most one rendered substituent of this group. Unsaturated/aromatic
-    parent atoms satisfy this through their parent bond-order valence; saturated
-    small-ring atoms such as cyclopropane carbons do not, so names like
-    dimethylcyclopropane keep locants to distinguish 1,1- from 1,2-patterns.
-    """
-
-    return all(sum(context.adjacency[loc].values()) >= 3 for loc in candidates)
+def _candidate_positions(group, locants, edges, base_nodes, base_edges):
+    count = len(group.positions)
+    universe = locants if group.category != "unsaturation" else edges
+    if count > len(universe) or comb(len(universe), count) > MAX_CANDIDATE_PLACEMENTS:
+        return ()
+    actual_signature = Counter(_position_signature(position, base_nodes, base_edges) for position in group.positions)
+    return tuple(
+        candidate
+        for candidate in combinations(universe, count)
+        if Counter(_position_signature(position, base_nodes, base_edges) for position in candidate) == actual_signature
+    )
 
 
-def _has_parent_set_automorphism_mapping(
-    source_set: set[str],
-    target_set: set[str],
-    context: ParentSymmetryContext,
-) -> bool:
-    if len(source_set) != len(target_set):
-        return False
-    mapping: dict[str, str] = {}
-    used: set[str] = set()
+def _position_signature(position, node_labels, edge_labels):
+    if isinstance(position, tuple):
+        u, v = position
+        return ("edge", tuple(sorted((node_labels[u], node_labels[v]), key=repr)), edge_labels[position])
+    return ("node", node_labels[position])
 
-    def compatible(src: str, dst: str) -> bool:
-        if context.labels[src] != context.labels[dst]:
-            return False
-        if (src in source_set) != (dst in target_set):
-            return False
-        for assigned_src, assigned_dst in mapping.items():
-            if context.adjacency[src].get(assigned_src, 0) != context.adjacency[dst].get(assigned_dst, 0):
-                return False
-        return True
 
-    def search() -> bool:
-        if len(mapping) == len(context.locants):
-            return True
-        src = min(
-            (loc for loc in context.locants if loc not in mapping),
-            key=lambda loc: (
-                loc not in source_set,
-                -sum(1 for assigned in mapping if context.adjacency[loc].get(assigned, 0)),
-                parse_locant(loc),
+def _base_node_labels(parts: AssemblyParts, locants: tuple[str, ...]) -> dict[str, tuple]:
+    stereo = {str(locant): descriptor for locant, descriptor in parts.stereo_features}
+    indicated_h = {str(locant) for locant in parts.indicated_hydrogens}
+    attachment = str(parts.attachment_locant) if parts.is_substituent else None
+    replacement = Counter((str(locant), item.name) for item in parts.a_prefixes for locant in item.locants)
+    front_modifiers = Counter(
+        (str(locant), name)
+        for name, locant in zip(parts.front_modifiers, parts.front_modifier_locants, strict=False)
+        if locant is not None
+    )
+    hydro_operations = Counter(
+        (str(locant), operation.operation_kind) for operation in parts.hydro_operations for locant in operation.locants
+    )
+    return {
+        locant: (
+            parts.parent_atom_symbols_by_locant[locant],
+            parts.parent_atom_charges_by_locant.get(locant, 0),
+            parts.parent_atom_isotopes_by_locant.get(locant),
+            stereo.get(locant),
+            locant in indicated_h,
+            locant == attachment,
+            tuple(
+                sorted(
+                    name
+                    for (item_locant, name), count in replacement.items()
+                    if item_locant == locant
+                    for _ in range(count)
+                )
+            ),
+            tuple(
+                sorted(
+                    name
+                    for (item_locant, name), count in front_modifiers.items()
+                    if item_locant == locant
+                    for _ in range(count)
+                )
+            ),
+            tuple(
+                sorted(
+                    kind
+                    for (item_locant, kind), count in hydro_operations.items()
+                    if item_locant == locant
+                    for _ in range(count)
+                )
             ),
         )
-        candidate_targets = [
-            loc for loc in context.locants if loc not in used and (src in source_set) == (loc in target_set)
-        ]
-        for dst in candidate_targets:
-            if not compatible(src, dst):
-                continue
-            mapping[src] = dst
-            used.add(dst)
-            if search():
-                return True
-            used.remove(dst)
-            del mapping[src]
-        return False
-
-    return search()
-
-
-def _parent_attachment_orbit(
-    context: ParentSymmetryContext, source: str, locants: tuple[str, ...] | list[str]
-) -> set[str]:
-    return {
-        target
-        for target in locants
-        if context.labels[target] == context.labels[source]
-        and _has_parent_automorphism_mapping(source, target, context)
+        for locant in locants
     }
 
 
-def _has_parent_automorphism_mapping(
-    source: str,
-    target: str,
-    context: ParentSymmetryContext,
-) -> bool:
-    mapping = {source: target}
-    used = {target}
+def _decorated_labels(base_nodes, base_edges, groups):
+    node_markers = {locant: [] for locant in base_nodes}
+    edge_markers = {edge: [] for edge in base_edges}
+    for group in groups:
+        marker = (group.category, group.key)
+        target = edge_markers if group.category == "unsaturation" else node_markers
+        for position in group.positions:
+            target[position].append(marker)
+    nodes = {locant: (base_nodes[locant], tuple(sorted(node_markers[locant]))) for locant in base_nodes}
+    edges = {edge: (base_edges[edge], tuple(sorted(edge_markers[edge]))) for edge in base_edges}
+    return nodes, edges
 
-    def compatible(src: str, dst: str) -> bool:
-        if context.labels[src] != context.labels[dst]:
+
+def _isomorphic(locants, edges, source_nodes, source_edges, target_nodes, target_edges) -> bool:
+    source_adj = _labeled_adjacency(locants, edges, source_edges)
+    target_adj = _labeled_adjacency(locants, edges, target_edges)
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+
+    def compatible(source: str, target: str) -> bool:
+        if source_nodes[source] != target_nodes[target]:
             return False
-        for assigned_src, assigned_dst in mapping.items():
-            if context.adjacency[src].get(assigned_src, 0) != context.adjacency[dst].get(assigned_dst, 0):
-                return False
-        return True
+        if Counter(source_adj[source].values()) != Counter(target_adj[target].values()):
+            return False
+        return all(source_adj[source].get(other) == target_adj[target].get(mapped) for other, mapped in mapping.items())
 
     def search() -> bool:
-        if len(mapping) == len(context.locants):
+        if len(mapping) == len(locants):
             return True
-        src = min(
-            (loc for loc in context.locants if loc not in mapping),
-            key=lambda loc: sum(1 for assigned in mapping if context.adjacency[loc].get(assigned, 0)),
+        source = min(
+            (locant for locant in locants if locant not in mapping),
+            key=lambda locant: sum(source_adj[locant].get(other) is not None for other in mapping),
         )
-        for dst in context.locants:
-            if dst in used or not compatible(src, dst):
+        for target in locants:
+            if target in used or not compatible(source, target):
                 continue
-            mapping[src] = dst
-            used.add(dst)
+            mapping[source] = target
+            used.add(target)
             if search():
                 return True
-            used.remove(dst)
-            del mapping[src]
+            used.remove(target)
+            del mapping[source]
         return False
 
     return search()
+
+
+def _labeled_adjacency(locants, edges, edge_labels):
+    adjacency = {locant: {} for locant in locants}
+    for u, v in edges:
+        adjacency[u][v] = edge_labels[(u, v)]
+        adjacency[v][u] = edge_labels[(u, v)]
+    return adjacency
+
+
+def _adjacency(parts: AssemblyParts, locants: set[str]) -> dict[str, set[str]]:
+    adjacency = {locant: set() for locant in locants}
+    for u, v in parts.parent_bond_orders_by_locants:
+        adjacency[u].add(v)
+        adjacency[v].add(u)
+    return adjacency
+
+
+def _connected(adjacency: dict[str, set[str]]) -> bool:
+    if not adjacency:
+        return False
+    pending = [next(iter(adjacency))]
+    seen = set(pending)
+    while pending:
+        for neighbor in adjacency[pending.pop()]:
+            if neighbor not in seen:
+                seen.add(neighbor)
+                pending.append(neighbor)
+    return len(seen) == len(adjacency)
+
+
+def _edge(pair: tuple[str, str]) -> tuple[str, str]:
+    return tuple(sorted((str(pair[0]), str(pair[1])), key=parse_locant))
+
+
+def _edge_sort_key(edge: tuple[str, str]):
+    return (parse_locant(edge[0]), parse_locant(edge[1]))
+
+
+def _is_numeric_locant(locant: str) -> bool:
+    return locant.isdigit()
+
+
+def _display_position(position: str | tuple[str, str]) -> str:
+    return "-".join(position) if isinstance(position, tuple) else position

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -29,6 +29,7 @@ from .functional_prefixes import PREFIX_HANDLERS, PrefixContext
 from .group_atom_roles import amide_nitrogen
 from .heteroatom_subgraphs import name_heteroatom_subgraph
 from .ionic_naming import apply_anionic_parent_names, apply_cationic_imino_names, apply_cationic_imino_parent_prefixes
+from .locant_elision import apply_redundant_locant_elision
 from .molecule import DecisionTrace, Molecule, NameAnalysis, TracePhase, charged_atoms
 from .molecule import bond_ids_within as _bond_ids_within
 from .name_assembly import NameAssemblyResult, rewrite_history_trace_data, token_span_trace_data
@@ -842,6 +843,7 @@ def _collect_subgraph_substituents(
     sub_exclude: set[int],
     *,
     emit_metadata: bool = True,
+    omit_redundant_locants: bool = False,
 ) -> dict[int, list[SubstituentItem]]:
     """Collect prefixes attached to a recursive subgraph parent.
     P-14.2, P-16.5, P-44, P-61 through P-67, and P-24 for the spiro side-ring substituents."""
@@ -849,6 +851,10 @@ def _collect_subgraph_substituents(
     main_set = set(candidate_path)
     subst_mapping: dict[int, list[SubstituentItem]] = {}
     sub_handled_atoms = set()
+
+    def configured_name_subgraph(*args, **kwargs):
+        kwargs.setdefault("omit_redundant_locants", omit_redundant_locants)
+        return name_subgraph(*args, **kwargs)
 
     for group in sub_perceived:
         # The attachment carbon being on this parent is not enough: the group's own
@@ -902,7 +908,7 @@ def _collect_subgraph_substituents(
                 branch_decisions = DecisionTrace() if emit_metadata else None
                 branch_exclude = sub_exclude | main_set
                 if emit_metadata:
-                    branch_name, branch_trace, branch_tree = name_subgraph(
+                    branch_name, branch_trace, branch_tree = configured_name_subgraph(
                         mol,
                         n_idx,
                         branch_exclude,
@@ -912,7 +918,7 @@ def _collect_subgraph_substituents(
                         decision_trace=branch_decisions,
                     )
                 else:
-                    branch_name = name_subgraph(
+                    branch_name = configured_name_subgraph(
                         mol,
                         n_idx,
                         branch_exclude,
@@ -932,7 +938,7 @@ def _collect_subgraph_substituents(
                             branch_name,
                             c_idx,
                             branch_exclude,
-                            name_subgraph,
+                            configured_name_subgraph,
                         )
                         if emit_metadata
                         else ()
@@ -1278,6 +1284,7 @@ def name_subgraph(
     return_trace: bool = False,
     return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
+    omit_redundant_locants: bool = False,
 ):
     """Name a recursive substituent subgraph attached to the current parent (P-13.6, P-14.2, P-16.5, P-61
     through P-67).  Extendable prefix vocabularies come from ``data/namer_rules.json``."""
@@ -1402,6 +1409,7 @@ def name_subgraph(
         sub_perceived,
         sub_exclude,
         emit_metadata=emit_metadata,
+        omit_redundant_locants=omit_redundant_locants,
     )
     # A retained ring is retained as a prefix too (``quinolin-7-yl``); a substituent
     # has no principal group, and its attachment is one more locant to cite.
@@ -1426,6 +1434,7 @@ def name_subgraph(
             start_idx,
             upstream_atom,
             fixed_start=parent_selection.fixed_start_required,
+            omit_redundant_locants=omit_redundant_locants,
         ),
         subst_mapping,
         locant_maps,
@@ -1462,6 +1471,8 @@ def name_subgraph(
         parent_selection.is_polycycle,
     )
 
+    apply_redundant_locant_elision(parts)
+
     rendered_name = _assemble_parent_name(
         mol,
         parts,
@@ -1483,6 +1494,7 @@ def name_subgraph(
             data={
                 "name": name,
                 "trace_segment_count": len(trace_segments),
+                "locant_elisions": parts.locant_elision_decisions,
             },
         )
     if return_trace:
@@ -1912,8 +1924,13 @@ def name_component(
     return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
     token_debug: bool = False,
+    omit_redundant_locants: bool = False,
 ):
     """Name one connected component or recursive component of a molecule."""
+
+    def configured_name_subgraph(*args, **kwargs):
+        kwargs.setdefault("omit_redundant_locants", omit_redundant_locants)
+        return name_subgraph(*args, **kwargs)
 
     return _name_component_impl(
         mol,
@@ -1922,10 +1939,11 @@ def name_component(
         return_trace=return_trace,
         return_tree=return_tree,
         decision_trace=decision_trace,
-        name_subgraph=name_subgraph,
+        name_subgraph=configured_name_subgraph,
         name_spiro_subgraph=_spiro_subgraph_assembly,
         assemble_parent_name=_assemble_parent_name,
         token_debug=token_debug,
+        omit_redundant_locants=omit_redundant_locants,
     )
 
 

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -850,7 +850,7 @@ def _collect_subgraph_substituents(
     sub_exclude: set[int],
     *,
     emit_metadata: bool = True,
-    omit_redundant_locants: bool = False,
+    omit_redundant_locants: bool = True,
 ) -> dict[int, list[SubstituentItem]]:
     """Collect prefixes attached to a recursive subgraph parent.
     P-14.2, P-16.5, P-44, P-61 through P-67, and P-24 for the spiro side-ring substituents."""
@@ -1289,7 +1289,7 @@ def name_subgraph(
     return_trace: bool = False,
     return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
-    omit_redundant_locants: bool = False,
+    omit_redundant_locants: bool = True,
 ):
     """Name a recursive substituent subgraph attached to the current parent (P-13.6, P-14.2, P-16.5, P-61
     through P-67).  Extendable prefix vocabularies come from ``data/namer_rules.json``."""
@@ -1929,7 +1929,7 @@ def name_component(
     return_tree: bool = False,
     decision_trace: DecisionTrace | None = None,
     token_debug: bool = False,
-    omit_redundant_locants: bool = False,
+    omit_redundant_locants: bool = True,
 ):
     """Name one connected component or recursive component of a molecule."""
 

--- a/src/openclatura/namer.py
+++ b/src/openclatura/namer.py
@@ -3,6 +3,7 @@
 import re
 from collections import Counter
 from dataclasses import dataclass, field
+from functools import partial
 
 from .additive import add_indicated_hydrogens as _add_indicated_hydrogens
 from .assembler import assemble_name_raw, post_process_rewrite_rules
@@ -102,6 +103,12 @@ class DirectSubgraphPrefix:
             "ligand_count": len(self.ligand_trees),
             "source": self.source,
         }
+
+
+def _subgraph_namer_with_locant_policy(omit_redundant_locants: bool):
+    """Bind request-scoped locant policy at the recursive naming entry point."""
+
+    return partial(name_subgraph, omit_redundant_locants=omit_redundant_locants)
 
 
 def _direct_subgraph_prefix(mol: Molecule, start_idx: int, component: set[int]) -> DirectSubgraphPrefix | None:
@@ -852,9 +859,7 @@ def _collect_subgraph_substituents(
     subst_mapping: dict[int, list[SubstituentItem]] = {}
     sub_handled_atoms = set()
 
-    def configured_name_subgraph(*args, **kwargs):
-        kwargs.setdefault("omit_redundant_locants", omit_redundant_locants)
-        return name_subgraph(*args, **kwargs)
+    configured_name_subgraph = _subgraph_namer_with_locant_policy(omit_redundant_locants)
 
     for group in sub_perceived:
         # The attachment carbon being on this parent is not enough: the group's own
@@ -1928,9 +1933,7 @@ def name_component(
 ):
     """Name one connected component or recursive component of a molecule."""
 
-    def configured_name_subgraph(*args, **kwargs):
-        kwargs.setdefault("omit_redundant_locants", omit_redundant_locants)
-        return name_subgraph(*args, **kwargs)
+    configured_name_subgraph = _subgraph_namer_with_locant_policy(omit_redundant_locants)
 
     return _name_component_impl(
         mol,

--- a/src/openclatura/naming_context.py
+++ b/src/openclatura/naming_context.py
@@ -27,13 +27,25 @@ class NamingIntent:
     upstream_atom: int | None = None
     fixed_start: bool = False
     is_substituent: bool = False
+    omit_redundant_locants: bool = False
 
     @classmethod
-    def component(cls, principal_atoms) -> "NamingIntent":
-        return cls(mode=NamingMode.COMPONENT, principal_atoms=tuple(principal_atoms))
+    def component(cls, principal_atoms, *, omit_redundant_locants: bool = False) -> "NamingIntent":
+        return cls(
+            mode=NamingMode.COMPONENT,
+            principal_atoms=tuple(principal_atoms),
+            omit_redundant_locants=omit_redundant_locants,
+        )
 
     @classmethod
-    def subgraph(cls, root_atom: int, upstream_atom: int | None, *, fixed_start: bool) -> "NamingIntent":
+    def subgraph(
+        cls,
+        root_atom: int,
+        upstream_atom: int | None,
+        *,
+        fixed_start: bool,
+        omit_redundant_locants: bool = False,
+    ) -> "NamingIntent":
         return cls(
             mode=NamingMode.SUBGRAPH,
             principal_atoms=(root_atom,),
@@ -41,6 +53,7 @@ class NamingIntent:
             upstream_atom=upstream_atom,
             fixed_start=fixed_start,
             is_substituent=True,
+            omit_redundant_locants=omit_redundant_locants,
         )
 
 

--- a/src/openclatura/naming_context.py
+++ b/src/openclatura/naming_context.py
@@ -27,10 +27,10 @@ class NamingIntent:
     upstream_atom: int | None = None
     fixed_start: bool = False
     is_substituent: bool = False
-    omit_redundant_locants: bool = False
+    omit_redundant_locants: bool = True
 
     @classmethod
-    def component(cls, principal_atoms, *, omit_redundant_locants: bool = False) -> "NamingIntent":
+    def component(cls, principal_atoms, *, omit_redundant_locants: bool = True) -> "NamingIntent":
         return cls(
             mode=NamingMode.COMPONENT,
             principal_atoms=tuple(principal_atoms),
@@ -44,7 +44,7 @@ class NamingIntent:
         upstream_atom: int | None,
         *,
         fixed_start: bool,
-        omit_redundant_locants: bool = False,
+        omit_redundant_locants: bool = True,
     ) -> "NamingIntent":
         return cls(
             mode=NamingMode.SUBGRAPH,

--- a/src/openclatura/parent_pipeline.py
+++ b/src/openclatura/parent_pipeline.py
@@ -131,6 +131,7 @@ def build_parent_parts(
         retained_name=retained_name,
         retained_parent_metadata=retained_parent_metadata,
         locant_map_source=locant_map_source,
+        omit_redundant_locants=intent.omit_redundant_locants,
         parent_atom_ids=set(numbered_path),
         parent_bond_ids=bond_ids_within(mol, set(numbered_path)),
         **assembly_overrides,
@@ -140,6 +141,7 @@ def build_parent_parts(
         parts.parent_atom_ids_by_locant[locant] = atom_idx
         parts.parent_atom_symbols_by_locant[locant] = mol.atoms[atom_idx].symbol
         parts.parent_atom_charges_by_locant[locant] = mol.atoms[atom_idx].charge
+        parts.parent_atom_isotopes_by_locant[locant] = mol.atoms[atom_idx].isotope
         if mol.atoms[atom_idx].stereo:
             parts.stereo_features.append((get_loc(atom_idx), mol.atoms[atom_idx].stereo))
         if mol.atoms[atom_idx].charge:

--- a/tests/fixtures/diverse_corpus.golden.json
+++ b/tests/fixtures/diverse_corpus.golden.json
@@ -61,7 +61,7 @@
   },
   {
     "smiles": "CC=C",
-    "name": "prop-1-ene",
+    "name": "propene",
     "category": "alkene"
   },
   {
@@ -76,7 +76,7 @@
   },
   {
     "smiles": "CC#C",
-    "name": "prop-1-yne",
+    "name": "propyne",
     "category": "alkyne"
   },
   {
@@ -501,7 +501,7 @@
   },
   {
     "smiles": "CC(C)=C",
-    "name": "2-methylprop-1-ene",
+    "name": "2-methylpropene",
     "category": "alkene"
   },
   {

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -5718,7 +5718,7 @@ def test_long_unsaturation_multiplicities_are_spellable():
     assert name_smiles("C=C=C=C=C=C=C=C=C=C=C=C=C=C=C[C@@H](Cl)[C@H](C)N") == (
         "(2S,3R)-3-chlorooctadeca-4,5,6,7,8,9,10,11,12,13,14,15,16,17-tetradecaen-2-amine"
     )
-    assert name_smiles("=".join("C" * 12)) == "dodeca-1,2,3,4,5,6,7,8,9,10,11-undecaene"
+    assert name_smiles("=".join("C" * 12)) == "dodecaundecaene"
 
 
 def test_unsaturation_interfix_survives_a_locant_set():
@@ -5726,7 +5726,7 @@ def test_unsaturation_interfix_survives_a_locant_set():
     # holds the stem and a vowel-initial multiplier apart, so the ``a`` stays --
     # ``hexadeca-...-octaene``, never ``hexadec-...-octaene``.
     assert name_smiles("C=CC=CC=CC=CC=CC=CC=CC=C") == "hexadeca-1,3,5,7,9,11,13,15-octaene"
-    assert name_smiles("C=C=C=C=C=C=C=C=C") == "nona-1,2,3,4,5,6,7,8-octaene"
+    assert name_smiles("C=C=C=C=C=C=C=C=C") == "nonaoctaene"
     # A consonant-initial multiplier never elided, and still does not.
     assert name_smiles("C=CC=C") == "buta-1,3-diene"
     assert name_smiles("C#CC#CC") == "penta-1,3-diyne"

--- a/tests/unit/test_locant_elision.py
+++ b/tests/unit/test_locant_elision.py
@@ -1,0 +1,88 @@
+"""Opt-in constitutional locant-elision regressions."""
+
+from openclatura import DEFAULT_NAMING_ENGINE, NamingRequest, name_smiles
+from openclatura.assembly_parts import AssemblyParts, SubstituentItem
+from openclatura.locant_elision import apply_redundant_locant_elision
+
+
+def _name(smiles: str, *, trace: bool = False):
+    return DEFAULT_NAMING_ENGINE.run(
+        NamingRequest(
+            smiles=smiles,
+            include_trace=trace,
+            omit_redundant_locants=True,
+        )
+    )
+
+
+def test_hexamethylbenzene_elision_is_opt_in():
+    smiles = "Cc1c(C)c(C)c(C)c(C)c1C"
+
+    assert name_smiles(smiles) == "1,2,3,4,5,6-hexamethylbenzene"
+    assert _name(smiles).name == "hexamethylbenzene"
+
+
+def test_trace_records_symmetry_proof_without_inventing_rule_id():
+    result = _name("Cc1c(C)c(C)c(C)c(C)c1C", trace=True)
+    assembly = [step for step in result.decisions if step.decision == "assembled component name"][-1]
+
+    assert assembly.data["locant_elisions"] == [
+        {
+            "category": "substituent",
+            "key": "methyl",
+            "locants": ["1", "2", "3", "4", "5", "6"],
+            "reason": "placement is unique under exact parent-graph symmetry",
+        }
+    ]
+    assert not any("rule" in decision for decision in assembly.data["locant_elisions"])
+
+
+def test_distinct_constitutional_placements_keep_locants():
+    assert _name("Cc1c(C)c(C)ccc1").name == "1,2,3-trimethylbenzene"
+    assert _name("Cc1cccc(C)c1").name == "1,3-dimethylbenzene"
+    assert _name("CC=CC").name == "but-2-ene"
+    assert _name("CCC(O)").name == "propan-1-ol"
+
+
+def test_simple_ring_and_chain_unsaturation_can_elide_unique_locants():
+    assert _name("C1=CCCCC1").name == "cyclohexene"
+    assert _name("CC=C").name == "propene"
+
+
+def test_nonconstitutional_and_unsupported_parent_locants_are_unchanged():
+    unchanged = {
+        "C/C=C\\C": "(2Z)-but-2-ene",
+        "[N-]=[N+]=P1=CC=CC=C1": "1-diazo-1lambda^5-phosphacyclohexa-1,3,5-triene",
+        "C1CC2CCC1C2": "bicyclo[2.2.1]heptane",
+    }
+    for smiles, expected in unchanged.items():
+        assert name_smiles(smiles) == expected
+        assert _name(smiles).name == expected
+
+
+def test_equivalent_smiles_atom_orderings_are_deterministic():
+    names = {
+        _name(smiles).name
+        for smiles in (
+            "Cc1c(C)c(C)c(C)c(C)c1C",
+            "c1(C)c(C)c(C)c(C)c(C)c1C",
+        )
+    }
+    assert names == {"hexamethylbenzene"}
+
+
+def test_candidate_limit_falls_back_to_printing_locants():
+    parts = AssemblyParts(parent_length=20, omit_redundant_locants=True)
+    for index in range(1, 21):
+        locant = str(index)
+        parts.parent_atom_symbols_by_locant[locant] = "C"
+        parts.parent_atom_charges_by_locant[locant] = 0
+        if index > 1:
+            edge = (str(index - 1), locant)
+            parts.parent_bond_orders_by_locants[edge] = 1
+    parts.substituents = [SubstituentItem(name="methyl", locants=[str(index) for index in range(1, 11)])]
+
+    apply_redundant_locant_elision(parts)
+
+    assert parts.elided_substituent_locants == set()
+    assert parts.locant_elision_decisions == []

--- a/tests/unit/test_locant_elision.py
+++ b/tests/unit/test_locant_elision.py
@@ -1,7 +1,7 @@
 """Configurable constitutional locant-elision regressions."""
 
 from openclatura import DEFAULT_NAMING_ENGINE, NamingRequest, name_many, name_smiles
-from openclatura.assembly_parts import AssemblyParts, SubstituentItem
+from openclatura.assembly_parts import AssemblyParts, PrincipalGroupItem
 from openclatura.locant_elision import apply_redundant_locant_elision
 
 
@@ -29,12 +29,14 @@ def test_hexamethylbenzene_existing_elision_is_preserved_by_default_policy():
 def test_broader_elision_defaults_on_and_can_be_disabled():
     assert NamingRequest().omit_redundant_locants is True
     assert name_smiles("C1=CCCCC1") == "cyclohexene"
-    assert _name_without_elision("C1=CCCCC1").name == "cyclohex-1-ene"
+    # Upstream's conventional simple-ring omission is independent of the
+    # broader graph-search policy and remains active when it is disabled.
+    assert _name_without_elision("C1=CCCCC1").name == "cyclohexene"
 
 
 def test_batch_api_forwards_default_and_opt_out_policy():
     assert name_many(["C1=CCCCC1"])[0].name == "cyclohexene"
-    assert name_many(["C1=CCCCC1"], omit_redundant_locants=False)[0].name == "cyclohex-1-ene"
+    assert name_many(["C1=CCCCC1"], omit_redundant_locants=False)[0].name == "cyclohexene"
 
 
 def test_trace_records_symmetry_proof_without_inventing_rule_id():
@@ -95,9 +97,16 @@ def test_candidate_limit_falls_back_to_printing_locants():
         if index > 1:
             edge = (str(index - 1), locant)
             parts.parent_bond_orders_by_locants[edge] = 1
-    parts.substituents = [SubstituentItem(name="methyl", locants=[str(index) for index in range(1, 11)])]
+    parts.principal_group = PrincipalGroupItem(key="ol", locants=["1"])
 
-    apply_redundant_locant_elision(parts)
+    apply_redundant_locant_elision(parts, max_candidate_placements=5)
 
     assert parts.elided_substituent_locants == set()
-    assert parts.locant_elision_decisions == []
+    assert parts.locant_elision_decisions == [
+        {
+            "category": "search",
+            "key": "candidate-placement-limit",
+            "locants": [],
+            "reason": "exact symmetry search limit exceeded; locants retained",
+        }
+    ]

--- a/tests/unit/test_locant_elision.py
+++ b/tests/unit/test_locant_elision.py
@@ -1,6 +1,6 @@
-"""Opt-in constitutional locant-elision regressions."""
+"""Configurable constitutional locant-elision regressions."""
 
-from openclatura import DEFAULT_NAMING_ENGINE, NamingRequest, name_smiles
+from openclatura import DEFAULT_NAMING_ENGINE, NamingRequest, name_many, name_smiles
 from openclatura.assembly_parts import AssemblyParts, SubstituentItem
 from openclatura.locant_elision import apply_redundant_locant_elision
 
@@ -15,22 +15,37 @@ def _name(smiles: str, *, trace: bool = False):
     )
 
 
-def test_hexamethylbenzene_existing_elision_is_preserved_by_opt_in_policy():
+def _name_without_elision(smiles: str):
+    return DEFAULT_NAMING_ENGINE.run(NamingRequest(smiles=smiles, omit_redundant_locants=False))
+
+
+def test_hexamethylbenzene_existing_elision_is_preserved_by_default_policy():
     smiles = "Cc1c(C)c(C)c(C)c(C)c1C"
 
     assert name_smiles(smiles) == "hexamethylbenzene"
     assert _name(smiles).name == "hexamethylbenzene"
 
 
+def test_broader_elision_defaults_on_and_can_be_disabled():
+    assert NamingRequest().omit_redundant_locants is True
+    assert name_smiles("C1=CCCCC1") == "cyclohexene"
+    assert _name_without_elision("C1=CCCCC1").name == "cyclohex-1-ene"
+
+
+def test_batch_api_forwards_default_and_opt_out_policy():
+    assert name_many(["C1=CCCCC1"])[0].name == "cyclohexene"
+    assert name_many(["C1=CCCCC1"], omit_redundant_locants=False)[0].name == "cyclohex-1-ene"
+
+
 def test_trace_records_symmetry_proof_without_inventing_rule_id():
-    result = _name("Cc1c(C)c(C)c(C)c(C)c1C", trace=True)
+    result = _name("C1=CCCCC1", trace=True)
     assembly = [step for step in result.decisions if step.decision == "assembled component name"][-1]
 
     assert assembly.data["locant_elisions"] == [
         {
-            "category": "substituent",
-            "key": "methyl",
-            "locants": ["1", "2", "3", "4", "5", "6"],
+            "category": "unsaturation",
+            "key": "double",
+            "locants": ["1-2"],
             "reason": "placement is unique under exact parent-graph symmetry",
         }
     ]

--- a/tests/unit/test_locant_elision.py
+++ b/tests/unit/test_locant_elision.py
@@ -15,10 +15,10 @@ def _name(smiles: str, *, trace: bool = False):
     )
 
 
-def test_hexamethylbenzene_elision_is_opt_in():
+def test_hexamethylbenzene_existing_elision_is_preserved_by_opt_in_policy():
     smiles = "Cc1c(C)c(C)c(C)c(C)c1C"
 
-    assert name_smiles(smiles) == "1,2,3,4,5,6-hexamethylbenzene"
+    assert name_smiles(smiles) == "hexamethylbenzene"
     assert _name(smiles).name == "hexamethylbenzene"
 
 


### PR DESCRIPTION
Implements an opt-in fix to delete some redundant locants after looking at symmetry. fixes issue #62.

## Summary by Sourcery

Enable conservative symmetry-based omission of redundant constitutional locants while preserving a compatibility option to retain them.

New Features:
- Add opt-in-configurable omission of redundant constitutional locants based on exact symmetry proofs for supported simple chain and monocyclic parents.

Bug Fixes:
- Elide uniquely determined substituent, unsaturation, and principal-group locants while retaining locants for constitutionally distinct or unsupported structures.

Enhancements:
- Propagate the locant-elision policy through single, batch, recursive, and traced naming APIs, defaulting it on with an explicit compatibility opt-out.
- Record locant-elision decisions in naming traces and fail safely when symmetry searches exceed configured limits.

Documentation:
- Document the new locant-elision option and its default behavior in the naming request API.

Tests:
- Add regression coverage for default elision, opt-out behavior, trace metadata, unsupported structures, deterministic output, and search-limit fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in option to omit redundant locants in generated chemical names.
  * Locant omission now supports substituents, unsaturations, and principal groups when unambiguous.
  * Conservative safeguards retain locants for unsupported, ambiguous, or overly complex structures.
  * Naming decision details can now be included in trace metadata.

* **Bug Fixes**
  * Improved handling of isotopes and equivalent structural placements during name generation.

* **Tests**
  * Added coverage for symmetry, unsaturation locants, unsupported structures, deterministic naming, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->