### PR TITLE
feat: add skeletal replacement prefixes for basic metals (Mg, Ca, Li, Na, K)

### DIFF
--- a/src/openclatura/assembly_spiro.py
+++ b/src/openclatura/assembly_spiro.py
@@ -169,7 +169,7 @@ def _prime_replacement_prefixes_for_primed_component(core_name: str, prefixes: l
         return prefixes
     return [
         re.sub(
-            r"^([0-9,]+)-((?:di|tri|tetra|penta)?(?:oxa|aza|thia|selena|tellura|phospha|sila|bora|germa|stanna))$",
+            r"^([0-9,]+)-((?:di|tri|tetra|penta)?(?:oxa|aza|thia|selena|tellura|phospha|sila|bora|germa|stanna|magnesa|calca|litha|natra|potassa))$",
             lambda match: f"{','.join(f'{locant}' + chr(39) for locant in match.group(1).split(','))}-{match.group(2)}",
             prefix,
         )
@@ -191,7 +191,7 @@ def _prime_inline_replacement_prefixes_for_primed_component(core_name: str) -> s
         return f"{match.group(1)}{locants}-{match.group(3)}spiro[{match.group(4)}"
 
     return re.sub(
-        r"(^|-)([0-9,]+)-((?:di|tri|tetra|penta)?(?:oxa|aza|thia|selena|tellura|phospha|sila|bora|germa|stanna))"
+        r"(^|-)([0-9,]+)-((?:di|tri|tetra|penta)?(?:oxa|aza|thia|selena|tellura|phospha|sila|bora|germa|stanna|magnesa|calca|litha|natra|potassa))"
         r"spiro\[([^\]]*)",
         prime,
         core_name,
@@ -442,7 +442,7 @@ def _extract_polycyclic_parent(name: str) -> str | None:
         idx = name.rfind(marker)
         if idx > 0 and name[idx - 1] == "-":
             return name[idx:]
-        if idx > 0 and re.fullmatch(r"(?:[0-9,]+-)?(?:oxa|aza|thia)", name[:idx]):
+        if idx > 0 and re.fullmatch(r"(?:[0-9,]+-)?(?:oxa|aza|thia|selena|tellura|phospha|sila|bora|germa|stanna|magnesa|calca|litha|natra|potassa)", name[:idx]):
             return name[idx:]
     return None
 

--- a/src/openclatura/assembly_spiro.py
+++ b/src/openclatura/assembly_spiro.py
@@ -442,7 +442,10 @@ def _extract_polycyclic_parent(name: str) -> str | None:
         idx = name.rfind(marker)
         if idx > 0 and name[idx - 1] == "-":
             return name[idx:]
-        if idx > 0 and re.fullmatch(r"(?:[0-9,]+-)?(?:oxa|aza|thia|selena|tellura|phospha|sila|bora|germa|stanna|magnesa|calca|litha|natra|potassa)", name[:idx]):
+        if idx > 0 and re.fullmatch(
+            r"(?:[0-9,]+-)?(?:oxa|aza|thia|selena|tellura|phospha|sila|bora|germa|stanna|magnesa|calca|litha|natra|potassa)",
+            name[:idx],
+        ):
             return name[idx:]
     return None
 

--- a/src/openclatura/audit/substituent_reconstruction.py
+++ b/src/openclatura/audit/substituent_reconstruction.py
@@ -1059,7 +1059,7 @@ def _join_two_port(wrapper_smiles: str, inner: Chem.Mol, hub_stereo: str | None 
 # A skeletal-replacement clause: ``7-aza``, ``2,4-dioxa``, ``3lambda^6-thia``.
 _REPLACEMENT_CLAUSE_RE = re.compile(
     r"\d+(?:,\d+)*(?:lambda\^?\{?\d+\}?)?-(?:di|tri|tetra|penta|hexa)?"
-    r"(?:oxa|aza|thia|selena|tellura|phospha|arsa|sila|germa|stanna|bora)-"
+    r"(?:oxa|aza|thia|selena|tellura|phospha|arsa|sila|germa|stanna|bora|magnesa|calca|litha|natra|potassa)-"
 )
 # The ring token a replacement prefix belongs to: bracketed von Baeyer/spiro, or
 # the bare ``cyclo`` of a replacement monocycle.

--- a/src/openclatura/data/namer_rules.json
+++ b/src/openclatura/data/namer_rules.json
@@ -1547,7 +1547,12 @@
       "aza": 3,
       "phospha": 4,
       "sila": 5,
-      "bora": 6
+      "bora": 6,
+      "magnesa": 7,
+      "calca": 8,
+      "litha": 9,
+      "natra": 10,
+      "potassa": 11
     }
   },
   "unsaturation_order": {

--- a/src/openclatura/rules/elements.py
+++ b/src/openclatura/rules/elements.py
@@ -36,11 +36,11 @@ ELEMENTS: dict[str, Element] = {
     "I": Element("I", "iodine", 53, 1, "ioda", 4, "iodo"),
     "Pb": Element("Pb", "lead", 82, 4, "plumba", 17, "plumbyl"),
     "Bi": Element("Bi", "bismuth", 83, 3, "bisma", 13, "bismuthanyl"),
-    "Li": Element("Li", "lithium", 3, 1, None, None, None),
-    "Na": Element("Na", "sodium", 11, 1, None, None, None),
-    "K": Element("K", "potassium", 19, 1, None, None, None),
-    "Mg": Element("Mg", "magnesium", 12, 2, None, None, None),
-    "Ca": Element("Ca", "calcium", 20, 2, None, None, None),
+    "Li": Element("Li", "lithium", 3, 1, "litha", 87, None),
+    "Na": Element("Na", "sodium", 11, 1, "natra", 88, None),
+    "K": Element("K", "potassium", 19, 1, "potassa", 89, None),
+    "Mg": Element("Mg", "magnesium", 12, 2, "magnesa", 82, None),
+    "Ca": Element("Ca", "calcium", 20, 2, "calca", 83, None),
 }
 
 

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -6035,3 +6035,8 @@ def test_azine_aryl_side_uses_the_retained_benzene_name():
     # A heteroatom breaks that symmetry and genuinely needs numbering, so the
     # shortcut must still decline rather than guess position 1.
     assert "benzaldehyde 5-azacyclohexa" in name_smiles("c1ccncc1C=NN=Cc1ccccc1")
+
+
+def test_organometallic_skeletal_replacement():
+    assert name_smiles('C1CC[Mg]C1') == '1-magnesacyclopentane'
+    assert name_smiles('C1C2OC3C#C[Mg]C#CC=3OC=2C#C[Mg]C#1') == '2,10-dioxa-6,14-dimagnesatricyclo[9.5.0.0^{3,9}]hexadeca-1(11),3(9)-dien-4,7,12,15-tetrayne'

--- a/src/openclatura/tests/test_analysis.py
+++ b/src/openclatura/tests/test_analysis.py
@@ -6038,5 +6038,8 @@ def test_azine_aryl_side_uses_the_retained_benzene_name():
 
 
 def test_organometallic_skeletal_replacement():
-    assert name_smiles('C1CC[Mg]C1') == '1-magnesacyclopentane'
-    assert name_smiles('C1C2OC3C#C[Mg]C#CC=3OC=2C#C[Mg]C#1') == '2,10-dioxa-6,14-dimagnesatricyclo[9.5.0.0^{3,9}]hexadeca-1(11),3(9)-dien-4,7,12,15-tetrayne'
+    assert name_smiles("C1CC[Mg]C1") == "1-magnesacyclopentane"
+    assert (
+        name_smiles("C1C2OC3C#C[Mg]C#CC=3OC=2C#C[Mg]C#1")
+        == "2,10-dioxa-6,14-dimagnesatricyclo[9.5.0.0^{3,9}]hexadeca-1(11),3(9)-dien-4,7,12,15-tetrayne"
+    )

--- a/src/openclatura/tests/test_rules_tables.py
+++ b/src/openclatura/tests/test_rules_tables.py
@@ -103,6 +103,7 @@ def test_hw_priorities_are_unique_and_ordered_by_seniority():
     assert [e.symbol for e in ranked] == [
         "F", "Cl", "Br", "I", "O", "S", "Se", "Te",
         "N", "P", "As", "Sb", "Bi", "Si", "Ge", "Sn", "Pb", "B", "Al", "Ga",
+        "Mg", "Ca", "Li", "Na", "K",
     ]  # fmt: skip
     priorities = [e.hw_priority for e in ranked]
     assert len(priorities) == len(set(priorities))


### PR DESCRIPTION
## Description
This PR adds support for IUPAC Blue Book P-51 skeletal replacement prefixes for fundamental alkali and alkaline earth metals (`Mg`, `Ca`, `Li`, `Na`, `K`), enabling correct nomenclature for organometallic compounds and macrocycles.

### The Issue
Previously, when the namer encountered these metals inside a ring structure, it failed to generate a von Baeyer replacement prefix because the `hw_stem` and `hw_priority` fields for these metals in `elements.ELEMENTS` were set to `None`. This caused compounds like magnesacycloalkanes to fall back to the bare parent carbon ring (e.g., returning `cyclopentane` instead of `1-magnesacyclopentane`).

### Changes made
* **Grammar/Element Definitions:** Updated `elements.ELEMENTS` to define the `hw_stem` (`magnesa`, `calca`, `litha`, `natra`, `potassa`) and `hw_priority` (ranked according to IUPAC seniority rules) for the affected elements.
* **Namer Rules:** Added these elements to the `replacement_prefix_order` hierarchy in `namer_rules.json`.
* **Regex Updates:** Expanded the hardcoded replacement clause regular expressions in `assembly_spiro.py` and `audit/substituent_reconstruction.py` so they correctly recognize these new prefixes.
* **Testing:** Added new assertions to `test_analysis.py` testing for `1-magnesacyclopentane` and an organomagnesium macrocycle (`2,10-dioxa-6,14-dimagnesatricyclo[9.5.0.0^{3,9}]hexadeca-1(11),3(9)-dien-4,7,12,15-tetrayne`). Updated `test_rules_tables.py` to expect the newly ranked metals.

All tests pass locally.

## Checklists
- [x] I have read the contributing guidelines.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified that all existing tests pass (`pytest`).

## Summary by Sourcery

Support IUPAC skeletal replacement prefixes for key alkali and alkaline earth metals to correctly name organometallic rings and polycycles.

New Features:
- Add skeletal replacement stems for Mg, Ca, Li, Na, and K in element definitions to enable von Baeyer replacement naming for these metals.
- Extend naming rules and regexes to recognise the new metal replacement prefixes in spiro and polycyclic assemblies.

Tests:
- Add organomagnesium ring and macrocycle naming tests to verify correct skeletal replacement behaviour.
- Update rules table tests to cover the new seniority ordering for metal replacement prefixes.