### PR TITLE
Version fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Read the public and executable version from installed package metadata so a
+  release version bump no longer needs to be duplicated in package code.
+
 ## [0.3.2] - 2026-09-03
 
 ### Added

--- a/src/openclatura/__init__.py
+++ b/src/openclatura/__init__.py
@@ -1,6 +1,8 @@
 """openclatura — deterministic SMILES → IUPAC name generator."""
 
 from collections.abc import Iterable
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
 from typing import Any
 
 from .describer import DescribedComponent, Description, DescriptionTokenSummary, describe
@@ -122,7 +124,11 @@ def name_many(
     )
 
 
-__version__ = "0.3.1"
+try:
+    __version__ = _distribution_version("openclatura")
+except PackageNotFoundError:
+    # The package may be imported directly from an unpacked source tree.
+    __version__ = "unknown"
 
 __all__ = [
     "AtomBinding",

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import types
 import warnings
+from importlib.metadata import version as distribution_version
 
 import pytest
 
@@ -16,6 +17,7 @@ from openclatura import (
     NamingRequest,
     NamingResult,
     OpsinCheck,
+    __version__,
     analyze_rdkit_mol,
     analyze_smiles,
     name,
@@ -26,6 +28,21 @@ from openclatura import (
     name_smiles,
     name_smiles_with_trace,
 )
+
+
+def test_public_version_comes_from_installed_package_metadata():
+    assert __version__ == distribution_version("openclatura")
+
+
+def test_cli_version_matches_installed_package_metadata():
+    result = subprocess.run(
+        [sys.executable, "-m", "openclatura.cli", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"openclatura {distribution_version('openclatura')}"
 
 
 def test_name_smiles_legacy_still_returns_string():


### PR DESCRIPTION
## Summary by Sourcery

Use installed package metadata as the single source of truth for the public and CLI version.

Bug Fixes:
- Read the public and CLI versions from installed package metadata so release version bumps are defined in one place.

Documentation:
- Document the metadata-based versioning fix in the changelog.

Tests:
- Add coverage verifying that the public API and CLI report the installed package version.