### PR TITLE
Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Read the public and executable version from installed package metadata so a
+  release version bump no longer needs to be duplicated in package code.
+
 ## [0.3.2] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Read the public and executable version from installed package metadata so a
-  release version bump no longer needs to be duplicated in package code.
+- Resolve the public and executable version from the active checkout or its
+  installed package metadata so release bumps are not duplicated in code and
+  unrelated installations cannot supply a stale version.
 
 ## [0.3.2] - 2026-09-03
 

--- a/src/openclatura/__init__.py
+++ b/src/openclatura/__init__.py
@@ -1,10 +1,9 @@
 """openclatura — deterministic SMILES → IUPAC name generator."""
 
 from collections.abc import Iterable
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _distribution_version
 from typing import Any
 
+from ._version import __version__
 from .describer import DescribedComponent, Description, DescriptionTokenSummary, describe
 from .engine import DEFAULT_NAMING_ENGINE, NamingEngine, NamingRequest, NamingResult
 from .functional_groups import register_group_detector
@@ -123,12 +122,6 @@ def name_many(
         chunksize=chunksize,
     )
 
-
-try:
-    __version__ = _distribution_version("openclatura")
-except PackageNotFoundError:
-    # The package may be imported directly from an unpacked source tree.
-    __version__ = "unknown"
 
 __all__ = [
     "AtomBinding",

--- a/src/openclatura/__init__.py
+++ b/src/openclatura/__init__.py
@@ -1,6 +1,8 @@
 """openclatura — deterministic SMILES → IUPAC name generator."""
 
 from collections.abc import Iterable
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
 from typing import Any
 
 from .describer import DescribedComponent, Description, DescriptionTokenSummary, describe
@@ -122,7 +124,11 @@ def name_many(
     )
 
 
-__version__ = "0.3.1"
+try:
+    __version__ = _distribution_version("openclatura")
+except PackageNotFoundError:
+    # The package may be imported directly from an unpacked source tree.
+    __version__ = "unknown"
 
 __all__ = [
     "AtomBinding",

--- a/src/openclatura/_version.py
+++ b/src/openclatura/_version.py
@@ -1,0 +1,40 @@
+"""Resolve the package version from the code that is actually being imported."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+
+import tomllib
+
+
+def _source_tree_version() -> str | None:
+    """Return this checkout's project version when imported from ``src``."""
+
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    try:
+        with pyproject.open("rb") as handle:
+            project = tomllib.load(handle).get("project")
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    if not isinstance(project, dict) or project.get("name") != "openclatura":
+        return None
+    version = project.get("version")
+    return version if isinstance(version, str) else None
+
+
+def resolve_version() -> str:
+    """Prefer source metadata, then metadata for an installed distribution."""
+
+    source_version = _source_tree_version()
+    if source_version is not None:
+        return source_version
+    try:
+        return distribution_version("openclatura")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = resolve_version()

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import types
 import warnings
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
 import pytest
@@ -30,11 +31,18 @@ from openclatura import (
 )
 
 
-def test_public_version_comes_from_installed_package_metadata():
-    assert __version__ == distribution_version("openclatura")
+def _expected_package_version() -> str:
+    try:
+        return distribution_version("openclatura")
+    except PackageNotFoundError:
+        return "unknown"
 
 
-def test_cli_version_matches_installed_package_metadata():
+def test_public_version_matches_available_package_metadata():
+    assert __version__ == _expected_package_version()
+
+
+def test_cli_version_matches_available_package_metadata():
     result = subprocess.run(
         [sys.executable, "-m", "openclatura.cli", "--version"],
         capture_output=True,
@@ -42,7 +50,7 @@ def test_cli_version_matches_installed_package_metadata():
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == f"openclatura {distribution_version('openclatura')}"
+    assert result.stdout.strip() == f"openclatura {_expected_package_version()}"
 
 
 def test_name_smiles_legacy_still_returns_string():

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import types
 import warnings
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as distribution_version
+from pathlib import Path
 
 import pytest
+import tomllib
 
 from openclatura import (
     DEFAULT_NAMING_ENGINE,
@@ -30,12 +31,12 @@ from openclatura import (
     name_smiles_with_trace,
 )
 
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
 
 def _expected_package_version() -> str:
-    try:
-        return distribution_version("openclatura")
-    except PackageNotFoundError:
-        return "unknown"
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)["project"]["version"]
 
 
 def test_public_version_matches_available_package_metadata():
@@ -51,6 +52,36 @@ def test_cli_version_matches_available_package_metadata():
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == f"openclatura {_expected_package_version()}"
+
+
+def test_source_checkout_version_wins_over_unrelated_distribution(tmp_path):
+    dist_info = tmp_path / "openclatura-99.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: openclatura\nVersion: 99.0\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join((str(tmp_path), str(PROJECT_ROOT / "src")))
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from importlib.metadata import version; "
+                "import openclatura; "
+                "print(version('openclatura')); "
+                "print(openclatura.__version__)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["99.0", _expected_package_version()]
 
 
 def test_name_smiles_legacy_still_returns_string():

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import types
 import warnings
+from importlib.metadata import version as distribution_version
 
 import pytest
 
@@ -16,6 +17,7 @@ from openclatura import (
     NamingRequest,
     NamingResult,
     OpsinCheck,
+    __version__,
     analyze_rdkit_mol,
     analyze_smiles,
     name,
@@ -26,6 +28,21 @@ from openclatura import (
     name_smiles,
     name_smiles_with_trace,
 )
+
+
+def test_public_version_comes_from_installed_package_metadata():
+    assert __version__ == distribution_version("openclatura")
+
+
+def test_cli_version_matches_installed_package_metadata():
+    result = subprocess.run(
+        [sys.executable, "-m", "openclatura.cli", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"openclatura {distribution_version('openclatura')}"
 
 
 def test_name_smiles_legacy_still_returns_string():


### PR DESCRIPTION
## Summary by Sourcery

Ensure package and CLI version reporting reflects the currently imported project metadata.

Bug Fixes:
- Resolve the public and CLI version from the active source checkout before falling back to installed package metadata, preventing stale or duplicated version values.

Tests:
- Add coverage verifying public and CLI versions match project metadata and that source checkout metadata takes precedence over unrelated installed distributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version information now consistently reflects the active source checkout or installed package.
  - Prevented stale versions from unrelated installations from appearing in the package or command-line output.
  - Reduced the risk of duplicated release bumps by keeping public and executable version details aligned.
  - Added a safe fallback when package version metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->