### PR TITLE
ci: extend paper evaluation timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.base_ref == 'tests'
     needs: [lint, test, rdkit-compat]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       max-parallel: 3


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Extend the paper evaluation workflow job timeout from 60 to 120 minutes in the CI configuration.